### PR TITLE
refactor: dont scan with use legacy for mainsail

### DIFF
--- a/src/app/contexts/Ledger/hooks/scanner.ts
+++ b/src/app/contexts/Ledger/hooks/scanner.ts
@@ -52,9 +52,10 @@ export const useLedgerScanner = (coin: string, network: string) => {
 				// @ts-ignore
 				const ledgerWallets = await instance.ledger().scan({ onProgress, startPath });
 
-				const legacyWallets = isLoadingMore
-					? {}
-					: await instance.ledger().scan({ onProgress, useLegacy: true });
+				const legacyWallets =
+					isLoadingMore || coin === "Mainsail"
+						? {}
+						: await instance.ledger().scan({ onProgress, useLegacy: true });
 
 				const allWallets = { ...legacyWallets, ...ledgerWallets };
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/86dt5v21x,
Depends on https://github.com/ArdentHQ/platform-sdk/pull/54

Removes the call with the useLegacy option for mainsail assuming is not needed

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
