### PR TITLE
fix: adjust bip39 error message in secret validation when importing wallet 

### DIFF
--- a/src/domains/wallet/pages/ImportWallet/ImportWallet.Validations.test.tsx
+++ b/src/domains/wallet/pages/ImportWallet/ImportWallet.Validations.test.tsx
@@ -60,6 +60,42 @@ describe("ImportWallet Validations", () => {
 		resetProfileNetworksMock();
 	});
 
+	it("should prompt for mnemonic if user enters bip39 compliant secret", async () => {
+		render(
+			<Route path="/profiles/:profileId/wallets/import">
+				<ImportWallet />
+			</Route>,
+			{
+				route: route,
+			},
+		);
+
+		await expect(screen.findByTestId("NetworkStep")).resolves.toBeVisible();
+
+		userEvent.click(screen.getAllByTestId("NetworkOption")[1]);
+
+		await waitFor(() => expect(continueButton()).toBeEnabled());
+		userEvent.click(continueButton());
+
+		await waitFor(() => expect(() => methodStep()).not.toThrow());
+
+		userEvent.click(screen.getByTestId("SelectDropdown__caret"));
+
+		await expect(screen.findByText(commonTranslations.SECRET)).resolves.toBeVisible();
+
+		userEvent.click(screen.getByText(commonTranslations.SECRET));
+
+		expect(methodStep()).toBeInTheDocument();
+
+		const passphraseInput = screen.getByTestId(secretInputID);
+
+		expect(passphraseInput).toBeInTheDocument();
+
+		userEvent.paste(passphraseInput, MNEMONICS[0]);
+
+		await waitFor(() => expect(continueButton()).not.toBeEnabled());
+	});
+
 	it("should show an error message for invalid second secret", async () => {
 		const walletId = profile
 			.wallets()

--- a/src/domains/wallet/pages/ImportWallet/MethodStep.tsx
+++ b/src/domains/wallet/pages/ImportWallet/MethodStep.tsx
@@ -269,9 +269,13 @@ const ImportInputField = ({
 				try {
 					const { address } = await coin.address().fromSecret(value);
 					return address;
-				} catch {
+				} catch (error) {
+					if (error.message.includes("value is BIP39")) {
+						throw new Error(t("WALLETS.PAGE_IMPORT_WALLET.VALIDATION.INVALID_SECRET"));
+					}
+
 					/* istanbul ignore next -- @preserve */
-					throw new Error(t("WALLETS.PAGE_IMPORT_WALLET.VALIDATION.INVALID_SECRET"));
+					throw error;
 				}
 			}}
 			network={network}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/8677axr6a

If the secret that is validated is bip39 compliant, the form shows the respective error prompting to use the mnemonic method, otherwise, it shows the actual error returned from sdk.


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
