### PR TITLE
fix: sync profile networks after adding custom network

### DIFF
--- a/src/domains/setting/pages/Networks/Networks.tsx
+++ b/src/domains/setting/pages/Networks/Networks.tsx
@@ -372,12 +372,12 @@ export const NetworksSettings = () => {
 			selectedNetworkIds: profileEnabledNetworkIds(profile),
 		});
 
-		await env.profiles().restore(profile, getProfileStoredPassword(profile));
-		await profile.sync();
-
 		setWalletConfig("selectedNetworkIds", profileEnabledNetworkIds(profile));
 
 		await persist();
+
+		await env.profiles().restore(profile, getProfileStoredPassword(profile));
+		await profile.sync();
 
 		toasts.success(t("SETTINGS.GENERAL.SUCCESS"));
 

--- a/src/domains/setting/pages/Networks/Networks.tsx
+++ b/src/domains/setting/pages/Networks/Networks.tsx
@@ -24,6 +24,7 @@ import CustomNetworkDetailsModal from "@/domains/setting/pages/Networks/blocks/C
 import { isCustomNetwork, profileEnabledNetworkIds } from "@/utils/network-utils";
 import { DashboardConfiguration } from "@/domains/dashboard/pages/Dashboard";
 import { useWalletConfig } from "@/domains/wallet/hooks";
+import { getProfileStoredPassword } from "@/utils/profile-utils";
 
 export const NetworksSettings = () => {
 	const { t } = useTranslation();
@@ -370,6 +371,9 @@ export const NetworksSettings = () => {
 			...(profile.settings().get(Contracts.ProfileSetting.DashboardConfiguration) as DashboardConfiguration),
 			selectedNetworkIds: profileEnabledNetworkIds(profile),
 		});
+
+		await env.profiles().restore(profile, getProfileStoredPassword(profile));
+		await profile.sync();
 
 		setWalletConfig("selectedNetworkIds", profileEnabledNetworkIds(profile));
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/2kj7a4j

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [x] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
