### PR TITLE
fix: ensure profile is restored using deeplinks 

### DIFF
--- a/src/domains/profile/pages/Welcome/Welcome.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.tsx
@@ -13,7 +13,7 @@ import { Image } from "@/app/components/Image";
 import { Page, Section } from "@/app/components/Layout";
 import { Link } from "@/app/components/Link";
 import { useEnvironmentContext } from "@/app/contexts";
-import { useAccentColor, useDeeplink, useProfileRestore, useTheme } from "@/app/hooks";
+import { useAccentColor, useDeeplink, useTheme } from "@/app/hooks";
 import { DeleteProfile } from "@/domains/profile/components/DeleteProfile/DeleteProfile";
 import { ProfileCard } from "@/domains/profile/components/ProfileCard";
 import { SignIn } from "@/domains/profile/components/SignIn/SignIn";
@@ -23,7 +23,6 @@ export const Welcome = () => {
 	const context = useEnvironmentContext();
 	const history = useHistory<LocationState>();
 	const [isThemeLoaded, setThemeLoaded] = useState(false);
-	const { restoreProfile } = useProfileRestore();
 	const isProfileCardClickedOnce = useRef(false);
 
 	const { t } = useTranslation();
@@ -75,8 +74,9 @@ export const Welcome = () => {
 				toasts.dismiss();
 				const validatingToastId = toasts.warning(t("COMMON.VALIDATING_URI"));
 
-				await restoreProfile(profile);
+				await context.env.profiles().restore(profile);
 				const error = await validateDeeplink(profile);
+				profile.status().reset();
 
 				if (error) {
 					toasts.update(validatingToastId, "error", error);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This fix ensures that profile is restored always through the profile-synchronizer, either the user enters using a deeplink or using the regular way from welcome screen. And that the same order of execution of actions is applied (profile restore -> profile sync -> and running sync jobs).

The same order of execution is applied in both ways.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
