### PR TITLE
chore: align checkboxes in custom network list vertically

### DIFF
--- a/src/domains/setting/pages/Networks/blocks/NetworkFormModal.tsx
+++ b/src/domains/setting/pages/Networks/blocks/NetworkFormModal.tsx
@@ -47,17 +47,13 @@ const NetworkFormModal: React.VFC<{
 		let configurationResponse: NodeConfigurationResponse;
 		let configurationCryptoResponse: any;
 
-		console.log("Sfdsgadshgkldasghkladsghdaskghjadslkghadsklghadsklghjlads");
-
 		try {
 			const response = await client.get(`${baseUrl}/api/node/configuration`);
 			const cryptoResponse = await client.get(`${baseUrl}/api/node/configuration/crypto`);
 
-			console.log({ cryptoResponse, response });
 			configurationResponse = JSON.parse(response.body()).data as NodeConfigurationResponse;
 			configurationCryptoResponse = JSON.parse(cryptoResponse.body()).data;
 		} catch {
-			console.log(":D");
 			setFetchingError(true);
 			setFetchingDetails(false);
 			return;

--- a/src/domains/setting/pages/Networks/blocks/NetworksList.tsx
+++ b/src/domains/setting/pages/Networks/blocks/NetworksList.tsx
@@ -38,7 +38,8 @@ const NetworksListNetwork: React.VFC<{
 				</div>
 				<div className="font-semibold">{networkDisplayName(network)}</div>
 			</div>
-			<div>
+
+			<div className="flex items-center">
 				<Checkbox
 					data-testid="NetworksListNetwork-checkbox"
 					id={`NetworksListNetwork-${network.id()}`}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Centers the checkboxes vertically.

![image](https://user-images.githubusercontent.com/6547002/171300207-16464077-13e9-4bd6-9605-57eec7236c9d.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
