### PR TITLE
Round remaining amount to prevent floating point precision issues

### DIFF
--- a/src/domains/transaction/hooks/use-send-transfer-form.ts
+++ b/src/domains/transaction/hooks/use-send-transfer-form.ts
@@ -11,7 +11,7 @@ import { useTransactionBuilder } from "@/domains/transaction/hooks/use-transacti
 import { SendTransferForm } from "@/domains/transaction/pages/SendTransfer";
 import { buildTransferData } from "@/domains/transaction/pages/SendTransfer/SendTransfer.helpers";
 import { handleBroadcastError } from "@/domains/transaction/utils";
-
+import { precisionRound } from "@/utils/precision-round";
 import { useTransactionQueryParameters } from "@/domains/transaction/hooks/use-transaction-query-parameters";
 
 export const useSendTransferForm = (wallet?: Contracts.IReadWriteWallet) => {
@@ -187,7 +187,9 @@ export const useSendTransferForm = (wallet?: Contracts.IReadWriteWallet) => {
 
 		const remaining = remainingBalance - fee;
 
-		setValue("amount", remaining);
+		// Using `8` for precision because is the maximum number of decimals
+		// that the amount field supports.
+		setValue("amount", precisionRound(remaining, 8));
 
 		void trigger(["fee", "amount"]);
 	}, [fee]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/utils/precision-round.test.ts
+++ b/src/utils/precision-round.test.ts
@@ -1,0 +1,13 @@
+import { precisionRound } from "./precision-round";
+
+describe("Precision round", () => {
+	it.each([
+		[9.892_000_000_000_001, 8, 9.892],
+		[9.892_000_000_000_001, 3, 9.892],
+		[9.892_000_000_000_001, 2, 9.89],
+		[9.892_000_000_000_001, 15, 9.892_000_000_000_001],
+		[1, 10, 1],
+	])("rounds a number according to precision", async (number, precision, result) => {
+		expect(precisionRound(number, precision)).toBe(result);
+	});
+});

--- a/src/utils/precision-round.ts
+++ b/src/utils/precision-round.ts
@@ -1,0 +1,4 @@
+export const precisionRound = (number: number, precision: number): number => {
+	const factor = Math.pow(10, precision);
+	return Math.round(number * factor) / factor;
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This was a tricky one, the issue is with floating-point numbers, basically, after it subtracts the fee from the balance it adds an extra decimal number (for example try this operation in the console `9.9 - 0.008`, it will return `9.892000000000001` instead of `9.892`), doesn't happen all the time of course, for example, this operation works fine: `9.9 - 0.006` 

There is not a definitive solution but [the more accepted solution seems to be to use an external library](https://stackoverflow.com/questions/1458633/how-to-deal-with-floating-point-number-precision-in-javascript)

I also tried using the BigNumber library from the SDK (`import { BigNumber } from "@payvo/sdk-helpers"`) but doing the operations inside the helpers return the exact same value.

The solution I am proposing here should solve this specific problem but I think this potential problem in other parts of the application but since it requires very specific operations is not kinda unlikely to appear, still something to take in mind.




## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
