### PR TITLE
refactor: limit allowed characters to printable ascii when signing with ledger

### DIFF
--- a/src/domains/message/pages/SignMessage/SignMessage.test.tsx
+++ b/src/domains/message/pages/SignMessage/SignMessage.test.tsx
@@ -124,6 +124,39 @@ describe("SignMessage", () => {
 		isLedgerMock.mockRestore();
 	});
 
+	it("should show an error if non-ascii characters are used when signing with a ledger wallet", async () => {
+		const isLedgerMock = jest.spyOn(wallet, "isLedger").mockReturnValue(true);
+
+		render(
+			<Route path="/profiles/:profileId/wallets/:walletId/sign-message">
+				<SignMessage />
+			</Route>,
+			{
+				history,
+				route: walletUrl(wallet.id()),
+			},
+		);
+
+		await expectHeading(messageTranslations.PAGE_SIGN_MESSAGE.FORM_STEP.TITLE);
+
+		expect(
+			screen.getByText(messageTranslations.PAGE_SIGN_MESSAGE.FORM_STEP.DESCRIPTION_LEDGER),
+		).toBeInTheDocument();
+
+		userEvent.paste(messageInput(), "£££");
+
+		await waitFor(() => expect(continueButton()).toBeDisabled());
+
+		await waitFor(() => expect(screen.getByTestId("Input__error")).toBeVisible());
+
+		expect(screen.getByTestId("Input__error")).toHaveAttribute(
+			"data-errortext",
+			"The following characters are not allowed: '£'",
+		);
+
+		isLedgerMock.mockRestore();
+	});
+
 	it("should sign message with mnemonic", async () => {
 		const signedMessage = {
 			message: signMessage,

--- a/src/domains/message/pages/SignMessage/SignMessage.tsx
+++ b/src/domains/message/pages/SignMessage/SignMessage.tsx
@@ -53,7 +53,7 @@ export const SignMessage: React.VFC = () => {
 	const { signMessage } = useValidation();
 
 	useEffect(() => {
-		register("message", signMessage.message());
+		register("message", signMessage.message(activeWallet.isLedger()));
 	}, [register, signMessage]);
 
 	const { hasDeviceAvailable, isConnected, connect } = useLedgerContext();

--- a/src/domains/message/validations/SignMessage.ts
+++ b/src/domains/message/validations/SignMessage.ts
@@ -1,5 +1,7 @@
+import { validateAscii } from "@/utils/validations";
+
 export const signMessage = (t: any) => ({
-	message: () => ({
+	message: (asciiOnly: boolean) => ({
 		maxLength: {
 			message: t("COMMON.VALIDATION.MAX_LENGTH", {
 				field: t("COMMON.MESSAGE"),
@@ -10,5 +12,12 @@ export const signMessage = (t: any) => ({
 		required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
 			field: t("COMMON.MESSAGE"),
 		}),
+		validate: (message: string) => {
+			if (asciiOnly) {
+				return validateAscii(t, message);
+			}
+
+			return true;
+		},
 	}),
 });

--- a/src/domains/message/validations/SignMessage.ts
+++ b/src/domains/message/validations/SignMessage.ts
@@ -1,7 +1,7 @@
 import { validateAscii } from "@/utils/validations";
 
 export const signMessage = (t: any) => ({
-	message: (asciiOnly: boolean) => ({
+	message: (asciiOnly?: boolean) => ({
 		maxLength: {
 			message: t("COMMON.VALIDATION.MAX_LENGTH", {
 				field: t("COMMON.MESSAGE"),

--- a/src/utils/validations/validate-pattern.test.ts
+++ b/src/utils/validations/validate-pattern.test.ts
@@ -26,13 +26,13 @@ describe("validatePattern", () => {
 
 describe("validateAscii", () => {
 	it("should return true for valid patterns", () => {
-		expect(validateAscii(translationMockFunction, "\x20")).toBe(true);
+		expect(validateAscii(translationMockFunction, "\u0020")).toBe(true);
 		expect(validateAscii(translationMockFunction, "0123456789")).toBe(true);
 		expect(validateAscii(translationMockFunction, "!@$&_.")).toBe(true);
 	});
 
 	it("should return illegal characters for invalid pattern", () => {
-		expect(validateAscii(translationMockFunction, "\x00")).toBe(`illegal characters '\x00'`);
+		expect(validateAscii(translationMockFunction, "\u0000")).toBe(`illegal characters '\u0000'`);
 		expect(validateAscii(translationMockFunction, "§")).toBe("illegal characters '§'");
 	});
 });

--- a/src/utils/validations/validate-pattern.test.ts
+++ b/src/utils/validations/validate-pattern.test.ts
@@ -1,17 +1,17 @@
-import { validatePattern } from "./validate-pattern";
+import { validateAscii, validatePattern } from "./validate-pattern";
 
 const translationMockFunction = jest
 	.fn()
 	.mockImplementation((text, options) => `illegal characters ${options.characters}`);
 
 describe("validatePattern", () => {
-	it("should be able to return true for valid patterns", () => {
+	it("should return true for valid patterns", () => {
 		expect(validatePattern(translationMockFunction, "loremipsumissimplydummytext", /[a-z]+/)).toBe(true);
 		expect(validatePattern(translationMockFunction, "0123456789", /\d+/)).toBe(true);
 		expect(validatePattern(translationMockFunction, "!@$&_.", /[!$&.@_]+/)).toBe(true);
 	});
 
-	it("should be able to return illegal characters", () => {
+	it("should return illegal characters for invalid pattern", () => {
 		expect(validatePattern(translationMockFunction, "lorem ipsum 0-1", /[a-z]+/)).toBe(
 			"illegal characters ' ', '-', '0', '1'",
 		);
@@ -21,5 +21,18 @@ describe("validatePattern", () => {
 		expect(validatePattern(translationMockFunction, "!@4$5&8*9", /[!$&.@_]+/)).toBe(
 			"illegal characters '*', '4', '5', '8', '9'",
 		);
+	});
+});
+
+describe("validateAscii", () => {
+	it("should return true for valid patterns", () => {
+		expect(validateAscii(translationMockFunction, "\x20")).toBe(true);
+		expect(validateAscii(translationMockFunction, "0123456789")).toBe(true);
+		expect(validateAscii(translationMockFunction, "!@$&_.")).toBe(true);
+	});
+
+	it("should return illegal characters for invalid pattern", () => {
+		expect(validateAscii(translationMockFunction, "\x00")).toBe(`illegal characters '\x00'`);
+		expect(validateAscii(translationMockFunction, "§")).toBe("illegal characters '§'");
 	});
 });

--- a/src/utils/validations/validate-pattern.ts
+++ b/src/utils/validations/validate-pattern.ts
@@ -18,7 +18,7 @@ export const validatePattern = (t: any, value: string, regexp: RegExp) => {
 };
 
 export const validateAscii = (t: any, value: string) => {
-	const matches = value.match(/[^\ -~]/g);
+	const matches = value.match(/[^ -~]/g);
 
 	if (matches && matches.length > 0) {
 		return t("COMMON.VALIDATION.ILLEGAL_CHARACTERS", {

--- a/src/utils/validations/validate-pattern.ts
+++ b/src/utils/validations/validate-pattern.ts
@@ -16,3 +16,17 @@ export const validatePattern = (t: any, value: string, regexp: RegExp) => {
 		  })
 		: true;
 };
+
+export const validateAscii = (t: any, value: string) => {
+	const matches = value.match(/[^\ -~]/g);
+
+	if (matches && matches.length > 0) {
+		return t("COMMON.VALIDATION.ILLEGAL_CHARACTERS", {
+			characters: sortBy(uniq([...matches]))
+				.map((char) => `'${char}'`)
+				.join(", "),
+		});
+	}
+
+	return true;
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2w3839j

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
