### PR TITLE
fix: remove default transparent border from `Badge` component

### DIFF
--- a/src/app/__snapshots__/App.test.tsx.snap
+++ b/src/app/__snapshots__/App.test.tsx.snap
@@ -193,7 +193,7 @@ exports[`App should close page skeleton if not e2e 1`] = `
                               </div>
                             </div>
                             <span
-                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
+                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
                             >
                               <div
                                 class="emotion-cache-1i4b0eq"
@@ -501,7 +501,7 @@ exports[`App should not migrate profiles 1`] = `
                               </div>
                             </div>
                             <span
-                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
+                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
                             >
                               <div
                                 class="emotion-cache-1i4b0eq"
@@ -946,7 +946,7 @@ exports[`App should render mock 1`] = `
                               </div>
                             </div>
                             <span
-                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
+                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
                             >
                               <div
                                 class="emotion-cache-1i4b0eq"
@@ -1254,7 +1254,7 @@ exports[`App should render page skeleton 1`] = `
                               </div>
                             </div>
                             <span
-                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
+                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
                             >
                               <div
                                 class="emotion-cache-1i4b0eq"
@@ -1644,7 +1644,7 @@ exports[`App should render welcome screen after page skeleton 1`] = `
                               </div>
                             </div>
                             <span
-                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
+                              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 emotion-cache-1jfmq7q"
                             >
                               <div
                                 class="emotion-cache-1i4b0eq"

--- a/src/app/components/Badge/Badge.styles.ts
+++ b/src/app/components/Badge/Badge.styles.ts
@@ -19,7 +19,7 @@ const baseStyle = (size?: Size, noShadow?: boolean) => {
 };
 
 const shape = "flex border-2 rounded-full justify-center items-center align-middle";
-const colors = "bg-theme-background border-transparent";
+const colors = "bg-theme-background";
 
 export const defaultClasses = `${shape} ${colors}`;
 

--- a/src/app/components/Badge/__snapshots__/Badge.test.tsx.snap
+++ b/src/app/components/Badge/__snapshots__/Badge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Badge should render 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-19jfgr"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-19jfgr"
   >
     <span />
   </span>
@@ -13,7 +13,7 @@ exports[`Badge should render 1`] = `
 exports[`Badge should render with icon 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-19jfgr"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-19jfgr"
   >
     <div
       class="css-15txs7d"
@@ -28,7 +28,7 @@ exports[`Badge should render with icon 1`] = `
 exports[`Badge should render with position 'bottom' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-cys5ec"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-cys5ec"
   >
     <div
       class="css-15txs7d"
@@ -43,7 +43,7 @@ exports[`Badge should render with position 'bottom' 1`] = `
 exports[`Badge should render with position 'bottom-left' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-1os0w1"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-1os0w1"
   >
     <div
       class="css-15txs7d"
@@ -58,7 +58,7 @@ exports[`Badge should render with position 'bottom-left' 1`] = `
 exports[`Badge should render with position 'bottom-right' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-19jfgr"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-19jfgr"
   >
     <div
       class="css-15txs7d"
@@ -73,7 +73,7 @@ exports[`Badge should render with position 'bottom-right' 1`] = `
 exports[`Badge should render with position 'left' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-1ltu2fy"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-1ltu2fy"
   >
     <div
       class="css-15txs7d"
@@ -88,7 +88,7 @@ exports[`Badge should render with position 'left' 1`] = `
 exports[`Badge should render with position 'right' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-n63zof"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-n63zof"
   >
     <div
       class="css-15txs7d"
@@ -103,7 +103,7 @@ exports[`Badge should render with position 'right' 1`] = `
 exports[`Badge should render with position 'top' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-1aektxz"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-1aektxz"
   >
     <div
       class="css-15txs7d"
@@ -118,7 +118,7 @@ exports[`Badge should render with position 'top' 1`] = `
 exports[`Badge should render with position 'top-left' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-1lw6cca"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-1lw6cca"
   >
     <div
       class="css-15txs7d"
@@ -133,7 +133,7 @@ exports[`Badge should render with position 'top-left' 1`] = `
 exports[`Badge should render with position 'top-right' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-1sslbw4"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-1sslbw4"
   >
     <div
       class="css-15txs7d"
@@ -148,7 +148,7 @@ exports[`Badge should render with position 'top-right' 1`] = `
 exports[`Badge should render with size 'lg' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-1jfmq7q"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-1jfmq7q"
   >
     <div
       class="css-15txs7d"
@@ -163,7 +163,7 @@ exports[`Badge should render with size 'lg' 1`] = `
 exports[`Badge should render with size 'md' 1`] = `
 <div>
   <span
-    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent css-19jfgr"
+    class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background css-19jfgr"
   >
     <div
       class="css-15txs7d"

--- a/src/app/components/FilterNetwork/NetworkOptions.tsx
+++ b/src/app/components/FilterNetwork/NetworkOptions.tsx
@@ -13,7 +13,7 @@ export const NetworkOption = ({ network, isSelected, onClick }: FilterOption) =>
 			return (
 				<Circle size="lg" className="relative border-theme-primary-500 text-theme-primary-500">
 					<NetworkIconContent network={network} />
-					<Badge className="bg-theme-primary-500 text-theme-primary-100" icon="CheckmarkSmall" />
+					<Badge className="border-transparent bg-theme-primary-500 text-theme-primary-100" icon="CheckmarkSmall" />
 				</Circle>
 			);
 		}

--- a/src/app/components/FilterNetwork/NetworkOptions.tsx
+++ b/src/app/components/FilterNetwork/NetworkOptions.tsx
@@ -13,7 +13,10 @@ export const NetworkOption = ({ network, isSelected, onClick }: FilterOption) =>
 			return (
 				<Circle size="lg" className="relative border-theme-primary-500 text-theme-primary-500">
 					<NetworkIconContent network={network} />
-					<Badge className="border-transparent bg-theme-primary-500 text-theme-primary-100" icon="CheckmarkSmall" />
+					<Badge
+						className="border-transparent bg-theme-primary-500 text-theme-primary-100"
+						icon="CheckmarkSmall"
+					/>
 				</Circle>
 			);
 		}

--- a/src/app/components/FilterNetwork/__snapshots__/FilterNetwork.test.tsx.snap
+++ b/src/app/components/FilterNetwork/__snapshots__/FilterNetwork.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`FilterNetwork should render public networks 1`] = `
             </svg>
           </div>
           <span
-            class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+            class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
           >
             <span />
           </span>
@@ -64,7 +64,7 @@ exports[`FilterNetwork should render public networks 1`] = `
             </svg>
           </div>
           <span
-            class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+            class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
           >
             <span />
           </span>
@@ -118,7 +118,7 @@ exports[`FilterNetworks should render public and testnet networks 1`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -156,7 +156,7 @@ exports[`FilterNetworks should render public and testnet networks 1`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -250,7 +250,7 @@ exports[`FilterNetworks should toggle a testnet network option 1`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -285,7 +285,7 @@ exports[`FilterNetworks should toggle view all 1`] = `
           All
         </div>
         <span
-          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-primary-700 bg-theme-primary-700 text-white css-19jfgr"
+          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-primary-700 bg-theme-primary-700 text-white css-19jfgr"
         >
           <div
             class="transition-transform rotate-180 css-15txs7d"
@@ -321,7 +321,7 @@ exports[`FilterNetworks should toggle view all 1`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -345,7 +345,7 @@ exports[`FilterNetworks should toggle view all 1`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -384,7 +384,7 @@ exports[`FilterNetworks should toggle view all 1`] = `
           All
         </div>
         <span
-          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
+          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
         >
           <div
             class="transition-transform css-15txs7d"
@@ -420,7 +420,7 @@ exports[`FilterNetworks should toggle view all 1`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -455,7 +455,7 @@ exports[`FilterNetworks should toggle view all 2`] = `
           All
         </div>
         <span
-          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
+          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
         >
           <div
             class="transition-transform css-15txs7d"
@@ -491,7 +491,7 @@ exports[`FilterNetworks should toggle view all 2`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -515,7 +515,7 @@ exports[`FilterNetworks should toggle view all 2`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -541,7 +541,7 @@ exports[`FilterNetworks should toggle view all 2`] = `
           All
         </div>
         <span
-          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
+          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
         >
           <div
             class="transition-transform css-15txs7d"
@@ -577,7 +577,7 @@ exports[`FilterNetworks should toggle view all 2`] = `
               </svg>
             </div>
             <span
-              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+              class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
             >
               <span />
             </span>
@@ -613,7 +613,7 @@ exports[`NetworkOptions should render available networks options 1`] = `
           </svg>
         </div>
         <span
-          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
         >
           <span />
         </span>
@@ -637,7 +637,7 @@ exports[`NetworkOptions should render available networks options 1`] = `
           </svg>
         </div>
         <span
-          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
         >
           <span />
         </span>
@@ -668,7 +668,7 @@ exports[`ToggleAllOption should render 1`] = `
       All
     </div>
     <span
-      class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
+      class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-primary-100 text-theme-primary-700 dark:border-theme-secondary-800 css-19jfgr"
     >
       <div
         class="transition-transform css-15txs7d"
@@ -699,7 +699,7 @@ exports[`ToggleAllOption should render selected 1`] = `
       All
     </div>
     <span
-      class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-primary-700 bg-theme-primary-700 text-white css-19jfgr"
+      class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-primary-700 bg-theme-primary-700 text-white css-19jfgr"
     >
       <div
         class="transition-transform rotate-180 css-15txs7d"

--- a/src/domains/dashboard/components/FilterWallets/__snapshots__/FilterWallets.test.tsx.snap
+++ b/src/domains/dashboard/components/FilterWallets/__snapshots__/FilterWallets.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`FilterWallets should render with networks selection 1`] = `
                 </svg>
               </div>
               <span
-                class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
+                class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-theme-secondary-300 dark:border-theme-secondary-800 css-19jfgr"
               >
                 <span />
               </span>

--- a/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
+++ b/src/domains/profile/pages/Welcome/__snapshots__/Welcome.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`Welcome should change route to create profile 1`] = `
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -411,7 +411,7 @@ exports[`Welcome should navigate to previous page with correct password 1`] = `
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -707,7 +707,7 @@ exports[`Welcome should navigate to profile dashboard 1`] = `
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -1003,7 +1003,7 @@ exports[`Welcome should navigate to profile dashboard with correct password 1`] 
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -1299,7 +1299,7 @@ exports[`Welcome should navigate to profile settings from profile card menu 1`] 
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -1595,7 +1595,7 @@ exports[`Welcome should navigate to profile settings with correct password 1`] =
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -1823,7 +1823,7 @@ exports[`Welcome should not select profile on wrong last location 1`] = `
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"
@@ -2119,7 +2119,7 @@ exports[`Welcome should render with profiles 1`] = `
                           </div>
                         </div>
                         <span
-                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background border-transparent mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
+                          class="flex border-2 rounded-full justify-center items-center align-middle bg-theme-background mr-2 mb-2 border-theme-background bg-theme-background text-theme-secondary-900 dark:text-theme-secondary-600 css-1jfmq7q"
                         >
                           <div
                             class="css-1i4b0eq"

--- a/src/domains/transaction/components/MultiSignatureDetail/Signatures.tsx
+++ b/src/domains/transaction/components/MultiSignatureDetail/Signatures.tsx
@@ -15,7 +15,7 @@ const WaitingBadge = () => {
 		<Tooltip content={t("COMMON.AWAITING_SIGNATURE")}>
 			<Badge
 				data-testid="Signatures__waiting-badge"
-				className="bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white"
+				className="border-transparent bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white"
 				icon="ClockSmall"
 			/>
 		</Tooltip>
@@ -29,7 +29,7 @@ const SignedBadge = () => {
 		<Tooltip content={t("COMMON.SIGNED")}>
 			<Badge
 				data-testid="Signatures__signed-badge"
-				className="bg-theme-success-200 text-theme-success-500 dark:bg-theme-success-600 dark:text-white"
+				className="border-transparent bg-theme-success-200 text-theme-success-500 dark:bg-theme-success-600 dark:text-white"
 				icon="CheckmarkSmall"
 			/>
 		</Tooltip>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Unselected items are not rendered properly in the network filter component.

![image](https://user-images.githubusercontent.com/6547002/183585091-e902c55a-8382-458b-9556-74edf98c25ba.png)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
