### PR TITLE
refactor: always show mnemonic skeleton indices

### DIFF
--- a/src/domains/wallet/components/MnemonicList/MnemonicList.tsx
+++ b/src/domains/wallet/components/MnemonicList/MnemonicList.tsx
@@ -28,14 +28,18 @@ export const MnemonicList: React.VFC<MnemonicListProperties> = ({ mnemonic }) =>
 			))}
 		</ul>
 	);
-}
+};
 
 export const MnemonicListSkeleton: React.VFC = () => {
-	const skeletons = useMemo(() => [...Array.from({ length: 24 })].map(() => {
-		const [min, max] = [50, 70];
+	const skeletons = useMemo(
+		() =>
+			[...Array.from({ length: 24 })].map(() => {
+				const [min, max] = [50, 70];
 
-		return Math.floor(Math.random() * (max - min + 1) + min);
-	}), []);
+				return Math.floor(Math.random() * (max - min + 1) + min);
+			}),
+		[],
+	);
 
 	return (
 		<ul className="grid grid-cols-2 gap-x-3 gap-y-5 sm:grid-cols-4">
@@ -56,4 +60,4 @@ export const MnemonicListSkeleton: React.VFC = () => {
 			))}
 		</ul>
 	);
-}
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Always shows the mnemonic indeces since they are not dynamic.

![image](https://user-images.githubusercontent.com/6547002/171261687-d4e26f48-9461-4561-b051-2fd5cef36eda.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
