### PR TITLE
refactor: replace env networks with profile networks

### DIFF
--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -13,8 +13,7 @@ import { useAutoSignOut } from "@/app/hooks/use-auto-signout";
 import { delay } from "@/utils/delay";
 import { getErroredNetworks, getProfileById, getProfileFromUrl, getProfileStoredPassword } from "@/utils/profile-utils";
 import { ProfilePeers } from "@/utils/profile-peers";
-import { enabledNetworksCount, profileEnabledNetworkIds } from "@/utils/network-utils";
-import { defaultNetworks } from "@/utils/server-utils";
+import { enabledNetworksCount, profileAllEnabledNetworks, profileEnabledNetworkIds } from "@/utils/network-utils";
 
 enum Intervals {
 	VeryShort = 15_000,
@@ -391,7 +390,7 @@ export const useProfileSynchronizer = ({
 				// step when creating or importing a wallet, which means we also
 				// skip that part of syncing network coin. The issues caused by that
 				// are solved by syncing the coin initially.
-				const availableNetworks = defaultNetworks(env, profile);
+				const availableNetworks = profileAllEnabledNetworks(profile);
 				const onlyHasOneNetwork = enabledNetworksCount(profile) === 1;
 				if (onlyHasOneNetwork) {
 					const coin = profile.coins().set(availableNetworks[0].coin(), availableNetworks[0].id());

--- a/src/utils/profile-peers.ts
+++ b/src/utils/profile-peers.ts
@@ -3,7 +3,8 @@ import { Networks } from "@ardenthq/sdk";
 import { groupBy } from "@ardenthq/sdk-helpers";
 import { pingServerAddress } from "@/utils/peers";
 import { ServerHealthStatus, NetworkHostType } from "@/domains/setting/pages/Servers/Servers.contracts";
-import { customNetworks, defaultNetworks } from "@/utils/server-utils";
+import { customNetworks } from "@/utils/server-utils";
+import { profileAllEnabledNetworks } from "./network-utils";
 
 interface PeerData {
 	address: string;
@@ -43,7 +44,7 @@ const customPeers = (env: Environment, profile: Contracts.IProfile) =>
 		.map(Peer);
 
 const defaultPeers = (env: Environment, profile: Contracts.IProfile) =>
-	defaultNetworks(env, profile)
+	profileAllEnabledNetworks(profile)
 		.map((network) => ({
 			address: network.toObject().hosts.find((host) => host.type === "full")?.host || "",
 			network,

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -1,6 +1,5 @@
 import { Contracts, Environment } from "@ardenthq/sdk-profiles";
 import { Networks } from "@ardenthq/sdk";
-import { networkDisplayName } from "./network-utils";
 import { NormalizedNetwork } from "@/domains/setting/pages/Servers/Servers.contracts";
 
 export const sortByName = (networks: NormalizedNetwork[]) => networks.sort((a, b) => a.name.localeCompare(b.name));
@@ -25,27 +24,6 @@ export const customNetworks = (env: Environment, profile: Contracts.IProfile) =>
 			}));
 		});
 	});
-};
-
-export const defaultNetworks = (env: Environment, profile: Contracts.IProfile) => {
-	const profileNetworks = profile.networks().all();
-
-	return env
-		.availableNetworks()
-		.filter((network: Networks.Network) => {
-			const idParts = network.id().split(".");
-
-			const networkData = profileNetworks[idParts[0]] as Networks.NetworkManifest | undefined;
-
-			if (networkData === undefined) {
-				return false;
-			}
-
-			const profileNetwork = networkData[idParts[1]] as Record<string, unknown> | undefined;
-
-			return profileNetwork !== undefined && profileNetwork.id !== undefined;
-		})
-		.sort((a, b) => networkDisplayName(a).localeCompare(networkDisplayName(b)));
 };
 
 export const hasAvailableMusigServer = ({ profile }: { profile?: Contracts.IProfile; network: Networks.Network }) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
