### PR TITLE
chore: increase width of various modals

### DIFF
--- a/src/app/components/DeleteResource/DeleteResource.tsx
+++ b/src/app/components/DeleteResource/DeleteResource.tsx
@@ -38,7 +38,7 @@ export const DeleteResource = ({
 		<Modal
 			title={title}
 			image={<Image name="Trash" useAccentColor={false} className="my-8 mx-auto max-w-52" />}
-			size="md"
+			size="2xl"
 			isOpen={isOpen}
 			onClose={onClose}
 			{...attributes}

--- a/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
+++ b/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DeleteResource should render with children 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
+++ b/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`WalletListItem should disable the send button when wallet has no balanc
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div
@@ -693,7 +693,7 @@ exports[`WalletListItem should render when isCompact = false 1`] = `
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div
@@ -1022,7 +1022,7 @@ exports[`WalletListItem should render when isCompact = true 1`] = `
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div
@@ -1651,7 +1651,7 @@ exports[`WalletListItem should render when isLargeScreen = true 1`] = `
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div
@@ -1989,7 +1989,7 @@ exports[`WalletListItem should render when isLargeScreen = true and wallet is no
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div
@@ -2318,7 +2318,7 @@ exports[`WalletListItem should render with a N/A for fiat 1`] = `
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div
@@ -2647,7 +2647,7 @@ exports[`WalletListItem should render with default BTC as default exchangeCurren
             data-testid="Modal__overlay"
           >
             <div
-              class="css-1nnbd55"
+              class="css-amqh1w"
               tabindex="-1"
             >
               <div

--- a/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
+++ b/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DeleteContact should render a modal 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/exchange/components/DeleteExchangeTransaction/__snapshots__/DeleteExchangeTransaction.test.tsx.snap
+++ b/src/domains/exchange/components/DeleteExchangeTransaction/__snapshots__/DeleteExchangeTransaction.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`DeleteExchangeTransaction should render a modal 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
+++ b/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DeleteProfile should render 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/profile/components/PasswordModal/PasswordModal.tsx
+++ b/src/domains/profile/components/PasswordModal/PasswordModal.tsx
@@ -25,7 +25,7 @@ export const PasswordModal = ({ isOpen, title, description, onClose, onSubmit }:
 			title={title}
 			titleClass="items-left"
 			description={description}
-			size="md"
+			size="2xl"
 			isOpen={isOpen}
 			onClose={onClose}
 		>

--- a/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
+++ b/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`PasswordModal should render with title and description 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/profile/components/SignIn/SignIn.tsx
+++ b/src/domains/profile/components/SignIn/SignIn.tsx
@@ -113,7 +113,7 @@ export const SignIn: React.VFC<SignInProperties> = ({ isOpen, profile, onCancel,
 
 			<Divider dashed={true} />
 
-			<Form context={methods} onSubmit={handleSubmit} className="mt-8">
+			<Form context={methods} onSubmit={handleSubmit} className={undefined}>
 				<FormField name="password">
 					<FormLabel label={t("SETTINGS.GENERAL.PERSONAL.PASSWORD")} />
 					<InputPassword

--- a/src/domains/profile/components/SignIn/SignIn.tsx
+++ b/src/domains/profile/components/SignIn/SignIn.tsx
@@ -92,7 +92,7 @@ export const SignIn: React.VFC<SignInProperties> = ({ isOpen, profile, onCancel,
 		<Modal
 			title={t("PROFILE.MODAL_SIGN_IN.TITLE")}
 			description={t("PROFILE.MODAL_SIGN_IN.DESCRIPTION")}
-			size="md"
+			size="2xl"
 			isOpen={isOpen}
 			onClose={onClose}
 		>

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SignIn should render a modal 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -105,7 +105,6 @@ exports[`SignIn should render a modal 1`] = `
               type="horizontal"
             />
             <form
-              class="mt-8"
               data-testid="Form"
             >
               <fieldset

--- a/src/domains/transaction/components/ConfirmRemovePendingTransaction/__snapshots__/ConfirmRemovePendingTransaction.test.tsx.snap
+++ b/src/domains/transaction/components/ConfirmRemovePendingTransaction/__snapshots__/ConfirmRemovePendingTransaction.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ConfirmRemovePendingTransaction should render multisignature registrati
     data-testid="ConfirmRemovePendingTransaction__Multisignature-Registration"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -137,7 +137,7 @@ exports[`ConfirmRemovePendingTransaction should render multisignature transactio
     data-testid="ConfirmRemovePendingTransaction__Transfer-Transaction"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DeleteWallet should render a modal 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-x6jl3y"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div

--- a/src/domains/wallet/components/UpdateWalletName/UpdateWalletName.tsx
+++ b/src/domains/wallet/components/UpdateWalletName/UpdateWalletName.tsx
@@ -53,7 +53,7 @@ export const UpdateWalletName: React.VFC<UpdateWalletNameProperties> = ({ onAfte
 			isOpen
 			title={t("WALLETS.MODAL_NAME_WALLET.TITLE")}
 			description={t("WALLETS.MODAL_NAME_WALLET.DESCRIPTION")}
-			size="lg"
+			size="2xl"
 			onClose={onCancel}
 		>
 			<Form context={form} onSubmit={onSubmit} className="mt-8">

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`UpdateWalletName should render 1`] = `
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -132,7 +132,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 1`] = 
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -276,7 +276,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 2`] = 
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -420,7 +420,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 3`] = 
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -564,7 +564,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 4`] = 
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -708,7 +708,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div
@@ -852,7 +852,7 @@ exports[`UpdateWalletName should show error message when name exceeds 42 charact
     data-testid="Modal__overlay"
   >
     <div
-      class="css-1nnbd55"
+      class="css-amqh1w"
       tabindex="-1"
     >
       <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR increases the width of the following modals:

- DeleteResource (-> Wallet / Contact / Profile)
- SignIn / PasswordModal
- UpdateWalletName

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
