### PR TITLE
refactor: use input fields in `SendVote` form step

### DIFF
--- a/src/domains/transaction/pages/SendVote/FormStep.tsx
+++ b/src/domains/transaction/pages/SendVote/FormStep.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/domains/transaction/components/TransactionDetail";
 import { VoteList } from "@/domains/vote/components/VoteList";
 import { StepHeader } from "@/app/components/StepHeader";
+import { SelectAddress } from "@/domains/profile/components/SelectAddress";
+import { SelectNetworkDropdown } from "@/app/components/SelectNetworkDropdown";
 
 type FormStepProperties = {
 	profile: ProfilesContracts.IProfile;
@@ -45,9 +47,26 @@ export const FormStep = ({ unvotes, votes, wallet, profile }: FormStepProperties
 				subtitle={t("TRANSACTION.PAGE_VOTE.FORM_STEP.DESCRIPTION")}
 			/>
 
-			<TransactionNetwork network={wallet.network()} border={false} />
+			<FormField name="network" className="mt-8">
+				<FormLabel label={t("COMMON.CRYPTOASSET")} />
+				<SelectNetworkDropdown profile={profile} networks={[network]} selectedNetwork={network} isDisabled />
+			</FormField>
 
-			<TransactionSender address={wallet.address()} network={wallet.network()} />
+			<FormField name="senderAddress" className="my-8">
+				<FormLabel label={t("TRANSACTION.SENDER")} />
+
+				<div data-testid="sender-address">
+					<SelectAddress
+						wallet={{
+							address: wallet.address(),
+							network: wallet.network(),
+						}}
+						wallets={profile.wallets().values()}
+						profile={profile}
+						disabled
+					/>
+				</div>
+			</FormField>
 
 			{unvotes.length > 0 && (
 				<TransactionDetail label={t("TRANSACTION.UNVOTES_COUNT", { count: unvotes.length })}>

--- a/src/domains/transaction/pages/SendVote/FormStep.tsx
+++ b/src/domains/transaction/pages/SendVote/FormStep.tsx
@@ -5,11 +5,7 @@ import { useTranslation } from "react-i18next";
 import { SendVoteStepProperties } from "./SendVote.contracts";
 import { FormField, FormLabel } from "@/app/components/Form";
 import { FeeField } from "@/domains/transaction/components/FeeField";
-import {
-	TransactionDetail,
-	TransactionNetwork,
-	TransactionSender,
-} from "@/domains/transaction/components/TransactionDetail";
+import { TransactionDetail } from "@/domains/transaction/components/TransactionDetail";
 import { VoteList } from "@/domains/vote/components/VoteList";
 import { StepHeader } from "@/app/components/StepHeader";
 import { SelectAddress } from "@/domains/profile/components/SelectAddress";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Part of https://app.clickup.com/t/2r1bejb

Always show input fields for network and sender in votes form. Currently, both fields are disabled. 

Example:
![2022-08-01-152714_846x1022_scrot](https://user-images.githubusercontent.com/22020168/182160258-fd4ed980-9898-4c49-bf86-c9d268b0aa91.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
