### PR TITLE
refactor: limit message signing to 600 characters

### DIFF
--- a/src/app/hooks/use-validation.ts
+++ b/src/app/hooks/use-validation.ts
@@ -15,7 +15,7 @@ import {
 	sendTransfer,
 	sendVote,
 } from "@/domains/transaction/validations";
-import { receiveFunds, verifyMessage } from "@/domains/wallet/validations";
+import { receiveFunds, signMessage, verifyMessage } from "@/domains/wallet/validations";
 
 export const useValidation = () => {
 	const { t } = useTranslation();
@@ -37,6 +37,7 @@ export const useValidation = () => {
 			sendVote: sendVote(t),
 			server: server(t),
 			settings: settings(t, env),
+			signMessage: signMessage(t),
 			verifyMessage: verifyMessage(t),
 		}),
 		[t, env],

--- a/src/domains/wallet/components/SignMessage/FormStep.tsx
+++ b/src/domains/wallet/components/SignMessage/FormStep.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { Avatar } from "@/app/components/Avatar";
 import { FormField, FormLabel } from "@/app/components/Form";
 import { Header } from "@/app/components/Header";
-import { Input, InputDefault, InputPassword } from "@/app/components/Input";
+import { Input, InputCounter, InputDefault, InputPassword } from "@/app/components/Input";
 import { useValidation } from "@/app/hooks";
 
 export const FormStep = ({
@@ -18,7 +18,8 @@ export const FormStep = ({
 }) => {
 	const { t } = useTranslation();
 
-	const { authentication } = useValidation();
+	const { authentication, signMessage } = useValidation();
+	const maxLength = signMessage.message().maxLength?.value;
 
 	const { register, setValue } = useFormContext();
 
@@ -58,12 +59,8 @@ export const FormStep = ({
 
 			<FormField name="message">
 				<FormLabel label={t("COMMON.MESSAGE")} />
-				<InputDefault
-					ref={register({
-						required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
-							field: t("COMMON.MESSAGE"),
-						}).toString(),
-					})}
+				<InputCounter
+					ref={register(signMessage.message())}
 					onChange={(event: ChangeEvent<HTMLInputElement>) =>
 						setValue("message", event.target.value, {
 							shouldDirty: true,
@@ -72,6 +69,7 @@ export const FormStep = ({
 					}
 					data-testid="SignMessage__message-input"
 					readOnly={disableMessageInput}
+					maxLengthLabel={maxLength.toString()}
 				/>
 			</FormField>
 

--- a/src/domains/wallet/components/SignMessage/FormStep.tsx
+++ b/src/domains/wallet/components/SignMessage/FormStep.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { Avatar } from "@/app/components/Avatar";
 import { FormField, FormLabel } from "@/app/components/Form";
 import { Header } from "@/app/components/Header";
-import { Input, InputCounter, InputDefault, InputPassword } from "@/app/components/Input";
+import { Input, InputCounter, InputPassword } from "@/app/components/Input";
 import { useValidation } from "@/app/hooks";
 
 export const FormStep = ({

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`SignMessage should render 1`] = `
                         Message
                       </label>
                       <div
-                        class=" css-1psxlcd"
+                        class="css-1psxlcd"
                       >
                         <div
                           class="relative flex h-full flex-1"
@@ -141,6 +141,21 @@ exports[`SignMessage should render 1`] = `
                             type="text"
                             value=""
                           />
+                        </div>
+                        <div
+                          class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                          data-testid="Input__addon-end"
+                        >
+                          <div
+                            class=""
+                          >
+                            <span
+                              class="text-sm font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                              data-testid="InputCounter__counter"
+                            >
+                              0/600
+                            </span>
+                          </div>
                         </div>
                       </div>
                     </fieldset>
@@ -363,7 +378,7 @@ exports[`SignMessage should render for ledger wallets 1`] = `
                         Message
                       </label>
                       <div
-                        class=" css-1psxlcd"
+                        class="css-1psxlcd"
                       >
                         <div
                           class="relative flex h-full flex-1"
@@ -376,6 +391,21 @@ exports[`SignMessage should render for ledger wallets 1`] = `
                             type="text"
                             value=""
                           />
+                        </div>
+                        <div
+                          class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                          data-testid="Input__addon-end"
+                        >
+                          <div
+                            class=""
+                          >
+                            <span
+                              class="text-sm font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                              data-testid="InputCounter__counter"
+                            >
+                              0/600
+                            </span>
+                          </div>
                         </div>
                       </div>
                     </fieldset>

--- a/src/domains/wallet/validations/SignMessage.ts
+++ b/src/domains/wallet/validations/SignMessage.ts
@@ -1,0 +1,14 @@
+export const signMessage = (t: any) => ({
+	message: () => ({
+    required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
+			field: t("COMMON.MESSAEG"),
+		}),
+		maxLength: {
+			message: t("COMMON.VALIDATION.MAX_LENGTH", {
+				field: t("COMMON.MESSAGE"),
+				maxLength: 600,
+			}),
+			value: 600,
+		},
+	}),
+});

--- a/src/domains/wallet/validations/SignMessage.ts
+++ b/src/domains/wallet/validations/SignMessage.ts
@@ -1,8 +1,5 @@
 export const signMessage = (t: any) => ({
 	message: () => ({
-    required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
-			field: t("COMMON.MESSAGE"),
-		}),
 		maxLength: {
 			message: t("COMMON.VALIDATION.MAX_LENGTH", {
 				field: t("COMMON.MESSAGE"),
@@ -10,5 +7,8 @@ export const signMessage = (t: any) => ({
 			}),
 			value: 600,
 		},
+		required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
+			field: t("COMMON.MESSAGE"),
+		}),
 	}),
 });

--- a/src/domains/wallet/validations/SignMessage.ts
+++ b/src/domains/wallet/validations/SignMessage.ts
@@ -1,7 +1,7 @@
 export const signMessage = (t: any) => ({
 	message: () => ({
     required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
-			field: t("COMMON.MESSAEG"),
+			field: t("COMMON.MESSAGE"),
 		}),
 		maxLength: {
 			message: t("COMMON.VALIDATION.MAX_LENGTH", {

--- a/src/domains/wallet/validations/index.ts
+++ b/src/domains/wallet/validations/index.ts
@@ -1,3 +1,4 @@
 export * from "./Alias";
 export * from "./ReceiveFunds";
+export * from "./SignMessage";
 export * from "./VerifyMessage";


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Limits the message input in the sign message modal to 600 characters.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
