### PR TITLE
refactor: invalidate migration address in regular transfer flow

### DIFF
--- a/src/domains/transaction/i18n.ts
+++ b/src/domains/transaction/i18n.ts
@@ -425,6 +425,7 @@ export const translations = {
 		MESSAGE_MISSING: "message parameter is missing.",
 		METHOD_MISSING: "method parameter is missing",
 		METHOD_NOT_SUPPORTED: "method <strong>{{method}}</strong> is not supported.",
+		MIGRATION_ADDRESS: "Sending to the migration address is not possible outside of the Migration page",
 		NETHASH_NOT_ENABLED: "network with nethash <strong>{{nethash}}</strong> is not enabled or available.",
 		NETWORK_INVALID: "network <strong>{{network}}</strong> is invalid.",
 		NETWORK_MISMATCH: "data belongs to another network.",

--- a/src/domains/transaction/validations/SendTransfer.test.tsx
+++ b/src/domains/transaction/validations/SendTransfer.test.tsx
@@ -4,6 +4,7 @@ import { Contracts } from "@ardenthq/sdk-profiles";
 
 import { sendTransfer } from "./SendTransfer";
 import { env, getDefaultProfileId } from "@/utils/testing-library";
+import { migrationWalletAddress } from "@/utils/polygon-migration";
 
 let profile: Contracts.IProfile;
 let translationMock: any;
@@ -31,6 +32,12 @@ describe("Send transfer validations", () => {
 		const noAddressWithoutRecipients = sendTransfer(translationMock).recipientAddress(profile, network, [], false);
 
 		await expect(noAddressWithoutRecipients.validate.valid("")).resolves.toBe("COMMON.VALIDATION.FIELD_REQUIRED");
+
+		const withMigrationAddress = sendTransfer(translationMock).recipientAddress(profile, network, [{}], false);
+
+		await expect(withMigrationAddress.validate.valid(migrationWalletAddress())).resolves.toBe(
+			"TRANSACTION.VALIDATION.MIGRATION_ADDRESS",
+		);
 	});
 
 	it("amount", () => {

--- a/src/domains/transaction/validations/SendTransfer.test.tsx
+++ b/src/domains/transaction/validations/SendTransfer.test.tsx
@@ -3,8 +3,8 @@ import { BigNumber } from "@ardenthq/sdk-helpers";
 import { Contracts } from "@ardenthq/sdk-profiles";
 
 import { sendTransfer } from "./SendTransfer";
-import { env, getDefaultProfileId } from "@/utils/testing-library";
 import { migrationWalletAddress } from "@/utils/polygon-migration";
+import { env, getDefaultProfileId } from "@/utils/testing-library";
 
 let profile: Contracts.IProfile;
 let translationMock: any;

--- a/src/domains/transaction/validations/SendTransfer.ts
+++ b/src/domains/transaction/validations/SendTransfer.ts
@@ -1,7 +1,7 @@
 import { Coins, Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
-import { TFunction } from "@/app/i18n/react-i18next.contracts";
 
+import { TFunction } from "@/app/i18n/react-i18next.contracts";
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
 import { migrationWalletAddress } from "@/utils/polygon-migration";
 

--- a/src/domains/transaction/validations/SendTransfer.ts
+++ b/src/domains/transaction/validations/SendTransfer.ts
@@ -3,6 +3,7 @@ import { Contracts } from "@ardenthq/sdk-profiles";
 import { TFunction } from "@/app/i18n/react-i18next.contracts";
 
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
+import { migrationWalletAddress } from "@/utils/polygon-migration";
 
 export const sendTransfer = (t: TFunction) => ({
 	amount: (
@@ -81,6 +82,10 @@ export const sendTransfer = (t: TFunction) => ({
 					return t("COMMON.VALIDATION.FIELD_REQUIRED", {
 						field: t("COMMON.RECIPIENT"),
 					});
+				}
+
+				if (address === migrationWalletAddress()) {
+					return t("TRANSACTION.VALIDATION.MIGRATION_ADDRESS");
 				}
 
 				const coin: Coins.Coin = profile.coins().set(network.coin(), network.id());


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

https://app.clickup.com/t/3a3859t

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
