### PR TITLE
refactor: only show notifications for wallets in visible networks

### DIFF
--- a/src/app/hooks/use-profile-synchronizer.test.tsx
+++ b/src/app/hooks/use-profile-synchronizer.test.tsx
@@ -25,6 +25,7 @@ import {
 	screen,
 	syncDelegates,
 	waitFor,
+	mockProfileWithPublicAndTestNetworks,
 } from "@/utils/testing-library";
 
 const history = createHashHistory();
@@ -797,6 +798,36 @@ describe("useProfileRestore", () => {
 
 		profileSyncMock.mockRestore();
 		dismissToastSpy.mockRestore();
+	});
+
+	it("should sync profile notifications for available wallets", async () => {
+		const profile = env.profiles().findById(getDefaultProfileId());
+
+		const resetProfileNetworksMock = mockProfileWithPublicAndTestNetworks(profile);
+
+		const profileNotificationsSyncSpy = jest.spyOn(profile.notifications().transactions(), "sync");
+
+		render(
+			<Route path="/profiles/:profileId/dashboard">
+				<div data-testid="ProfileSynced">test</div>
+			</Route>,
+			{
+				history,
+				route: dashboardURL,
+				withProfileSynchronizer: true,
+			},
+		);
+
+		await expect(screen.findByTestId("ProfileSynced")).resolves.toBeVisible();
+
+		expect(profileNotificationsSyncSpy).toHaveBeenCalledWith({
+			identifiers: [
+				{ networkId: "ark.devnet", type: "address", value: "D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD" },
+				{ networkId: "ark.devnet", type: "address", value: "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb" },
+			],
+		});
+
+		resetProfileNetworksMock();
 	});
 
 	it("should restore profile", async () => {

--- a/src/app/hooks/use-profile-synchronizer.test.tsx
+++ b/src/app/hooks/use-profile-synchronizer.test.tsx
@@ -412,6 +412,50 @@ describe("useProfileSynchronizer", () => {
 		process.env.MOCK_SYNCHRONIZER = undefined;
 	});
 
+	it("should sync profile notifications for available wallets", async () => {
+		const profile = env.profiles().findById(getDefaultProfileId());
+
+		const resetProfileNetworksMock = mockProfileWithPublicAndTestNetworks(profile);
+
+		const profileNotificationsSyncSpy = jest.spyOn(profile.notifications().transactions(), "sync");
+
+		const Component = () => {
+			const { syncProfileWallets } = useProfileJobs(profile);
+
+			return <button data-testid="SyncProfile" onClick={() => syncProfileWallets()} />;
+		};
+
+		history.push(dashboardURL);
+
+		render(
+			<Route path="/profiles/:profileId/dashboard">
+				<Component />
+			</Route>,
+			{
+				history,
+				route: dashboardURL,
+				withProfileSynchronizer: true,
+			},
+		);
+
+		await expect(screen.findByTestId("SyncProfile")).resolves.toBeVisible();
+
+		userEvent.click(screen.getByTestId("SyncProfile"));
+
+		await waitFor(() =>
+			expect(profileNotificationsSyncSpy).toHaveBeenCalledWith({
+				identifiers: [
+					{ networkId: "ark.devnet", type: "address", value: "D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD" },
+					{ networkId: "ark.devnet", type: "address", value: "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb" },
+				],
+			}),
+		);
+
+		resetProfileNetworksMock();
+
+		profileNotificationsSyncSpy.mockRestore();
+	});
+
 	it("should sync profile and handle resync with errored networks", async () => {
 		jest.useFakeTimers();
 		history.push(dashboardURL);
@@ -798,36 +842,6 @@ describe("useProfileRestore", () => {
 
 		profileSyncMock.mockRestore();
 		dismissToastSpy.mockRestore();
-	});
-
-	it("should sync profile notifications for available wallets", async () => {
-		const profile = env.profiles().findById(getDefaultProfileId());
-
-		const resetProfileNetworksMock = mockProfileWithPublicAndTestNetworks(profile);
-
-		const profileNotificationsSyncSpy = jest.spyOn(profile.notifications().transactions(), "sync");
-
-		render(
-			<Route path="/profiles/:profileId/dashboard">
-				<div data-testid="ProfileSynced">test</div>
-			</Route>,
-			{
-				history,
-				route: dashboardURL,
-				withProfileSynchronizer: true,
-			},
-		);
-
-		await expect(screen.findByTestId("ProfileSynced")).resolves.toBeVisible();
-
-		expect(profileNotificationsSyncSpy).toHaveBeenCalledWith({
-			identifiers: [
-				{ networkId: "ark.devnet", type: "address", value: "D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD" },
-				{ networkId: "ark.devnet", type: "address", value: "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb" },
-			],
-		});
-
-		resetProfileNetworksMock();
 	});
 
 	it("should restore profile", async () => {

--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -61,9 +61,9 @@ export const useProfileJobs = (profile?: Contracts.IProfile): Record<string, any
 
 					const walletIdentifiers: Services.WalletIdentifier[] = profile
 						.wallets()
-						.valuesWithCoin()
+						.values()
 						.filter((wallet) =>
-							profile.availableNetworks().some((network) => wallet.network().id() === network.id()),
+							profile.availableNetworks().some((network) => wallet.networkId() === network.id()),
 						)
 						.map((wallet) => ({
 							networkId: wallet.networkId(),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes https://app.clickup.com/t/2t1ywax

Filters the notifications to show only for the ones for the available profile networks

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
