### PR TITLE
refactor: adjust background color of `FormButtons` component

### DIFF
--- a/src/app/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
+++ b/src/app/components/ConfirmationModal/__snapshots__/ConfirmationModal.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Confirmation Modal should render with custom title and description 1`] 
               data-testid="ConfirmationModal"
             >
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -160,7 +160,7 @@ exports[`Confirmation Modal should render with default title and description 1`]
               data-testid="ConfirmationModal"
             >
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
+++ b/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`DeleteResource should render with children 1`] = `
               Hello!
             </span>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/app/components/Form/FormButtons.tsx
+++ b/src/app/components/Form/FormButtons.tsx
@@ -25,7 +25,7 @@ const FormButtonsWrapper = styled.div<{
 				}
 			}
 		`};
-	${tw`flex fixed bg-theme-background dark:bg-black sm:dark:bg-transparent inset-x-0 bottom-0 px-8 py-3 gap-3 shadow-footer-smooth dark:shadow-footer-smooth-dark`}
+	${tw`flex fixed bg-theme-background dark:bg-black sm:bg-transparent sm:dark:bg-transparent inset-x-0 bottom-0 px-8 py-3 gap-3 shadow-footer-smooth dark:shadow-footer-smooth-dark`}
 	${tw`sm:(relative inset-auto p-0 mt-8 justify-end shadow-none dark:shadow-none)`}
 	${css`
 		& > button {

--- a/src/app/components/QRModal/__snapshots__/QRModal.test.tsx.snap
+++ b/src/app/components/QRModal/__snapshots__/QRModal.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`QRModal should render 1`] = `
                   class="z-10"
                 >
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="z-20 space-x-2 css-1q9v3yc"

--- a/src/app/components/StepNavigation/__snapshots__/StepNavigation.test.tsx.snap
+++ b/src/app/components/StepNavigation/__snapshots__/StepNavigation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`StepNavigation should disable buttons if loading 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1yqe28v"
@@ -62,7 +62,7 @@ exports[`StepNavigation should disable buttons if loading 1`] = `
 exports[`StepNavigation should not render back button if on last step 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"
@@ -82,7 +82,7 @@ exports[`StepNavigation should not render back button if on last step 1`] = `
 exports[`StepNavigation should not render back to wallet button if not on last step 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"
