### PR TITLE
refactor: implement qr errors as toasts

### DIFF
--- a/src/app/components/QRFileUpload/QRFileUpload.test.tsx
+++ b/src/app/components/QRFileUpload/QRFileUpload.test.tsx
@@ -22,7 +22,7 @@ describe("QRFileUpload", () => {
 
 		const scanImageMock = jest.spyOn(QRScanner, "scanImage").mockResolvedValue({ data: qrCodeUrl });
 
-		render(<QRFileUpload onRead={onRead} />);
+		render(<QRFileUpload onError={jest.fn()} onRead={onRead} />);
 
 		userEvent.click(screen.getByTestId("QRFileUpload__upload"));
 		await waitFor(() => expect(onRead).toHaveBeenCalledWith(qrCodeUrl));
@@ -37,7 +37,7 @@ describe("QRFileUpload", () => {
 
 		const scanImageMock = jest.spyOn(QRScanner, "scanImage").mockResolvedValue({ data: qrCodeUrl });
 
-		render(<QRFileUpload onRead={onRead} />);
+		render(<QRFileUpload onError={jest.fn()} onRead={onRead} />);
 
 		userEvent.click(screen.getByTestId("QRFileUpload__upload"));
 		await waitFor(() => expect(onRead).not.toHaveBeenCalled());
@@ -77,7 +77,7 @@ describe("QRFileUpload", () => {
 			throw new Error(errorMessage);
 		});
 
-		render(<QRFileUpload onError={onError} />);
+		render(<QRFileUpload onError={onError} onRead={jest.fn()} />);
 
 		userEvent.click(screen.getByTestId("QRFileUpload__upload"));
 		await waitFor(() => expect(onError).toHaveBeenCalledWith(new Error(errorMessage)));

--- a/src/app/components/QRFileUpload/QRFileUpload.tsx
+++ b/src/app/components/QRFileUpload/QRFileUpload.tsx
@@ -7,8 +7,8 @@ import { Icon } from "@/app/components/Icon";
 import { useFiles } from "@/app/hooks/use-files";
 
 interface QRFileUploadProperties {
-	onError?: (error: Error) => void;
-	onRead?: (text: string) => void;
+	onError: (error: Error) => void;
+	onRead: (text: string) => void;
 }
 
 export const QRFileUpload = ({ onError, onRead }: QRFileUploadProperties) => {
@@ -25,13 +25,13 @@ export const QRFileUpload = ({ onError, onRead }: QRFileUploadProperties) => {
 
 			const { data } = await QRScanner.scanImage(file, { returnDetailedScanResult: true });
 
-			onRead?.(data);
+			onRead(data);
 		} catch (error) {
 			if (error.name === "AbortError") {
 				return;
 			}
 
-			onError?.(new Error("InvalidQR"));
+			onError(new Error("InvalidQR"));
 		}
 	};
 

--- a/src/app/components/QRModal/QRModal.test.tsx
+++ b/src/app/components/QRModal/QRModal.test.tsx
@@ -64,6 +64,8 @@ describe("QRModal", () => {
 
 		scanImageMock.mockRestore();
 		browserAccessMock.mockRestore();
+
+		toastSpy.mockReset();
 	});
 
 	it("should handle read", async () => {
@@ -116,7 +118,12 @@ describe("QRModal", () => {
 			},
 		);
 
-		render(<QRModal isOpen={true} onCancel={jest.fn()} onRead={jest.fn()} />);
+		const { rerender } = render(<QRModal isOpen={true} onCancel={jest.fn()} onRead={jest.fn()} />);
+
+		rerender(<QRModal isOpen={true} onCancel={jest.fn()} onRead={jest.fn()} />);
+		rerender(<QRModal isOpen={true} onCancel={jest.fn()} onRead={jest.fn()} />);
+		rerender(<QRModal isOpen={true} onCancel={jest.fn()} onRead={jest.fn()} />);
+		rerender(<QRModal isOpen={true} onCancel={jest.fn()} onRead={jest.fn()} />);
 
 		await waitFor(() => {
 			expect(toastSpy).toHaveBeenCalledWith(transactionTranslations.MODAL_QR_CODE.ERROR);

--- a/src/app/components/QRModal/QRModal.tsx
+++ b/src/app/components/QRModal/QRModal.tsx
@@ -112,7 +112,7 @@ export const QRModal = ({ isOpen, onCancel, onRead }: QRModalProperties) => {
 		onRead?.(qrCodeString);
 	};
 
-	const resetErrorCounter = () => errorCounter.current = 0;
+	const resetErrorCounter = () => (errorCounter.current = 0);
 
 	useEffect(() => {
 		/* istanbul ignore next */

--- a/src/app/components/QRModal/QRModal.tsx
+++ b/src/app/components/QRModal/QRModal.tsx
@@ -7,6 +7,7 @@ import { QRCameraReader } from "@/app/components/QRCameraReader";
 import { Spinner } from "@/app/components/Spinner";
 import { QRFileUpload } from "@/app/components/QRFileUpload";
 import { FormButtons } from "@/app/components/Form";
+import { toasts } from "@/app/services";
 
 interface QRError {
 	title?: string;
@@ -79,18 +80,14 @@ export const QRModal = ({ isOpen, onCancel, onRead }: QRModalProperties) => {
 		}
 
 		if (qrError.message === "InvalidQR") {
-			setError({
-				message: t("TRANSACTION.MODAL_QR_CODE.INVALID_QR_CODE"),
-			});
+			toasts.error(t("TRANSACTION.MODAL_QR_CODE.INVALID_QR_CODE"));
 
 			return;
 		}
 
 		/* istanbul ignore else */
 		if (qrError.message) {
-			setError({
-				message: t("TRANSACTION.MODAL_QR_CODE.ERROR"),
-			});
+			toasts.error(t("TRANSACTION.MODAL_QR_CODE.ERROR"));
 		}
 	};
 

--- a/src/domains/transaction/i18n.ts
+++ b/src/domains/transaction/i18n.ts
@@ -174,7 +174,7 @@ export const translations = {
 	MODAL_QR_CODE: {
 		DESCRIPTION: "Hold a compatible QR Code in front of your device's camera",
 		ERROR: "Something went wrong.",
-		INVALID_QR_CODE: "The QR code is invalid.",
+		INVALID_QR_CODE: "The uploaded QR code is invalid.",
 		PERMISSION_ERROR: {
 			DESCRIPTION: "Please allow access to the camera in the browser settings.",
 			TITLE: "Permission Denied",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/2unj6kg

Instead of showing the QR errors inside the viewfinder, this PR implements them as toasts.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
