### PR TITLE
refactor: add missing divider to forms

### DIFF
--- a/src/domains/setting/pages/Export/Export.tsx
+++ b/src/domains/setting/pages/Export/Export.tsx
@@ -8,7 +8,7 @@ import { Header } from "@/app/components/Header";
 import { ListDivided } from "@/app/components/ListDivided";
 import { Toggle } from "@/app/components/Toggle";
 import { useEnvironmentContext } from "@/app/contexts";
-import { useActiveProfile } from "@/app/hooks";
+import { useActiveProfile, useBreakpoint } from "@/app/hooks";
 import { SettingsWrapper } from "@/domains/setting/components/SettingsPageWrapper";
 import { useProfileExport } from "@/domains/setting/hooks/use-profile-export";
 import { useFiles } from "@/app/hooks/use-files";
@@ -18,6 +18,8 @@ const EXTENSION = "wwe";
 
 export const ExportSettings = () => {
 	const { t } = useTranslation();
+
+	const { isXs } = useBreakpoint();
 
 	const form = useForm({ mode: "onChange" });
 	const { register } = form;
@@ -54,7 +56,7 @@ export const ExportSettings = () => {
 				/>
 			),
 			labelDescription: t("SETTINGS.EXPORT.OPTIONS.EXCLUDE_LEDGER_WALLETS.DESCRIPTION"),
-			wrapperClass: "pt-6",
+			wrapperClass: "pt-6 sm:pb-6",
 		},
 	];
 
