### PR TITLE
fix: reset final count when starting new export

### DIFF
--- a/src/domains/transaction/components/TransactionExportModal/hooks/use-transaction-export.ts
+++ b/src/domains/transaction/components/TransactionExportModal/hooks/use-transaction-export.ts
@@ -75,6 +75,8 @@ export const useTransactionExport = ({
 			setStatus(ExportProgressStatus.Idle);
 		},
 		startExport: async (settings: ExportSettings) => {
+			setFinalCount(0);
+
 			setStatus(ExportProgressStatus.Progress);
 
 			const dateRange = getTimestampRange(settings.dateRange, settings.from, settings.to);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Resets the final count when starting a new export. This way the previous count is not displayed after clicking back to start a new export with changed settings, after the previous export has been fully processed.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
