### PR TITLE
refactor: recalculate balances after syncing exchange rates

### DIFF
--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.blocks.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.blocks.tsx
@@ -121,6 +121,7 @@ export const GroupNetworkTotal: React.VFC<WalletsGroupNetworkTotalProperties> = 
 	wallets,
 	maxWidthReferences,
 	noBorder,
+	isSyncing,
 }) => {
 	const profile = useActiveProfile();
 	const { t } = useTranslation();
@@ -138,7 +139,7 @@ export const GroupNetworkTotal: React.VFC<WalletsGroupNetworkTotalProperties> = 
 		}
 
 		return [totalNetworkBalance, totalConvertedNetworkBalance];
-	}, [wallets]);
+	}, [wallets, isSyncing]);
 
 	const renderWallets = () => {
 		if (profileIsSyncing) {

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.contracts.ts
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.contracts.ts
@@ -20,6 +20,7 @@ export interface WalletsGroupHeaderProperties {
 	maxWidthReferences?: MaxWidthReferences;
 	onClick?: (event: React.MouseEvent) => void;
 	className?: string;
+	isSyncing?: boolean;
 }
 
 export interface WalletsGroupHeaderSkeletonProperties {
@@ -48,6 +49,7 @@ export interface WalletsGroupNetworkTotalProperties {
 	wallets: Contracts.IReadWriteWallet[];
 	maxWidthReferences?: MaxWidthReferences;
 	noBorder?: boolean;
+	isSyncing?: boolean;
 }
 
 export interface WalletsGroupSkeletonProperties {

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.tsx
@@ -7,6 +7,7 @@ import { WalletsGroupProperties } from "@/domains/wallet/components/WalletsGroup
 import { WalletsGroupHeader } from "@/domains/wallet/components/WalletsGroup/WalletsGroupHeader";
 import { WalletsList } from "@/domains/wallet/components/WalletsList";
 import { AccordionWrapper } from "@/app/components/Accordion";
+import { useConfiguration } from "@/app/contexts";
 
 const MAX_WALLETS_ON_DASHBOARD_LIST = 10;
 
@@ -15,6 +16,8 @@ export const WalletsGroup: React.VFC<WalletsGroupProperties> = ({ network, walle
 	const history = useHistory();
 	const profile = useActiveProfile();
 	const { isExpanded, handleHeaderClick } = useAccordion();
+
+	const { profileIsSyncingExchangeRates } = useConfiguration();
 
 	const goToCoinWallets = useCallback(() => {
 		history.push(`/profiles/${profile.id()}/network/${network.id()}`);
@@ -25,9 +28,10 @@ export const WalletsGroup: React.VFC<WalletsGroupProperties> = ({ network, walle
 			<WalletsGroupHeader
 				network={network}
 				wallets={wallets}
-				onClick={handleHeaderClick}
-				isExpanded={isExpanded}
 				maxWidthReferences={maxWidthReferences}
+				isExpanded={isExpanded}
+				isSyncing={profileIsSyncingExchangeRates}
+				onClick={handleHeaderClick}
 			/>
 
 			{isExpanded && (

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroupHeader.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroupHeader.tsx
@@ -22,6 +22,7 @@ export const WalletsGroupHeader: React.VFC<WalletsGroupHeaderProperties> = ({
 	isExpanded,
 	maxWidthReferences,
 	className,
+	isSyncing,
 }) => (
 	<AccordionHeader isExpanded={isExpanded} onClick={onClick} data-testid="WalletsGroupHeader" className={className}>
 		<GroupNetworkIcon network={network} isGroupExpanded={isExpanded} />
@@ -31,6 +32,7 @@ export const WalletsGroupHeader: React.VFC<WalletsGroupHeaderProperties> = ({
 			wallets={wallets}
 			maxWidthReferences={maxWidthReferences}
 			noBorder={!onClick}
+			isSyncing={isSyncing}
 		/>
 	</AccordionHeader>
 );


### PR DESCRIPTION

The balances on the dashboard are only calculated when the given wallets change. There are some scenarios in which we want them to reload as well, such as:

- exchange rates have changed
- wallet balances have changed

https://app.clickup.com/t/2vcctpp
 
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