@@ -92,7 +94,7 @@ export const ExportSettings = () => {
 			<Form id="export-settings__form" context={form} onSubmit={handleSubmit} className="mt-8">
 				<h2 className="mb-0 text-lg">{t("COMMON.WALLETS")}</h2>
 
-				<ListDivided items={walletExportOptions} />
+				<ListDivided items={walletExportOptions} noBorder={isXs} />
 
 				<FormButtons>
 					<Button data-testid="Export-settings__submit-button" type="submit">

--- a/src/domains/setting/pages/Export/__snapshots__/Export.test.tsx.snap
+++ b/src/domains/setting/pages/Export/__snapshots__/Export.test.tsx.snap
@@ -659,7 +659,7 @@ exports[`Export Settings should render export settings 1`] = `
                     Wallets
                   </h2>
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
@@ -712,7 +712,7 @@ exports[`Export Settings should render export settings 1`] = `
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div

--- a/src/domains/setting/pages/Networks/Networks.tsx
+++ b/src/domains/setting/pages/Networks/Networks.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/app/components/Button";
 import { Form, FormButtons } from "@/app/components/Form";
 import { Header } from "@/app/components/Header";
 import { ListDivided } from "@/app/components/ListDivided";
-import { useActiveProfile } from "@/app/hooks";
+import { useActiveProfile, useBreakpoint } from "@/app/hooks";
 import { SettingsWrapper } from "@/domains/setting/components/SettingsPageWrapper";
 import { toasts } from "@/app/services";
 import { Toggle } from "@/app/components/Toggle";
@@ -27,6 +27,8 @@ import { useWalletConfig } from "@/domains/wallet/hooks";
 
 export const NetworksSettings = () => {
 	const { t } = useTranslation();
+
+	const { isXs } = useBreakpoint();
 
 	const getProfileNetworksList = () => {
 		const profileNetworks = profile.networks().all();
@@ -260,7 +262,7 @@ export const NetworksSettings = () => {
 				),
 				label: t("SETTINGS.NETWORKS.OPTIONS.DEFAULT_NETWORKS.TITLE"),
 				labelDescription: t("SETTINGS.NETWORKS.OPTIONS.DEFAULT_NETWORKS.DESCRIPTION"),
-				wrapperClass: "pt-4 pb-6",
+				wrapperClass: "pb-6",
 			},
 			{
 				content: useCustomNetworks && (
@@ -293,7 +295,7 @@ export const NetworksSettings = () => {
 					/>
 				),
 				labelDescription: t("SETTINGS.NETWORKS.OPTIONS.CUSTOM_NETWORKS.DESCRIPTION"),
-				wrapperClass: "pt-4 pb-6",
+				wrapperClass: "pt-6 sm:pb-6",
 			},
 		],
 		[selectedNetworks, useCustomNetworks, customNetworks],
@@ -386,8 +388,8 @@ export const NetworksSettings = () => {
 		<SettingsWrapper profile={profile} activeSettings="networks">
 			<Header title={t("SETTINGS.NETWORKS.TITLE")} subtitle={t("SETTINGS.NETWORKS.SUBTITLE")} />
 
-			<Form id="Networks--form" context={form} onSubmit={handleSubmit} className="mt-4">
-				<ListDivided items={networksOptions} />
+			<Form id="Networks--form" context={form} onSubmit={handleSubmit} className="mt-6">
+				<ListDivided items={networksOptions} noBorder={isXs} />
 
 				<FormButtons>
 					<Button disabled={isSaveButtonDisabled} data-testid="Networks--submit-button" type="submit">

--- a/src/domains/setting/pages/Networks/__snapshots__/Networks.test.tsx.snap
+++ b/src/domains/setting/pages/Networks/__snapshots__/Networks.test.tsx.snap
@@ -649,16 +649,16 @@ exports[`Network Settings should check the main network by default 1`] = `
                   </div>
                 </div>
                 <form
-                  class="mt-4"
+                  class="mt-6"
                   data-testid="Form"
                   id="Networks--form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
-                      class="flex w-full flex-col pt-4 pb-6"
+                      class="flex w-full flex-col pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -783,7 +783,7 @@ exports[`Network Settings should check the main network by default 1`] = `
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-4 pb-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -1508,16 +1508,16 @@ exports[`Network Settings should render networks settings section 1`] = `
                   </div>
                 </div>
                 <form
-                  class="mt-4"
+                  class="mt-6"
                   data-testid="Form"
                   id="Networks--form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
-                      class="flex w-full flex-col pt-4 pb-6"
+                      class="flex w-full flex-col pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -1642,7 +1642,7 @@ exports[`Network Settings should render networks settings section 1`] = `
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-4 pb-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div

--- a/src/domains/setting/pages/Networks/blocks/CustomNetworksList.tsx
+++ b/src/domains/setting/pages/Networks/blocks/CustomNetworksList.tsx
@@ -112,13 +112,11 @@ const CustomNetworksList: React.VFC<{
 		<div data-testid="CustomNetworksList" className="mt-3 grid gap-3 xl:grid-cols-2">
 			<button
 				type="button"
-				className="transition-color flex cursor-pointer items-center space-x-4 rounded-xl border-2 border-theme-primary-100 px-4 py-3 text-theme-primary-600 duration-100 hover:border-theme-primary-700 hover:bg-theme-primary-700 hover:text-white dark:border-theme-secondary-800 dark:hover:border-theme-primary-700"
+				className="transition-color flex cursor-pointer items-center space-x-3 rounded-xl border-2 border-theme-primary-100 px-4 py-3 text-theme-primary-600 duration-100 hover:border-theme-primary-700 hover:bg-theme-primary-700 hover:text-white dark:border-theme-secondary-800 dark:hover:border-theme-primary-700"
 				onClick={onAdd}
 				data-testid="CustomNetworksList--add"
 			>
-				<span>
-					<Icon name="Plus" />
-				</span>
+				<Icon name="Plus" />
 				<span className="font-semibold">{t("SETTINGS.NETWORKS.CUSTOM_NETWORKS.ADD_NETWORK")}</span>
 			</button>
 

--- a/src/domains/setting/pages/Servers/Servers.test.tsx
+++ b/src/domains/setting/pages/Servers/Servers.test.tsx
@@ -83,7 +83,6 @@ const peerResponseHeight = {
 const arkDevnet = "ark.devnet";
 const serverFormSaveButtonTestingId = "ServerFormModal--save";
 const addNewPeerButtonTestId = "CustomPeers--addnew";
-const addOtherPeerTestId = "CustomPeers--addother";
 const peerStatusOkTestId = "CustomPeersPeer--statusok";
 const peerStatusLoadingTestId = "CustomPeersPeer--statusloading";
 const peerStatusErrorTestId = "CustomPeersPeer--statuserror";
@@ -742,7 +741,7 @@ describe("Servers Settings", () => {
 
 			expect(table).toBeInTheDocument();
 
-			expect(screen.getByTestId(addOtherPeerTestId)).toBeInTheDocument();
+			expect(screen.getByTestId(addNewPeerButtonTestId)).toBeInTheDocument();
 
 			expect(within(table).getAllByTestId(CustomPeersNetworkItem)).toHaveLength(3);
 
@@ -763,9 +762,9 @@ describe("Servers Settings", () => {
 
 			expect(table).toBeInTheDocument();
 
-			expect(screen.getByTestId(addOtherPeerTestId)).toBeInTheDocument();
+			expect(screen.getByTestId(addNewPeerButtonTestId)).toBeInTheDocument();
 
-			userEvent.click(screen.getByTestId(addOtherPeerTestId));
+			userEvent.click(screen.getByTestId(addNewPeerButtonTestId));
 
 			await fillServerForm({
 				address: musigHostTest,
@@ -786,7 +785,7 @@ describe("Servers Settings", () => {
 				},
 			);
 
-			userEvent.click(screen.getByTestId(addOtherPeerTestId));
+			userEvent.click(screen.getByTestId(addNewPeerButtonTestId));
 
 			const networkSelect = within(screen.getByTestId("ServerFormModal--network")).getByTestId(
 				"SelectDropdown__input",
@@ -844,7 +843,7 @@ describe("Servers Settings", () => {
 				},
 			);
 
-			userEvent.click(screen.getByTestId(addOtherPeerTestId));
+			userEvent.click(screen.getByTestId(addNewPeerButtonTestId));
 
 			const networkSelect = within(screen.getByTestId("ServerFormModal--network")).getByTestId(
 				"SelectDropdown__input",
@@ -890,7 +889,7 @@ describe("Servers Settings", () => {
 
 			expect(table).toBeInTheDocument();
 
-			expect(screen.getByTestId(addOtherPeerTestId)).toBeInTheDocument();
+			expect(screen.getByTestId(addNewPeerButtonTestId)).toBeInTheDocument();
 
 			expect(within(table).getAllByTestId("CustomPeers-network-item--mobile")).toHaveLength(3);
 

--- a/src/domains/setting/pages/Servers/Servers.tsx
+++ b/src/domains/setting/pages/Servers/Servers.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/app/components/Button";
 import { Form, FormButtons } from "@/app/components/Form";
 import { Header } from "@/app/components/Header";
 import { ListDivided } from "@/app/components/ListDivided";
-import { useActiveProfile, useProfileJobs } from "@/app/hooks";
+import { useActiveProfile, useBreakpoint, useProfileJobs } from "@/app/hooks";
 import { SettingsWrapper } from "@/domains/setting/components/SettingsPageWrapper";
 import NodesStatus from "@/domains/setting/pages/Servers/blocks/NodesStatus";
 import CustomPeers from "@/domains/setting/pages/Servers/blocks/CustomPeers";
@@ -25,6 +25,8 @@ import { useAvailableNetworks } from "@/domains/wallet/hooks";
 
 export const ServersSettings = () => {
 	const { t } = useTranslation();
+
+	const { isXs } = useBreakpoint();
 
 	const { persist, env } = useEnvironmentContext();
 	const profile = useActiveProfile();
@@ -150,7 +152,7 @@ export const ServersSettings = () => {
 				contentClass: "sm:mt-4",
 				label: t("SETTINGS.SERVERS.OPTIONS.CUSTOM_PEERS.TITLE"),
 				labelDescription: t("SETTINGS.SERVERS.OPTIONS.CUSTOM_PEERS.DESCRIPTION"),
-				wrapperClass: "pt-6",
+				wrapperClass: "pt-6 sm:pb-6",
 			},
 		],
 		[enabledNetworks, customNetworks],
@@ -180,7 +182,7 @@ export const ServersSettings = () => {
 			<Header title={t("SETTINGS.SERVERS.TITLE")} subtitle={t("SETTINGS.SERVERS.SUBTITLE")} />
 
 			<Form id="servers__form" context={form} onSubmit={saveSettings} className="mt-4">
-				<ListDivided items={serverOptions} />
+				<ListDivided items={serverOptions} noBorder={isXs} />
 
 				<FormButtons>
 					<Button disabled={isSaveButtonDisabled} data-testid="Server-settings__submit-button" type="submit">

--- a/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
+++ b/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
@@ -650,7 +650,7 @@ exports[`Servers Settings should render servers settings 1`] = `
                   id="servers__form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
@@ -870,7 +870,7 @@ exports[`Servers Settings should render servers settings 1`] = `
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -903,7 +903,8 @@ exports[`Servers Settings should render servers settings 1`] = `
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-4"
+                          class="mt-3"
+                          data-testid="CustomPeers--list"
                         >
                           <div
                             class="rounded-lg border-solid border-theme-secondary-300 text-center leading-5 text-theme-secondary-text dark:border-theme-secondary-800 sm:border sm:p-6"
@@ -914,14 +915,25 @@ exports[`Servers Settings should render servers settings 1`] = `
                             </div>
                           </div>
                           <button
-                            class="mt-3 w-full css-1jhy6v9"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -1605,7 +1617,7 @@ exports[`Servers Settings with servers should ping the servers in an interval 1`
                   id="servers__form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
@@ -1832,7 +1844,7 @@ exports[`Servers Settings with servers should ping the servers in an interval 1`
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -1865,7 +1877,7 @@ exports[`Servers Settings with servers should ping the servers in an interval 1`
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -2494,14 +2506,25 @@ exports[`Servers Settings with servers should ping the servers in an interval 1`
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -3185,7 +3208,7 @@ exports[`Servers Settings with servers should render custom servers 1`] = `
                   id="servers__form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
@@ -3404,7 +3427,7 @@ exports[`Servers Settings with servers should render custom servers 1`] = `
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -3437,7 +3460,7 @@ exports[`Servers Settings with servers should render custom servers 1`] = `
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -4051,14 +4074,25 @@ exports[`Servers Settings with servers should render custom servers 1`] = `
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -4961,7 +4995,7 @@ exports[`Servers Settings with servers should render customs servers in xs 1`] =
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -4994,7 +5028,7 @@ exports[`Servers Settings with servers should render customs servers in xs 1`] =
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -5319,14 +5353,25 @@ exports[`Servers Settings with servers should render customs servers in xs 1`] =
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -6010,7 +6055,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                   id="servers__form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
@@ -6237,7 +6282,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -6270,7 +6315,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -6899,14 +6944,25 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -7817,7 +7873,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -7850,7 +7906,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -8190,14 +8246,25 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -9108,7 +9175,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -9141,7 +9208,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -9658,14 +9725,25 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -10349,7 +10427,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                   id="servers__form"
                 >
                   <ul
-                    class="css-slpw39"
+                    class="css-14npy8n"
                     data-testid="list-divided__items"
                   >
                     <li
@@ -10576,7 +10654,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -10609,7 +10687,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -11238,14 +11316,25 @@ exports[`Servers Settings with unreachable servers should show status error if r
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -12156,7 +12245,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -12189,7 +12278,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -12529,14 +12618,25 @@ exports[`Servers Settings with unreachable servers should show status error if r
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>
@@ -13447,7 +13547,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                       </div>
                     </li>
                     <li
-                      class="flex w-full flex-col pt-6"
+                      class="flex w-full flex-col pt-6 sm:pb-6"
                       data-testid="list-divided-item__wrapper"
                     >
                       <div
@@ -13480,7 +13580,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                         data-testid="list-divided-item__content"
                       >
                         <div
-                          class="mt-3"
+                          class="mt-1 sm:mt-3"
                           data-testid="CustomPeers--list"
                         >
                           <div
@@ -13997,14 +14097,25 @@ exports[`Servers Settings with unreachable servers should show status error if r
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 css-1jhy6v9"
-                            data-testid="CustomPeers--addother"
+                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            data-testid="CustomPeers--addnew"
                             type="button"
                           >
                             <div
                               class="flex items-center space-x-2"
                             >
-                              Add New
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg>
+                                  plus.svg
+                                </svg>
+                              </div>
+                              <span>
+                                Add New
+                              </span>
                             </div>
                           </button>
                         </div>

--- a/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
+++ b/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
@@ -915,7 +915,7 @@ exports[`Servers Settings should render servers settings 1`] = `
                             </div>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -2506,7 +2506,7 @@ exports[`Servers Settings with servers should ping the servers in an interval 1`
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -4074,7 +4074,7 @@ exports[`Servers Settings with servers should render custom servers 1`] = `
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -5353,7 +5353,7 @@ exports[`Servers Settings with servers should render customs servers in xs 1`] =
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -6944,7 +6944,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -8246,7 +8246,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -9725,7 +9725,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -11316,7 +11316,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -12618,7 +12618,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >
@@ -14097,7 +14097,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                             </table>
                           </div>
                           <button
-                            class="mt-6 w-full sm:mt-3 space-x-2 css-1jhy6v9"
+                            class="mt-6 w-full space-x-2 sm:mt-3 css-1jhy6v9"
                             data-testid="CustomPeers--addnew"
                             type="button"
                           >

--- a/src/domains/setting/pages/Servers/blocks/CustomPeers.tsx
+++ b/src/domains/setting/pages/Servers/blocks/CustomPeers.tsx
@@ -23,27 +23,6 @@ import { useEnvironmentContext } from "@/app/contexts";
 import { AccordionContent, AccordionHeader, AccordionWrapper } from "@/app/components/Accordion";
 import { networkDisplayName } from "@/utils/network-utils";
 
-const CustomPeersNoPeers: React.VFC<{
-	addNewServerHandler: () => void;
-}> = ({ addNewServerHandler }) => {
-	const { t } = useTranslation();
-
-	return (
-		<div className="mt-4">
-			<EmptyBlock>{t("SETTINGS.SERVERS.CUSTOM_PEERS.EMPTY_MESSAGE")}</EmptyBlock>
-
-			<Button
-				data-testid="CustomPeers--addnew"
-				onClick={addNewServerHandler}
-				variant="secondary"
-				className="mt-3 w-full"
-			>
-				{t("COMMON.ADD_NEW")}
-			</Button>
-		</div>
-	);
-};
-
 interface PeerRowProperties {
 	name: string;
 	address: string;
@@ -450,10 +429,6 @@ const CustomPeers: React.VFC<{
 
 	const { isXs } = useBreakpoint();
 
-	if (networks.length === 0) {
-		return <CustomPeersNoPeers addNewServerHandler={addNewServerHandler} />;
-	}
-
 	const columns: Column[] = [
 		{
 			Header: t("COMMON.NETWORK"),
@@ -485,8 +460,12 @@ const CustomPeers: React.VFC<{
 		},
 	];
 
-	return (
-		<div data-testid="CustomPeers--list" className="mt-3">
+	const renderPeers = () => {
+		if (networks.length === 0) {
+			return <EmptyBlock>{t("SETTINGS.SERVERS.CUSTOM_PEERS.EMPTY_MESSAGE")}</EmptyBlock>;
+		}
+
+		return (
 			<Table columns={columns} data={networks} rowsPerPage={networks.length} hideHeader={isXs}>
 				{(network: NormalizedNetwork) => (
 					<CustomPeersPeer
@@ -499,14 +478,21 @@ const CustomPeers: React.VFC<{
 					/>
 				)}
 			</Table>
+		);
+	}
+
+	return (
+		<div data-testid="CustomPeers--list" className={networks.length === 0 ? "mt-3" : "mt-1 sm:mt-3"}>
+			{renderPeers()}
 
 			<Button
-				data-testid="CustomPeers--addother"
+				data-testid="CustomPeers--addnew"
 				onClick={addNewServerHandler}
 				variant="secondary"
-				className="mt-6 w-full sm:mt-3"
+				className="mt-6 w-full sm:mt-3 space-x-2"
 			>
-				{t("COMMON.ADD_NEW")}
+				<Icon name="Plus" />
+				<span>{t("COMMON.ADD_NEW")}</span>
 			</Button>
 		</div>
 	);

--- a/src/domains/setting/pages/Servers/blocks/CustomPeers.tsx
+++ b/src/domains/setting/pages/Servers/blocks/CustomPeers.tsx
@@ -479,7 +479,7 @@ const CustomPeers: React.VFC<{
 				)}
 			</Table>
 		);
-	}
+	};
 
 	return (
 		<div data-testid="CustomPeers--list" className={networks.length === 0 ? "mt-3" : "mt-1 sm:mt-3"}>
@@ -489,7 +489,7 @@ const CustomPeers: React.VFC<{
 				data-testid="CustomPeers--addnew"
 				onClick={addNewServerHandler}
 				variant="secondary"
-				className="mt-6 w-full sm:mt-3 space-x-2"
+				className="mt-6 w-full space-x-2 sm:mt-3"
 			>
 				<Icon name="Plus" />
 				<span>{t("COMMON.ADD_NEW")}</span>

--- a/src/domains/transaction/pages/SendTransfer/NetworkStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/NetworkStep.tsx
@@ -51,9 +51,7 @@ export const NetworkStep = ({ profile, networks }: { profile: Contracts.IProfile
 				/>
 			</FormField>
 
-			{networks.length === 2 && (
-				<Divider />
-			)}
+			{networks.length === 2 && <Divider />}
 		</section>
 	);
 };

--- a/src/domains/transaction/pages/SendTransfer/NetworkStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/NetworkStep.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import { Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
 import React, { useMemo } from "react";
@@ -8,8 +9,11 @@ import { FormField, FormLabel } from "@/app/components/Form";
 import { SelectNetwork } from "@/domains/network/components/SelectNetwork";
 import { StepHeader } from "@/app/components/StepHeader";
 import { useAvailableNetworks } from "@/domains/wallet/hooks";
+import { Divider } from "@/app/components/Divider";
 
 export const NetworkStep = ({ profile, networks }: { profile: Contracts.IProfile; networks: Networks.Network[] }) => {
+	const { t } = useTranslation();
+
 	const { setValue, watch } = useFormContext();
 
 	const profileAvailableNetworks = useAvailableNetworks({ profile });
@@ -24,21 +28,20 @@ export const NetworkStep = ({ profile, networks }: { profile: Contracts.IProfile
 
 	const selectedNetwork: Networks.Network = watch("network");
 
-	const { t } = useTranslation();
-
 	const handleSelect = (network?: Networks.Network | null) => {
 		setValue("network", network, { shouldDirty: true, shouldValidate: true });
 	};
 
 	return (
-		<section data-testid="SendTransfer__network-step" className="space-y-6">
+		<section data-testid="SendTransfer__network-step">
 			<StepHeader
 				title={t("TRANSACTION.PAGE_TRANSACTION_SEND.NETWORK_STEP.TITLE")}
 				subtitle={t("TRANSACTION.PAGE_TRANSACTION_SEND.NETWORK_STEP.SUBTITLE")}
 			/>
 
-			<FormField name="network">
-				<FormLabel label={t("COMMON.CRYPTOASSET")} />
+			<FormField name="network" className={cn("mt-8", { "my-8": networks.length === 2 })}>
+				{networks.length > 2 && <FormLabel label={t("COMMON.CRYPTOASSET")} />}
+
 				<SelectNetwork
 					profile={profile}
 					id="SendTransfer__network-step__select"
@@ -47,6 +50,10 @@ export const NetworkStep = ({ profile, networks }: { profile: Contracts.IProfile
 					onSelect={handleSelect}
 				/>
 			</FormField>
+
+			{networks.length === 2 && (
+				<Divider />
+			)}
 		</section>
 	);
 };

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
@@ -15,6 +15,7 @@ import { FormStep } from "./FormStep";
 import { ReviewStep } from "./ReviewStep";
 import { SendTransfer } from "./SendTransfer";
 import { SummaryStep } from "./SummaryStep";
+import { NetworkStep } from "./NetworkStep";
 import { buildTransferData } from "@/domains/transaction/pages/SendTransfer/SendTransfer.helpers";
 import { LedgerProvider, minVersionList, StepsProvider } from "@/app/contexts";
 import { translations as transactionTranslations } from "@/domains/transaction/i18n";
@@ -35,7 +36,6 @@ import {
 	mockProfileWithPublicAndTestNetworks,
 	mockProfileWithOnlyPublicNetworks,
 } from "@/utils/testing-library";
-import { NetworkStep } from "./NetworkStep";
 
 const passphrase = getDefaultWalletMnemonic();
 const fixtureProfileId = getDefaultProfileId();
@@ -179,6 +179,7 @@ describe("SendTransfer", () => {
 		);
 
 		expect(screen.getByTestId(networkStepID)).toBeInTheDocument();
+
 		await waitFor(() => expect(screen.queryByTestId("FormLabel")).not.toBeInTheDocument());
 
 		expect(

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
@@ -35,6 +35,7 @@ import {
 	mockProfileWithPublicAndTestNetworks,
 	mockProfileWithOnlyPublicNetworks,
 } from "@/utils/testing-library";
+import { NetworkStep } from "./NetworkStep";
 
 const passphrase = getDefaultWalletMnemonic();
 const fixtureProfileId = getDefaultProfileId();
@@ -164,6 +165,48 @@ describe("SendTransfer", () => {
 	afterEach(() => {
 		jest.restoreAllMocks();
 		resetProfileNetworksMock();
+	});
+
+	it("should render network step with network cards", async () => {
+		const { asFragment } = renderWithForm(
+			<StepsProvider activeStep={1} steps={4}>
+				<NetworkStep profile={profile} networks={profile.availableNetworks().slice(0, 2)} />
+			</StepsProvider>,
+			{
+				registerCallback: defaultRegisterCallback,
+				withProviders: true,
+			},
+		);
+
+		expect(screen.getByTestId(networkStepID)).toBeInTheDocument();
+		await waitFor(() => expect(screen.queryByTestId("FormLabel")).not.toBeInTheDocument());
+
+		expect(
+			within(screen.getByTestId("SendTransfer__network-step__select")).getAllByTestId("NetworkOption"),
+		).toHaveLength(2);
+
+		expect(asFragment()).toMatchSnapshot();
+	});
+
+	it("should render network step with dropdown", () => {
+		const { asFragment } = renderWithForm(
+			<StepsProvider activeStep={1} steps={4}>
+				<NetworkStep profile={profile} networks={profile.availableNetworks()} />
+			</StepsProvider>,
+			{
+				registerCallback: defaultRegisterCallback,
+				withProviders: true,
+			},
+		);
+
+		expect(screen.getByTestId(networkStepID)).toBeInTheDocument();
+		expect(screen.getByTestId("FormLabel")).toBeInTheDocument();
+
+		expect(
+			within(screen.getByTestId("SendTransfer__network-step__select")).getByTestId("SelectDropdown"),
+		).toBeInTheDocument();
+
+		expect(asFragment()).toMatchSnapshot();
 	});
 
 	it("should render form step", async () => {

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.NetworkSelection.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.NetworkSelection.test.tsx.snap
@@ -1595,7 +1595,6 @@ exports[`SendTransfer Network Selection should select cryptoasset 1`] = `
                 data-testid="tab-pabel__active-panel"
               >
                 <section
-                  class="space-y-6"
                   data-testid="SendTransfer__network-step"
                 >
                   <div
@@ -1651,15 +1650,8 @@ exports[`SendTransfer Network Selection should select cryptoasset 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="flex flex-col css-1bcidjh"
+                    class="mt-8 my-8 css-1bcidjh"
                   >
-                    <label
-                      class="FormLabel mb-2 flex text-sm font-semibold text-theme-secondary-text transition-colors duration-100"
-                      data-testid="FormLabel"
-                      for="network"
-                    >
-                      Cryptoasset
-                    </label>
                     <div
                       data-testid="SendTransfer__network-step__select"
                     >
@@ -1751,6 +1743,10 @@ exports[`SendTransfer Network Selection should select cryptoasset 1`] = `
                       </div>
                     </div>
                   </fieldset>
+                  <div
+                    class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                    type="horizontal"
+                  />
                 </section>
               </div>
               <div

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -7860,7 +7860,6 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                 data-testid="tab-pabel__active-panel"
               >
                 <section
-                  class="space-y-6"
                   data-testid="SendTransfer__network-step"
                 >
                   <div
@@ -7916,15 +7915,8 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                     </div>
                   </div>
                   <fieldset
-                    class="flex flex-col css-1bcidjh"
+                    class="mt-8 my-8 css-1bcidjh"
                   >
-                    <label
-                      class="FormLabel mb-2 flex text-sm font-semibold text-theme-secondary-text transition-colors duration-100"
-                      data-testid="FormLabel"
-                      for="network"
-                    >
-                      Cryptoasset
-                    </label>
                     <div
                       data-testid="SendTransfer__network-step__select"
                     >
@@ -8016,6 +8008,10 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                       </div>
                     </div>
                   </fieldset>
+                  <div
+                    class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                    type="horizontal"
+                  />
                 </section>
               </div>
               <div

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2147,13 +2147,13 @@ exports[`SendTransfer should render form and use location state 1`] = `
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
-                            aria-owns="downshift-40-menu"
+                            aria-owns="downshift-42-menu"
                             role="combobox"
                           >
                             <div>
                               <label
-                                for="downshift-40-input"
-                                id="downshift-40-label"
+                                for="downshift-42-input"
+                                id="downshift-42-label"
                               />
                               <div
                                 class="invisible fixed w-auto whitespace-nowrap"
@@ -2184,13 +2184,13 @@ exports[`SendTransfer should render form and use location state 1`] = `
                                 >
                                   <input
                                     aria-autocomplete="list"
-                                    aria-controls="downshift-40-menu"
-                                    aria-labelledby="downshift-40-label"
+                                    aria-controls="downshift-42-menu"
+                                    aria-labelledby="downshift-42-label"
                                     autocomplete="off"
                                     class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                                     data-testid="SelectDropdown__input"
                                     disabled=""
-                                    id="downshift-40-input"
+                                    id="downshift-42-input"
                                     name="network"
                                     placeholder="Select option"
                                     type="text"
@@ -2237,8 +2237,8 @@ exports[`SendTransfer should render form and use location state 1`] = `
                               </div>
                             </div>
                             <div
-                              aria-labelledby="downshift-40-label"
-                              id="downshift-40-menu"
+                              aria-labelledby="downshift-42-label"
+                              id="downshift-42-menu"
                               role="listbox"
                             />
                           </div>
@@ -3326,13 +3326,13 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
-                            aria-owns="downshift-58-menu"
+                            aria-owns="downshift-60-menu"
                             role="combobox"
                           >
                             <div>
                               <label
-                                for="downshift-58-input"
-                                id="downshift-58-label"
+                                for="downshift-60-input"
+                                id="downshift-60-label"
                               />
                               <div
                                 class="invisible fixed w-auto whitespace-nowrap"
@@ -3363,13 +3363,13 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                                 >
                                   <input
                                     aria-autocomplete="list"
-                                    aria-controls="downshift-58-menu"
-                                    aria-labelledby="downshift-58-label"
+                                    aria-controls="downshift-60-menu"
+                                    aria-labelledby="downshift-60-label"
                                     autocomplete="off"
                                     class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                                     data-testid="SelectDropdown__input"
                                     disabled=""
-                                    id="downshift-58-input"
+                                    id="downshift-60-input"
                                     name="network"
                                     placeholder="Select option"
                                     type="text"
@@ -3416,8 +3416,8 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                               </div>
                             </div>
                             <div
-                              aria-labelledby="downshift-58-label"
-                              id="downshift-58-menu"
+                              aria-labelledby="downshift-60-label"
+                              id="downshift-60-menu"
                               role="listbox"
                             />
                           </div>
@@ -4078,13 +4078,13 @@ exports[`SendTransfer should render form step 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-0-menu"
+              aria-owns="downshift-2-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-0-input"
-                  id="downshift-0-label"
+                  for="downshift-2-input"
+                  id="downshift-2-label"
                 />
                 <div
                   class="invisible fixed w-auto whitespace-nowrap"
@@ -4115,13 +4115,13 @@ exports[`SendTransfer should render form step 1`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-0-menu"
-                      aria-labelledby="downshift-0-label"
+                      aria-controls="downshift-2-menu"
+                      aria-labelledby="downshift-2-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                       data-testid="SelectDropdown__input"
                       disabled=""
-                      id="downshift-0-input"
+                      id="downshift-2-input"
                       name="network"
                       placeholder="Select option"
                       type="text"
@@ -4168,8 +4168,8 @@ exports[`SendTransfer should render form step 1`] = `
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-0-label"
-                id="downshift-0-menu"
+                aria-labelledby="downshift-2-label"
+                id="downshift-2-menu"
                 role="listbox"
               />
             </div>
@@ -4760,13 +4760,13 @@ exports[`SendTransfer should render form step with deeplink values and handle ca
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-29-menu"
+              aria-owns="downshift-31-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-29-input"
-                  id="downshift-29-label"
+                  for="downshift-31-input"
+                  id="downshift-31-label"
                 />
                 <div
                   class="invisible fixed w-auto whitespace-nowrap"
@@ -4797,13 +4797,13 @@ exports[`SendTransfer should render form step with deeplink values and handle ca
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-29-menu"
-                      aria-labelledby="downshift-29-label"
+                      aria-controls="downshift-31-menu"
+                      aria-labelledby="downshift-31-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                       data-testid="SelectDropdown__input"
                       disabled=""
-                      id="downshift-29-input"
+                      id="downshift-31-input"
                       name="network"
                       placeholder="Select option"
                       type="text"
@@ -4850,8 +4850,8 @@ exports[`SendTransfer should render form step with deeplink values and handle ca
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-29-label"
-                id="downshift-29-menu"
+                aria-labelledby="downshift-31-label"
+                id="downshift-31-menu"
                 role="listbox"
               />
             </div>
@@ -5490,13 +5490,13 @@ exports[`SendTransfer should render form step with deeplink values and use them 
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-18-menu"
+              aria-owns="downshift-20-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-18-input"
-                  id="downshift-18-label"
+                  for="downshift-20-input"
+                  id="downshift-20-label"
                 />
                 <div
                   class="invisible fixed w-auto whitespace-nowrap"
@@ -5527,13 +5527,13 @@ exports[`SendTransfer should render form step with deeplink values and use them 
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-18-menu"
-                      aria-labelledby="downshift-18-label"
+                      aria-controls="downshift-20-menu"
+                      aria-labelledby="downshift-20-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                       data-testid="SelectDropdown__input"
                       disabled=""
-                      id="downshift-18-input"
+                      id="downshift-20-input"
                       name="network"
                       placeholder="Select option"
                       type="text"
@@ -5580,8 +5580,8 @@ exports[`SendTransfer should render form step with deeplink values and use them 
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-18-label"
-                id="downshift-18-menu"
+                aria-labelledby="downshift-20-label"
+                id="downshift-20-menu"
                 role="listbox"
               />
             </div>
@@ -6220,13 +6220,13 @@ exports[`SendTransfer should render form step without memo input 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-6-menu"
+              aria-owns="downshift-8-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-6-input"
-                  id="downshift-6-label"
+                  for="downshift-8-input"
+                  id="downshift-8-label"
                 />
                 <div
                   class="invisible fixed w-auto whitespace-nowrap"
@@ -6257,13 +6257,13 @@ exports[`SendTransfer should render form step without memo input 1`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-6-menu"
-                      aria-labelledby="downshift-6-label"
+                      aria-controls="downshift-8-menu"
+                      aria-labelledby="downshift-8-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                       data-testid="SelectDropdown__input"
                       disabled=""
-                      id="downshift-6-input"
+                      id="downshift-8-input"
                       name="network"
                       placeholder="Select option"
                       type="text"
@@ -6310,8 +6310,8 @@ exports[`SendTransfer should render form step without memo input 1`] = `
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-6-label"
-                id="downshift-6-menu"
+                aria-labelledby="downshift-8-label"
+                id="downshift-8-menu"
                 role="listbox"
               />
             </div>
@@ -6853,13 +6853,13 @@ exports[`SendTransfer should render form step without test networks 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-12-menu"
+              aria-owns="downshift-14-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-12-input"
-                  id="downshift-12-label"
+                  for="downshift-14-input"
+                  id="downshift-14-label"
                 />
                 <div
                   class="invisible fixed w-auto whitespace-nowrap"
@@ -6890,13 +6890,13 @@ exports[`SendTransfer should render form step without test networks 1`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-12-menu"
-                      aria-labelledby="downshift-12-label"
+                      aria-controls="downshift-14-menu"
+                      aria-labelledby="downshift-14-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none text-theme-secondary-text css-1nupw50"
                       data-testid="SelectDropdown__input"
                       disabled=""
-                      id="downshift-12-input"
+                      id="downshift-14-input"
                       name="network"
                       placeholder="Select option"
                       type="text"
@@ -6943,8 +6943,8 @@ exports[`SendTransfer should render form step without test networks 1`] = `
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-12-label"
-                id="downshift-12-menu"
+                aria-labelledby="downshift-14-label"
+                id="downshift-14-menu"
                 role="listbox"
               />
             </div>
@@ -8047,6 +8047,328 @@ exports[`SendTransfer should render network selection without selected wallet 1`
       </div>
     </div>
   </div>
+</DocumentFragment>
+`;
+
+exports[`SendTransfer should render network step with dropdown 1`] = `
+<DocumentFragment>
+  <section
+    data-testid="SendTransfer__network-step"
+  >
+    <div
+      class="sm:mt-8"
+    >
+      <div
+        class="flex flex-col"
+      >
+        <span
+          class="css-3qwsx5"
+        >
+          Select a Cryptoasset
+        </span>
+        <ul
+          class="css-xa5o6q"
+        >
+          <li
+            class="css-47028"
+          />
+          <li
+            class="css-3ldhk3"
+          />
+          <li
+            class="css-3ldhk3"
+          />
+          <li
+            class="css-3ldhk3"
+          />
+        </ul>
+      </div>
+      <div
+        class="flex items-end justify-between bg-theme-background mt-6 hidden sm:block"
+      >
+        <div
+          class="space-y-4"
+        >
+          <h1
+            class="mb-0 text-2xl"
+            data-testid="header__title"
+          >
+            Select a Cryptoasset
+          </h1>
+          <div
+            class="flex items-center text-theme-secondary-text"
+            data-testid="header__subtitle"
+          >
+            Select a cryptoasset to send funds from.
+          </div>
+        </div>
+      </div>
+    </div>
+    <fieldset
+      class="mt-8 css-1bcidjh"
+    >
+      <label
+        class="FormLabel mb-2 flex text-sm font-semibold text-theme-secondary-text transition-colors duration-100"
+        data-testid="FormLabel"
+        for="network"
+      >
+        Cryptoasset
+      </label>
+      <div
+        data-testid="SendTransfer__network-step__select"
+      >
+        <div
+          class="relative w-full"
+          data-testid="SelectDropdown"
+        >
+          <div
+            class="sr-only css-1psxlcd"
+          >
+            <div
+              class="relative flex h-full flex-1"
+            >
+              <input
+                autocomplete="off"
+                class="no-ligatures w-full border-none css-1nupw50"
+                data-testid="select-list__input"
+                name="network"
+                readonly=""
+                tabindex="-1"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="w-full"
+          >
+            <div
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-owns="downshift-0-menu"
+              role="combobox"
+            >
+              <div>
+                <label
+                  for="downshift-0-input"
+                  id="downshift-0-label"
+                />
+                <div
+                  class="css-1psxlcd"
+                >
+                  <div
+                    class="relative flex h-full flex-1"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="downshift-0-menu"
+                      aria-labelledby="downshift-0-label"
+                      autocomplete="off"
+                      class="no-ligatures w-full border-none cursor-default css-1nupw50"
+                      data-testid="SelectDropdown__input"
+                      id="downshift-0-input"
+                      name="network"
+                      placeholder="Select option"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                  <div
+                    class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                    data-testid="Input__addon-end"
+                  >
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="flex items-center"
+                      >
+                        <div
+                          class="flex items-center justify-center py-2 px-1"
+                          data-testid="SelectDropdown__caret"
+                        >
+                          <div
+                            class="transition-transform text-theme-secondary-500 css-15txs7d"
+                            height="10"
+                            width="10"
+                          >
+                            <svg>
+                              caret-down.svg
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-labelledby="downshift-0-label"
+                id="downshift-0-menu"
+                role="listbox"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`SendTransfer should render network step with network cards 1`] = `
+<DocumentFragment>
+  <section
+    data-testid="SendTransfer__network-step"
+  >
+    <div
+      class="sm:mt-8"
+    >
+      <div
+        class="flex flex-col"
+      >
+        <span
+          class="css-3qwsx5"
+        >
+          Select a Cryptoasset
+        </span>
+        <ul
+          class="css-xa5o6q"
+        >
+          <li
+            class="css-47028"
+          />
+          <li
+            class="css-3ldhk3"
+          />
+          <li
+            class="css-3ldhk3"
+          />
+          <li
+            class="css-3ldhk3"
+          />
+        </ul>
+      </div>
+      <div
+        class="flex items-end justify-between bg-theme-background mt-6 hidden sm:block"
+      >
+        <div
+          class="space-y-4"
+        >
+          <h1
+            class="mb-0 text-2xl"
+            data-testid="header__title"
+          >
+            Select a Cryptoasset
+          </h1>
+          <div
+            class="flex items-center text-theme-secondary-text"
+            data-testid="header__subtitle"
+          >
+            Select a cryptoasset to send funds from.
+          </div>
+        </div>
+      </div>
+    </div>
+    <fieldset
+      class="mt-8 my-8 css-1bcidjh"
+    >
+      <div
+        data-testid="SendTransfer__network-step__select"
+      >
+        <div
+          class="flex-col space-y-3 space-x-0 sm:flex sm:flex-row sm:space-x-3 sm:space-y-0"
+          data-testid="NetworkOptions"
+        >
+          <li
+            class="flex h-18 w-full cursor-pointer"
+            data-testid="NetworkOption"
+          >
+            <div
+              aria-label="ARK"
+              class="flex h-full w-full items-center items-center justify-between space-x-4 rounded-xl border-2 pl-4 pr-6 text-theme-secondary-500 dark:text-theme-secondary-800 border-theme-primary-100 dark:border-theme-secondary-800"
+              data-testid="NetworkOption-ARK-ark.mainnet"
+            >
+              <div
+                class="flex items-center space-x-4"
+              >
+                <div
+                  aria-label="ARK"
+                  class="flex items-center justify-center rounded-xl p-1 text-theme-primary-600"
+                >
+                  <div
+                    class="css-1i4b0eq"
+                    data-testid="NetworkIcon__icon"
+                    height="20"
+                    width="20"
+                  >
+                    <svg>
+                      ark.svg
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
+                >
+                  ARK
+                </div>
+              </div>
+            </div>
+          </li>
+          <li
+            class="flex h-18 w-full cursor-pointer"
+            data-testid="NetworkOption"
+          >
+            <div
+              aria-label="ARK Devnet"
+              class="flex h-full w-full items-center items-center justify-between space-x-4 rounded-xl border-2 pl-4 pr-6 text-theme-secondary-500 dark:text-theme-secondary-800 border-theme-primary-100 dark:border-theme-secondary-800"
+              data-testid="NetworkOption-ARK-ark.devnet"
+            >
+              <div
+                class="flex items-center space-x-4"
+              >
+                <div
+                  aria-label="ARK Devnet"
+                  class="flex items-center justify-center rounded-xl p-1 text-theme-secondary-700"
+                >
+                  <div
+                    class="css-1i4b0eq"
+                    data-testid="NetworkIcon__icon"
+                    height="20"
+                    width="20"
+                  >
+                    <svg>
+                      ark.svg
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
+                >
+                  ARK Devnet
+                </div>
+              </div>
+              <span>
+                <div
+                  class="text-theme-secondary-500 dark:text-theme-secondary-700 css-1i4b0eq"
+                  height="20"
+                  width="20"
+                >
+                  <svg>
+                    code.svg
+                  </svg>
+                </div>
+              </span>
+            </div>
+          </li>
+        </div>
+      </div>
+    </fieldset>
+    <div
+      class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+      type="horizontal"
+    />
+  </section>
 </DocumentFragment>
 `;
 

--- a/src/domains/wallet/components/MnemonicVerification/MnemonicVerification.tsx
+++ b/src/domains/wallet/components/MnemonicVerification/MnemonicVerification.tsx
@@ -6,6 +6,7 @@ import { MnemonicVerificationProgress } from "./MnemonicVerificationProgress";
 import { TabPanel, Tabs } from "@/app/components/Tabs";
 
 interface Properties {
+	className?: string;
 	mnemonic: string;
 	wordPositions?: number[];
 	optionsLimit: number;
@@ -35,6 +36,7 @@ const defaultProps = {
 };
 
 export function MnemonicVerification({
+	className,
 	mnemonic,
 	wordPositions = defaultProps.wordPositions,
 	optionsLimit,
@@ -74,13 +76,13 @@ export function MnemonicVerification({
 	};
 
 	return (
-		<Tabs activeId={activeTab}>
+		<Tabs className={className} activeId={activeTab}>
 			<MnemonicVerificationProgress activeTab={activeTab} wordPositions={positions} />
 
 			{!isCompleted && (
 				<div className="mt-8">
 					{positions.map((position, index) => (
-						<TabPanel key={index} tabId={index}>
+						<TabPanel key={position} tabId={index}>
 							<MnemonicVerificationOptions
 								limit={optionsLimit}
 								answer={currentAnswer}

--- a/src/domains/wallet/components/NetworkStep/NetworkStep.tsx
+++ b/src/domains/wallet/components/NetworkStep/NetworkStep.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import { Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
 import React from "react";
@@ -9,6 +10,7 @@ import { Alert } from "@/app/components/Alert";
 import { FormField, FormLabel } from "@/app/components/Form";
 import { Header } from "@/app/components/Header";
 import { SelectNetwork } from "@/domains/network/components/SelectNetwork";
+import { Divider } from "@/app/components/Divider";
 
 interface NetworkStepProperties {
 	profile: Contracts.IProfile;
@@ -42,7 +44,7 @@ export const NetworkStep = ({ title, subtitle, disabled, error, filter, profile 
 				</div>
 			)}
 
-			<FormField name="network" className="mt-8">
+			<FormField name="network" className={cn("mt-8", { "my-8": networks.length === 2 })}>
 				{networks.length > 2 && <FormLabel label={t("COMMON.CRYPTOASSET")} />}
 
 				<SelectNetwork
@@ -53,6 +55,10 @@ export const NetworkStep = ({ title, subtitle, disabled, error, filter, profile 
 					onSelect={handleSelect}
 				/>
 			</FormField>
+
+			{networks.length === 2 && (
+				<Divider />
+			)}
 		</section>
 	);
 };

--- a/src/domains/wallet/components/NetworkStep/NetworkStep.tsx
+++ b/src/domains/wallet/components/NetworkStep/NetworkStep.tsx
@@ -56,9 +56,7 @@ export const NetworkStep = ({ title, subtitle, disabled, error, filter, profile 
 				/>
 			</FormField>
 
-			{networks.length === 2 && (
-				<Divider />
-			)}
+			{networks.length === 2 && <Divider />}
 		</section>
 	);
 };

--- a/src/domains/wallet/pages/CreateWallet/ConfirmPassphraseStep.tsx
+++ b/src/domains/wallet/pages/CreateWallet/ConfirmPassphraseStep.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { Header } from "@/app/components/Header";
 import { MnemonicVerification } from "@/domains/wallet/components/MnemonicVerification";
+import { Divider } from "@/app/components/Divider";
 
 export const ConfirmPassphraseStep = () => {
 	const { getValues, register, setValue, watch } = useFormContext();
@@ -23,7 +24,7 @@ export const ConfirmPassphraseStep = () => {
 	}, [isVerified, register]);
 
 	return (
-		<section data-testid="CreateWallet__ConfirmPassphraseStep" className="space-y-6">
+		<section data-testid="CreateWallet__ConfirmPassphraseStep">
 			<Header
 				title={t("WALLETS.PAGE_CREATE_WALLET.PASSPHRASE_CONFIRMATION_STEP.TITLE")}
 				subtitle={t("WALLETS.PAGE_CREATE_WALLET.PASSPHRASE_CONFIRMATION_STEP.SUBTITLE")}
@@ -31,11 +32,14 @@ export const ConfirmPassphraseStep = () => {
 			/>
 
 			<MnemonicVerification
+				className="mt-6 mb-8"
 				mnemonic={mnemonic}
 				optionsLimit={6}
 				handleComplete={handleComplete}
 				isCompleted={isVerified}
 			/>
+
+			<Divider />
 		</section>
 	);
 };

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -474,7 +474,7 @@ exports[`CreateWallet should create a wallet 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-8 css-1bcidjh"
+                      class="mt-8 my-8 css-1bcidjh"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -567,6 +567,10 @@ exports[`CreateWallet should create a wallet 1`] = `
                         </div>
                       </div>
                     </fieldset>
+                    <div
+                      class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                      type="horizontal"
+                    />
                   </section>
                 </div>
                 <div
@@ -1801,7 +1805,7 @@ exports[`CreateWallet should create a wallet with encryption 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-8 css-1bcidjh"
+                      class="mt-8 my-8 css-1bcidjh"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -1894,6 +1898,10 @@ exports[`CreateWallet should create a wallet with encryption 1`] = `
                         </div>
                       </div>
                     </fieldset>
+                    <div
+                      class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                      type="horizontal"
+                    />
                   </section>
                 </div>
                 <div
@@ -3133,7 +3141,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-8 css-1bcidjh"
+                      class="mt-8 my-8 css-1bcidjh"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -3226,6 +3234,10 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                         </div>
                       </div>
                     </fieldset>
+                    <div
+                      class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                      type="horizontal"
+                    />
                   </section>
                 </div>
                 <div
@@ -3737,7 +3749,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-8 css-1bcidjh"
+                      class="mt-8 my-8 css-1bcidjh"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -3830,6 +3842,10 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                         </div>
                       </div>
                     </fieldset>
+                    <div
+                      class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                      type="horizontal"
+                    />
                   </section>
                 </div>
                 <div
@@ -4372,7 +4388,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                       </div>
                     </div>
                     <fieldset
-                      class="mt-8 css-1bcidjh"
+                      class="mt-8 my-8 css-1bcidjh"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -4465,6 +4481,10 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                         </div>
                       </div>
                     </fieldset>
+                    <div
+                      class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+                      type="horizontal"
+                    />
                   </section>
                 </div>
                 <div

--- a/src/domains/wallet/pages/ImportWallet/ImportWallet.tsx
+++ b/src/domains/wallet/pages/ImportWallet/ImportWallet.tsx
@@ -311,6 +311,7 @@ export const ImportWallet = () => {
 										subtitle={t("WALLETS.PAGE_IMPORT_WALLET.NETWORK_STEP.SUBTITLE")}
 									/>
 								</TabPanel>
+
 								<TabPanel tabId={Step.MethodStep}>
 									<MethodStep profile={activeProfile} />
 								</TabPanel>

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`LedgerTabs should render connection step 1`] = `
             </div>
           </div>
           <fieldset
-            class="mt-8 css-1bcidjh"
+            class="mt-8 my-8 css-1bcidjh"
           >
             <div
               data-testid="SelectNetwork"
@@ -155,6 +155,10 @@ exports[`LedgerTabs should render connection step 1`] = `
               </div>
             </div>
           </fieldset>
+          <div
+            class="border-theme-secondary-300 dark:border-theme-secondary-800 css-12qg4ub"
+            type="horizontal"
+          />
         </section>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

Closes #31.

Adds a divider to:

- export, network and server settings
- network step of create / import wallet forms
- network step of transaction form
- mnemonic verification step

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
