### PR TITLE
fix: restore `AddRecipient` toggle ux to previous state

### DIFF
--- a/src/domains/transaction/components/AddRecipient/AddRecipient.test.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.test.tsx
@@ -2,7 +2,7 @@
 import { Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
 import userEvent from "@testing-library/user-event";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Route } from "react-router-dom";
 
@@ -309,7 +309,7 @@ describe("AddRecipient", () => {
 		await waitFor(() => expect(addRecipientButton()).toBeEnabled());
 		userEvent.click(addRecipientButton());
 
-		await waitFor(() => expect(recipientList()).toHaveLength(2));
+		await waitFor(() => expect(recipientList()).toHaveLength(3));
 
 		userEvent.click(singleButton);
 
@@ -421,7 +421,7 @@ describe("AddRecipient", () => {
 
 		userEvent.click(addRecipientButton());
 
-		await waitFor(() => expect(recipientList()).toHaveLength(3));
+		await waitFor(() => expect(recipientList()).toHaveLength(4));
 	});
 
 	it("should disable recipient fields if network is not filled", async () => {
@@ -573,25 +573,23 @@ describe("AddRecipient", () => {
 				form.register("senderAddress");
 			}, []);
 
-			const [recipients, setRecipients] = useState([
-				{
-					address: "D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax",
-					amount: 1,
-				},
-				{
-					address: "D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ay",
-					amount: 1,
-				},
-			]);
-
 			return (
 				<Route path="/profiles/:profileId">
 					<FormProvider {...form}>
 						<AddRecipient
 							profile={profile}
 							wallet={wallet}
-							onChange={(newRecipients) => setRecipients(newRecipients)}
-							recipients={recipients}
+							onChange={jest.fn()}
+							recipients={[
+								{
+									address: "D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax",
+									amount: 1,
+								},
+								{
+									address: "D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ay",
+									amount: 1,
+								},
+							]}
 						/>
 					</FormProvider>
 				</Route>

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -204,12 +204,11 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 	}, [isSingle, setValue]);
 
 	useEffect(() => {
-		if (recipients.length === 0) {
+		if (isMountedReference.current) {
 			return;
 		}
 
-		// Avoid rerenders.
-		if (JSON.stringify(addedRecipients) === JSON.stringify(recipients)) {
+		if (recipients.length === 0) {
 			return;
 		}
 

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -241,16 +241,7 @@ export const SendTransfer: React.VFC = () => {
 		}
 
 		if (qrData.get("recipient")) {
-			form.setValue(
-				"recipients",
-				[
-					{
-						address: qrData.get("recipient"),
-						amount: qrData.get("amount") || amount,
-					},
-				],
-				{ shouldDirty: true, shouldValidate: true },
-			);
+			form.setValue("recipientAddress", qrData.get("recipient"), { shouldDirty: true, shouldValidate: true });
 		}
 
 		toasts.success(t("TRANSACTION.QR_CODE_SUCCESS"));

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -217,7 +217,7 @@ export const SendTransfer: React.VFC = () => {
 	const handleQRCodeRead = (url: string) => {
 		setShowQRModal(false);
 
-		const { amount, network } = getValues();
+		const { network } = getValues();
 
 		const error = validateTransferURLParams(url, {
 			coin: network?.coin(),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Restores the UX change in `AddRecipient` component introduced by https://github.com/ArdentHQ/arkvault/pull/102.

When adding recipient + amount and switching to multiple recipient form (using the toggle) the recipient should not be automatically added, but instead, the data should be filled in the multiple-recipient form inputs requiring from the user to click  "Add Recipient" button to add the recipient.

Example:

https://user-images.githubusercontent.com/22020168/180481769-24a8f094-1f32-4903-9667-856d36dd29e3.mp4


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
