### PR TITLE
refactor: adjust positioning and paddings of toasts

### DIFF
--- a/src/styles/toasts.css
+++ b/src/styles/toasts.css
@@ -20,7 +20,7 @@
 }
 
 .Toastify__toast {
-	@apply shadow-none cursor-default;
+	@apply rounded-none shadow-none cursor-default;
 	background: unset;
 	color: unset;
 }
@@ -30,7 +30,12 @@
 }
 
 .Toastify__toast-body {
-	@apply overflow-hidden;
+	@apply p-0 overflow-hidden;
+}
+
+.Toastify__toast-container--bottom-right {
+	right: 0;
+	bottom: 0;
 }
 
 @supports (padding-bottom: env(safe-area-inset-bottom)) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The toasts, especially on mobile, are positioned slightly wrong - they should stick to the bottom and sides. Probably a remainder of the recent toastify upgrade.

![image](https://user-images.githubusercontent.com/6547002/182811080-cd7334fd-aac0-4d88-a498-241ff0a6451c.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
