### PR TITLE
fix: ensure profile avatar is always set when importing profile

### DIFF
--- a/src/domains/profile/pages/ImportProfile/ProfileFormStep.tsx
+++ b/src/domains/profile/pages/ImportProfile/ProfileFormStep.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Contracts, Environment } from "@ardenthq/sdk-profiles";
+import { Contracts, Environment, Helpers } from "@ardenthq/sdk-profiles";
 import { Divider } from "@/app/components/Divider";
 import { FilePreview } from "@/domains/profile/components/FilePreview";
 import { ProfileForm, ProfileFormState } from "@/domains/profile/components/ProfileForm";
@@ -46,6 +46,10 @@ export const ImportProfileForm: React.VFC<ImportProfileFormProperties> = ({
 		profile.settings().set(Contracts.ProfileSetting.Theme, viewingMode);
 		profile.settings().set(Contracts.ProfileSetting.Avatar, avatarImage);
 		profile.settings().set(Contracts.ProfileSetting.ExchangeCurrency, currency);
+
+		profile
+			.settings()
+			.set(Contracts.ProfileSetting.Avatar, avatarImage || Helpers.Avatar.make(profile.name().trim()));
 
 		if (enteredPassword || password) {
 			// @ts-ignore


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