@@ -124,7 +124,7 @@ exports[`StepNavigation should not render back to wallet button if not on last s
 exports[`StepNavigation should not render continue button if on last two steps 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"
@@ -166,7 +166,7 @@ exports[`StepNavigation should not render continue button if on last two steps 1
 exports[`StepNavigation should not render continue button if on last two steps 2`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"
@@ -186,7 +186,7 @@ exports[`StepNavigation should not render continue button if on last two steps 2
 exports[`StepNavigation should render back button if not on last step 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"
@@ -228,7 +228,7 @@ exports[`StepNavigation should render back button if not on last step 1`] = `
 exports[`StepNavigation should render back to wallet button if on last step 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"
@@ -248,7 +248,7 @@ exports[`StepNavigation should render back to wallet button if on last step 1`] 
 exports[`StepNavigation should render continue button if not on last two steps 1`] = `
 <DocumentFragment>
   <div
-    class="css-1kzb86y"
+    class="css-2wyvkd"
   >
     <button
       class="css-1jhy6v9"

--- a/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
+++ b/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`WalletListItem should disable the send button when wallet has no balanc
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -776,7 +776,7 @@ exports[`WalletListItem should render when isCompact = false 1`] = `
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -1105,7 +1105,7 @@ exports[`WalletListItem should render when isCompact = true 1`] = `
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -1734,7 +1734,7 @@ exports[`WalletListItem should render when isLargeScreen = true 1`] = `
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -2072,7 +2072,7 @@ exports[`WalletListItem should render when isLargeScreen = true and wallet is no
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -2401,7 +2401,7 @@ exports[`WalletListItem should render with a N/A for fiat 1`] = `
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -2730,7 +2730,7 @@ exports[`WalletListItem should render with default BTC as default exchangeCurren
                         </div>
                       </fieldset>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"

--- a/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
+++ b/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`ContactForm should render responsive 1`] = `
       class="flex w-full border-0 border-theme-secondary-300 dark:border-theme-secondary-800 sm:border-t justify-end"
     >
       <div
-        class="css-1kzb86y"
+        class="css-2wyvkd"
       >
         <button
           class="css-1jhy6v9"
@@ -409,7 +409,7 @@ exports[`ContactForm should render responsive 2`] = `
       class="flex w-full border-0 border-theme-secondary-300 dark:border-theme-secondary-800 sm:border-t justify-end"
     >
       <div
-        class="css-1kzb86y"
+        class="css-2wyvkd"
       >
         <button
           class="css-1jhy6v9"
@@ -649,7 +649,7 @@ exports[`ContactForm should render with errors 1`] = `
       class="flex w-full border-0 border-theme-secondary-300 dark:border-theme-secondary-800 sm:border-t justify-end"
     >
       <div
-        class="css-1kzb86y"
+        class="css-2wyvkd"
       >
         <button
           class="css-1jhy6v9"

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -243,7 +243,7 @@ exports[`CreateContact should render 1`] = `
                   class="flex w-full border-0 border-theme-secondary-300 dark:border-theme-secondary-800 sm:border-t justify-end"
                 >
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"

--- a/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
+++ b/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`DeleteContact should render a modal 1`] = `
               class="mt-4"
             />
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`UpdateContact should render responsive 1`] = `
                   class="flex w-full border-0 border-theme-secondary-300 dark:border-theme-secondary-800 sm:border-t justify-between"
                 >
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -712,7 +712,7 @@ exports[`UpdateContact should render responsive 2`] = `
                     </div>
                   </button>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -1102,7 +1102,7 @@ exports[`UpdateContact should render responsive 3`] = `
                     </div>
                   </button>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"

--- a/src/domains/exchange/components/DeleteExchangeTransaction/__snapshots__/DeleteExchangeTransaction.test.tsx.snap
+++ b/src/domains/exchange/components/DeleteExchangeTransaction/__snapshots__/DeleteExchangeTransaction.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`DeleteExchangeTransaction should render a modal 1`] = `
               class="mt-4"
             />
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
@@ -841,7 +841,7 @@ exports[`ExchangeForm should render exchange form 1`] = `
           </div>
         </div>
         <div
-          class="css-1kzb86y"
+          class="css-2wyvkd"
         >
           <button
             class="css-1jhy6v9"
@@ -1307,7 +1307,7 @@ exports[`ExchangeForm should render exchange form with id of finished order 1`] 
           </div>
         </div>
         <div
-          class="css-1kzb86y"
+          class="css-2wyvkd"
         >
           <button
             class="css-1bx0hyc"

--- a/src/domains/exchange/pages/ExchangeView/__snapshots__/ExchangeView.test.tsx.snap
+++ b/src/domains/exchange/pages/ExchangeView/__snapshots__/ExchangeView.test.tsx.snap
@@ -947,7 +947,7 @@ exports[`ExchangeView should fetch providers if not loaded yet 1`] = `
                   </div>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -1930,7 +1930,7 @@ exports[`ExchangeView should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -2913,7 +2913,7 @@ exports[`ExchangeView should render dark theme 1`] = `
                   </div>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -3896,7 +3896,7 @@ exports[`ExchangeView should render light theme 1`] = `
                   </div>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"

--- a/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
+++ b/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`DeleteProfile should render 1`] = `
               class="mt-4"
             />
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
+++ b/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`PasswordModal should render with title and description 1`] = `
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1yqe28v"

--- a/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
+++ b/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`ResetProfile should render 1`] = `
               </div>
             </div>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`SignIn should render a modal 1`] = `
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/profile/components/WelcomeModal/__snapshots__/WelcomeModal.test.tsx.snap
+++ b/src/domains/profile/components/WelcomeModal/__snapshots__/WelcomeModal.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`WelcomeModal should render a modal if user hasnt completed the tutorial
                   </span>
                 </label>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -554,7 +554,7 @@ exports[`CreateProfile should render 1`] = `
                     </fieldset>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1jhy6v9"

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ImportProfile.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ImportProfile.test.tsx.snap
@@ -656,7 +656,7 @@ exports[`ImportProfile should apply theme setting of imported profile regardless
                           </fieldset>
                         </div>
                         <div
-                          class="css-1kzb86y"
+                          class="css-2wyvkd"
                         >
                           <button
                             class="css-1jhy6v9"
@@ -1352,7 +1352,7 @@ exports[`ImportProfile should apply theme setting of imported profile regardless
                           </fieldset>
                         </div>
                         <div
-                          class="css-1kzb86y"
+                          class="css-2wyvkd"
                         >
                           <button
                             class="css-1jhy6v9"
@@ -1566,7 +1566,7 @@ exports[`ImportProfile should render first step 1`] = `
                   </button>
                 </p>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ProcessingImportStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ProcessingImportStep.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`Import Profile - Processing import should enter password again 1`] = `
           </div>
         </div>
         <div
-          class="css-1kzb86y"
+          class="css-2wyvkd"
         >
           <button
             class="css-1jhy6v9"
@@ -238,7 +238,7 @@ exports[`Import Profile - Processing import should handle import error 1`] = `
           </div>
         </div>
         <div
-          class="css-1d6x3tk"
+          class="css-1tkbsa1"
         >
           <button
             class="css-1jhy6v9"
@@ -477,7 +477,7 @@ exports[`Import Profile - Processing import should show error if json import has
           </div>
         </div>
         <div
-          class="css-1d6x3tk"
+          class="css-1tkbsa1"
         >
           <button
             class="css-1jhy6v9"

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ProfileFormStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ProfileFormStep.test.tsx.snap
@@ -659,7 +659,7 @@ exports[`Import Profile - Profile Form Step should fail password confirmation 1`
               </fieldset>
             </div>
             <div
-              class="css-1kzb86y"
+              class="css-2wyvkd"
             >
               <button
                 class="css-1jhy6v9"
@@ -1206,7 +1206,7 @@ exports[`Import Profile - Profile Form Step should render profile form 1`] = `
               </fieldset>
             </div>
             <div
-              class="css-1kzb86y"
+              class="css-2wyvkd"
             >
               <button
                 class="css-1jhy6v9"
@@ -1753,7 +1753,7 @@ exports[`Import Profile - Profile Form Step should render profile form with empt
               </fieldset>
             </div>
             <div
-              class="css-1kzb86y"
+              class="css-2wyvkd"
             >
               <button
                 class="css-1jhy6v9"
@@ -2324,7 +2324,7 @@ exports[`Import Profile - Profile Form Step should store profile 1`] = `
               </fieldset>
             </div>
             <div
-              class="css-1kzb86y"
+              class="css-2wyvkd"
             >
               <button
                 class="css-1jhy6v9"
@@ -2876,7 +2876,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
               </fieldset>
             </div>
             <div
-              class="css-1kzb86y"
+              class="css-2wyvkd"
             >
               <button
                 class="css-1jhy6v9"
@@ -3429,7 +3429,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
               </fieldset>
             </div>
             <div
-              class="css-1kzb86y"
+              class="css-2wyvkd"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/SelectFileStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/SelectFileStep.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Import Profile Select File Step should change back from json to wwe 1`]
       </div>
     </div>
     <div
-      class="css-1d6x3tk"
+      class="css-1tkbsa1"
     >
       <button
         class="css-1jhy6v9"
@@ -202,7 +202,7 @@ exports[`Import Profile Select File Step should handle back event 1`] = `
       </button>
     </p>
     <div
-      class="css-1d6x3tk"
+      class="css-1tkbsa1"
     >
       <button
         class="css-1jhy6v9"
@@ -306,7 +306,7 @@ exports[`Import Profile Select File Step should render file selection for wwe an
       </button>
     </p>
     <div
-      class="css-1d6x3tk"
+      class="css-1tkbsa1"
     >
       <button
         class="css-1jhy6v9"
@@ -422,7 +422,7 @@ exports[`Import Profile Select File Step should render with json fileFormat sele
       </div>
     </div>
     <div
-      class="css-1d6x3tk"
+      class="css-1tkbsa1"
     >
       <button
         class="css-1jhy6v9"
@@ -526,7 +526,7 @@ exports[`Import Profile Select File Step should render with wwe fileFormat selec
       </button>
     </p>
     <div
-      class="css-1d6x3tk"
+      class="css-1tkbsa1"
     >
       <button
         class="css-1jhy6v9"

--- a/src/domains/setting/components/DevelopmentNetwork/__snapshots__/DevelopmentNetwork.test.tsx.snap
+++ b/src/domains/setting/components/DevelopmentNetwork/__snapshots__/DevelopmentNetwork.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`DevelopmentNetwork should render a modal 1`] = `
               Disabling this setting will hide your wallets associated with development networks. Are you sure you want to continue?
             </div>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/setting/components/PasswordRemovalConfirmModal/__snapshots__/PasswordRemovalConfirmModal.test.tsx.snap
+++ b/src/domains/setting/components/PasswordRemovalConfirmModal/__snapshots__/PasswordRemovalConfirmModal.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`PasswordRemovalConfirmModal should render 1`] = `
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/setting/pages/Appearance/__snapshots__/Appearance.test.tsx.snap
+++ b/src/domains/setting/pages/Appearance/__snapshots__/Appearance.test.tsx.snap
@@ -972,7 +972,7 @@ exports[`Appearance Settings should render appearance settings 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"

--- a/src/domains/setting/pages/Appearance/blocks/__snapshots__/AppearanceForm.test.tsx.snap
+++ b/src/domains/setting/pages/Appearance/blocks/__snapshots__/AppearanceForm.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`AppearanceForm should render 1`] = `
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1yqe28v"

--- a/src/domains/setting/pages/Export/__snapshots__/Export.test.tsx.snap
+++ b/src/domains/setting/pages/Export/__snapshots__/Export.test.tsx.snap
@@ -762,7 +762,7 @@ exports[`Export Settings should render export settings 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1bx0hyc"

--- a/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
+++ b/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
@@ -1570,7 +1570,7 @@ exports[`General Settings should disable submit button when profile is not resto
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -3180,7 +3180,7 @@ exports[`General Settings should not update the uploaded avatar when removing fo
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1bx0hyc"
@@ -4771,7 +4771,7 @@ exports[`General Settings should render 1`] = `
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -6363,7 +6363,7 @@ exports[`General Settings should show identicon when removing image if name is s
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -7955,7 +7955,7 @@ exports[`General Settings should update profile 1`] = `
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -9547,7 +9547,7 @@ exports[`General Settings should update the avatar when removing focus from name
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1bx0hyc"
@@ -11131,7 +11131,7 @@ exports[`General Settings should update the avatar when removing focus from name
                     </ul>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1bx0hyc"

--- a/src/domains/setting/pages/Networks/__snapshots__/Networks.test.tsx.snap
+++ b/src/domains/setting/pages/Networks/__snapshots__/Networks.test.tsx.snap
@@ -833,7 +833,7 @@ exports[`Network Settings should check the main network by default 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -1692,7 +1692,7 @@ exports[`Network Settings should render networks settings section 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"

--- a/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
+++ b/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
@@ -992,7 +992,7 @@ exports[`Password Settings should not allow setting the current password as the 
                     </fieldset>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="mr-auto flex w-full space-x-2 sm:w-auto css-1cp5yjb"
@@ -1803,7 +1803,7 @@ exports[`Password Settings should render password settings 1`] = `
                     </fieldset>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="w-full sm:w-auto css-1yqe28v"
@@ -2644,7 +2644,7 @@ exports[`Password Settings should set a password 1`] = `
                     </fieldset>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="mr-auto flex w-full space-x-2 sm:w-auto css-1cp5yjb"
@@ -3666,7 +3666,7 @@ exports[`Password Settings should show an error toast if the current password do
                     </fieldset>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="mr-auto flex w-full space-x-2 sm:w-auto css-1cp5yjb"
@@ -4702,7 +4702,7 @@ exports[`Password Settings should trigger password confirmation mismatch error 1
                     </fieldset>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="mr-auto flex w-full space-x-2 sm:w-auto css-1cp5yjb"

--- a/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
+++ b/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
@@ -941,7 +941,7 @@ exports[`Servers Settings should render servers settings 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -2532,7 +2532,7 @@ exports[`Servers Settings with servers should ping the servers in an interval 1`
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -4100,7 +4100,7 @@ exports[`Servers Settings with servers should render custom servers 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -5379,7 +5379,7 @@ exports[`Servers Settings with servers should render customs servers in xs 1`] =
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -6970,7 +6970,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -8272,7 +8272,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -9751,7 +9751,7 @@ exports[`Servers Settings with servers should show status ok after ping the serv
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -11342,7 +11342,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -12644,7 +12644,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"
@@ -14123,7 +14123,7 @@ exports[`Servers Settings with unreachable servers should show status error if r
                     </li>
                   </ul>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <button
                       class="css-1yqe28v"

--- a/src/domains/transaction/components/ConfirmRemovePendingTransaction/__snapshots__/ConfirmRemovePendingTransaction.test.tsx.snap
+++ b/src/domains/transaction/components/ConfirmRemovePendingTransaction/__snapshots__/ConfirmRemovePendingTransaction.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`ConfirmRemovePendingTransaction should render multisignature registrati
               class="mt-4"
             />
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"
@@ -212,7 +212,7 @@ exports[`ConfirmRemovePendingTransaction should render multisignature transactio
               class="mt-4"
             />
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/transaction/components/ConfirmSendTransaction/__snapshots__/ConfirmSendTransaction.test.tsx.snap
+++ b/src/domains/transaction/components/ConfirmSendTransaction/__snapshots__/ConfirmSendTransaction.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`ConfirmSendTransaction should render modal 1`] = `
               </div>
             </div>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/transaction/components/ErrorStep/__snapshots__/ErrorStep.test.tsx.snap
+++ b/src/domains/transaction/components/ErrorStep/__snapshots__/ErrorStep.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`ErrorStep should display error details 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <div
         class="mr-auto"
@@ -203,7 +203,7 @@ exports[`ErrorStep should emit onBack 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <div
         class="mr-auto"
@@ -339,7 +339,7 @@ exports[`ErrorStep should emit onRepeat 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <div
         class="mr-auto"
@@ -475,7 +475,7 @@ exports[`ErrorStep should render with custom title 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <div
         class="mr-auto"
@@ -596,7 +596,7 @@ exports[`ErrorStep should render with default texts 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <div
         class="mr-auto"

--- a/src/domains/transaction/components/FeeWarning/__snapshots__/FeeWarning.test.tsx.snap
+++ b/src/domains/transaction/components/FeeWarning/__snapshots__/FeeWarning.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`FeeWarning should render a warning for a fee that is too HIGH 1`] = `
               </fieldset>
             </div>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"
@@ -241,7 +241,7 @@ exports[`FeeWarning should render a warning for a fee that is too LOW 1`] = `
               </fieldset>
             </div>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportError/__snapshots__/TransactionExportError.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportError/__snapshots__/TransactionExportError.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`TransactionExportError should render in lg 1`] = `
       />
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -93,7 +93,7 @@ exports[`TransactionExportError should render in md 1`] = `
       />
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -154,7 +154,7 @@ exports[`TransactionExportError should render in sm 1`] = `
       />
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -215,7 +215,7 @@ exports[`TransactionExportError should render in xl 1`] = `
       />
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -276,7 +276,7 @@ exports[`TransactionExportError should render in xs 1`] = `
       />
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"

--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/__snapshots__/TransactionExportForm.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/__snapshots__/TransactionExportForm.test.tsx.snap
@@ -548,7 +548,7 @@ exports[`TransactionExportForm should render fiat column if wallet is live 1`] =
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -1076,7 +1076,7 @@ exports[`TransactionExportForm should render in lg 1`] = `
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -1604,7 +1604,7 @@ exports[`TransactionExportForm should render in md 1`] = `
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -2132,7 +2132,7 @@ exports[`TransactionExportForm should render in sm 1`] = `
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -2660,7 +2660,7 @@ exports[`TransactionExportForm should render in xl 1`] = `
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -3187,7 +3187,7 @@ exports[`TransactionExportForm should render in xs 1`] = `
       </li>
     </ul>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"

--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportSuccess/__snapshots__/TransactionExportSuccess.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportSuccess/__snapshots__/TransactionExportSuccess.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`TransactionExportForm should render in lg 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -87,7 +87,7 @@ exports[`TransactionExportForm should render in md 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -145,7 +145,7 @@ exports[`TransactionExportForm should render in sm 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -203,7 +203,7 @@ exports[`TransactionExportForm should render in xl 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -261,7 +261,7 @@ exports[`TransactionExportForm should render in xs 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"
@@ -324,7 +324,7 @@ exports[`TransactionExportForm should render warnigg if count is zero 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"

--- a/src/domains/transaction/components/TransactionExportModal/__snapshots__/TransactionExportModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionExportModal/__snapshots__/TransactionExportModal.test.tsx.snap
@@ -554,7 +554,7 @@ exports[`TransactionExportModal should render 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -716,7 +716,7 @@ exports[`TransactionExportModal should render error status 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -1306,7 +1306,7 @@ exports[`TransactionExportModal should render progress status 1`] = `
                     </li>
                   </ul>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -1465,7 +1465,7 @@ exports[`TransactionExportModal should render success and download file 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -1624,7 +1624,7 @@ exports[`TransactionExportModal should render success and stay open if download 
                     </div>
                   </div>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"
@@ -1783,7 +1783,7 @@ exports[`TransactionExportModal should render success status 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1d6x3tk"
+                    class="css-1tkbsa1"
                   >
                     <button
                       class="css-1jhy6v9"

--- a/src/domains/transaction/components/UnlockTokens/__snapshots__/UnlockTokensModal.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/__snapshots__/UnlockTokensModal.test.tsx.snap
@@ -850,7 +850,7 @@ exports[`UnlockTokensModal should handle unlock token transaction with error 4`]
                   </div>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <div
                     class="mr-auto"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -746,7 +746,7 @@ exports[`SendDelegateResignation Delegate Resignation should change fee 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -1531,7 +1531,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 1st step 1`]
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -2242,7 +2242,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -2864,7 +2864,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -3445,7 +3445,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step and
                     </div>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <div
                       class="mr-auto"
@@ -4122,7 +4122,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -4932,7 +4932,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -5719,7 +5719,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -6506,7 +6506,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -545,7 +545,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -2554,7 +2554,7 @@ exports[`SendIpfs should send a ipfs transfer with a ledger wallet 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -3316,7 +3316,7 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -4080,7 +4080,7 @@ exports[`SendIpfs should send an IPFS transaction using encryption password 1`] 
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -4842,7 +4842,7 @@ exports[`SendIpfs should send an ipfs transaction with a multisig wallet 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -5615,7 +5615,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -6181,7 +6181,7 @@ exports[`SendIpfs should show error step and go back 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <div
                       class="mr-auto"

--- a/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
+++ b/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
@@ -545,7 +545,7 @@ exports[`Registration should register second signature 1`] = `
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -1125,7 +1125,7 @@ exports[`Registration should show error step and go back 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <div
                       class="mr-auto"
@@ -1804,7 +1804,7 @@ exports[`Registration should show mnemonic error 1`] = `
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.Fees.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.Fees.test.tsx.snap
@@ -838,7 +838,7 @@ exports[`SendTransfer Fee Handling should send a single transfer with a high fee
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -1699,7 +1699,7 @@ exports[`SendTransfer Fee Handling should send a single transfer with a low fee 
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.NetworkSelection.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.NetworkSelection.test.tsx.snap
@@ -1173,7 +1173,7 @@ exports[`SendTransfer Network Selection should select a cryptoasset and select s
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -1786,7 +1786,7 @@ exports[`SendTransfer Network Selection should select cryptoasset 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -760,7 +760,7 @@ exports[`SendTransfer should display unconfirmed transactions modal when submitt
                 </section>
               </div>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -1015,7 +1015,7 @@ exports[`SendTransfer should display unconfirmed transactions modal when submitt
                         </div>
                       </div>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -1598,7 +1598,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -2840,7 +2840,7 @@ exports[`SendTransfer should render form and use location state with nethash par
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -4071,7 +4071,7 @@ exports[`SendTransfer should render form and use location state with network par
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -5271,7 +5271,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -10175,7 +10175,7 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -12727,7 +12727,7 @@ exports[`SendTransfer should send a single transfer and handle undefined expirat
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -13510,7 +13510,7 @@ exports[`SendTransfer should send a single transfer and show unconfirmed transac
                 </section>
               </div>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -13839,7 +13839,7 @@ exports[`SendTransfer should send a single transfer and show unconfirmed transac
                         </div>
                       </div>
                       <div
-                        class="css-1d6x3tk"
+                        class="css-1tkbsa1"
                       >
                         <button
                           class="css-1jhy6v9"
@@ -14715,7 +14715,7 @@ exports[`SendTransfer should send a single transfer using wallet with encryption
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -15576,7 +15576,7 @@ exports[`SendTransfer should send a single transfer with keyboard 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -16437,7 +16437,7 @@ exports[`SendTransfer should send a single transfer without keyboard 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -16991,7 +16991,7 @@ exports[`SendTransfer should show error step and go back 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <div
                       class="mr-auto"

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -822,7 +822,7 @@ exports[`SendVote should send a unvote transaction 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -1661,7 +1661,7 @@ exports[`SendVote should send a vote transaction with keyboard 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -2500,7 +2500,7 @@ exports[`SendVote should send a vote transaction without keyboard 1`] = `
                 </section>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -3068,7 +3068,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"
@@ -3645,7 +3645,7 @@ exports[`SendVote should show error step and go back 1`] = `
                     </div>
                   </div>
                   <div
-                    class="css-1kzb86y"
+                    class="css-2wyvkd"
                   >
                     <div
                       class="mr-auto"

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`DeleteWallet should render a modal 1`] = `
               </button>
             </fieldset>
             <div
-              class="css-1d6x3tk"
+              class="css-1tkbsa1"
             >
               <button
                 class="css-1jhy6v9"

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`SignMessage should render 1`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -382,7 +382,7 @@ exports[`SignMessage should render for ledger wallets 1`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`UpdateWalletName should render 1`] = `
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -234,7 +234,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 1`] = 
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -378,7 +378,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 2`] = 
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -522,7 +522,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 3`] = 
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -666,7 +666,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 4`] = 
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -810,7 +810,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"
@@ -954,7 +954,7 @@ exports[`UpdateWalletName should show error message when name exceeds 42 charact
                 </div>
               </fieldset>
               <div
-                class="css-1d6x3tk"
+                class="css-1tkbsa1"
               >
                 <button
                   class="css-1jhy6v9"

--- a/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`VerifyMessage should not render in xs 1`] = `
                   </fieldset>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -411,7 +411,7 @@ exports[`VerifyMessage should not render in xs 2`] = `
                   </fieldset>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -637,7 +637,7 @@ exports[`VerifyMessage should not render in xs 3`] = `
                   </fieldset>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -863,7 +863,7 @@ exports[`VerifyMessage should not render in xs 4`] = `
                   </fieldset>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -1089,7 +1089,7 @@ exports[`VerifyMessage should not render in xs 5`] = `
                   </fieldset>
                 </div>
                 <div
-                  class="css-1d6x3tk"
+                  class="css-1tkbsa1"
                 >
                   <button
                     class="css-1jhy6v9"

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -574,7 +574,7 @@ exports[`CreateWallet should create a wallet 1`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -1307,7 +1307,7 @@ exports[`CreateWallet should create a wallet 2`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1bx0hyc"
@@ -1905,7 +1905,7 @@ exports[`CreateWallet should create a wallet with encryption 1`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -2641,7 +2641,7 @@ exports[`CreateWallet should create a wallet with encryption 2`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1bx0hyc"
@@ -3241,7 +3241,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -3849,7 +3849,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1jhy6v9"
@@ -4488,7 +4488,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                   </section>
                 </div>
                 <div
-                  class="css-1kzb86y"
+                  class="css-2wyvkd"
                 >
                   <button
                     class="css-1yqe28v"

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`LedgerTabs should render connection step 1`] = `
       </div>
     </div>
     <div
-      class="css-1kzb86y"
+      class="css-2wyvkd"
     >
       <button
         class="css-1jhy6v9"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -1765,7 +1765,7 @@ exports[`ImportWallet should render as ledger import 1`] = `
                 </div>
               </div>
               <div
-                class="css-1kzb86y"
+                class="css-2wyvkd"
               >
                 <button
                   class="css-1jhy6v9"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

There are some tiny artefacts around the `Upload Image` button, mostly visible in light mode, caused by the background color of the `FormButtons` component.

![image](https://user-images.githubusercontent.com/6547002/182806024-17f53113-ff0b-41c0-a24d-fe9f2cea1b49.png)

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
