### PR TITLE
ci: set maximum attempts of jobs to 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/app/ --env=./src/tests/custom-env.js --forceExit --maxWorkers=2
                       --logHeapUsage --watchAll=false --coverage
@@ -80,7 +80,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/contact --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -119,7 +119,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/dashboard --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -158,7 +158,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/error --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -197,7 +197,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/exchange --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -236,7 +236,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/network --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -275,7 +275,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/news --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -314,7 +314,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/profile --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -353,7 +353,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/setting --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -392,7 +392,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/transaction --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=3 --logHeapUsage --watchAll=false
@@ -431,7 +431,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/vote --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -470,7 +470,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/domains/wallet --env=./src/tests/custom-env.js
                       --forceExit --maxWorkers=50% --logHeapUsage
@@ -509,7 +509,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/router --env=./src/tests/custom-env.js --forceExit
                       --maxWorkers=50% --logHeapUsage --watchAll=false
@@ -548,7 +548,7 @@ jobs:
               uses: nick-invision/retry@v2
               with:
                   timeout_minutes: 10
-                  max_attempts: 3
+                  max_attempts: 1
                   command: node --expose-gc ./node_modules/jest/bin/jest.js
                       src/utils --env=./src/tests/custom-env.js --forceExit
                       --maxWorkers=50% --logHeapUsage --watchAll=false

--- a/scripts/generate-test-workflow.js
+++ b/scripts/generate-test-workflow.js
@@ -216,7 +216,7 @@ for (const [directory, { coverageThreshold, maxWorkers }] of Object.entries(dire
 				uses: "nick-invision/retry@v2",
 				with: {
 					timeout_minutes: 10,
-					max_attempts: 3,
+					max_attempts: 1,
 					command: `.pnpm test --expose-gc test src/${directory} --env=./src/tests/custom-env.js --forceExit --maxWorkers=${maxWorkers} --logHeapUsage --watchAll=false --coverage --collectCoverageFrom='${JSON.stringify(
 						collectCoverageFrom,
 					)}' --coverageThreshold='${JSON.stringify({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Having multiple attempts was useful when individual jobs couldn't be executed in isolation once they failed, which has now been possible for a while. As of now it just means the whole workflow takes forever to definitely fail.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
