### PR TITLE
fix: use explicit --no-frozen-lockfile for dep update workflow

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -32,7 +32,7 @@ jobs:
               run: npx npm-check-updates --configFilePath ./
 
             - name: Install Updated JS dependencies
-              run: pnpm install
+              run: pnpm install --no-frozen-lockfile
 
             - name: Rebuild Assets
               run: ZENDESK_WIDGET_KEY=${{ secrets.ZENDESK_WIDGET_KEY }} pnpm run build


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Since we're updating, the lockfile will not match and CI defaults to `--frozen-lockfile`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
