### PR TITLE
refactor: hide username for validator resignation

### DIFF
--- a/src/domains/transaction/components/DelegateResignationDetail/DelegateResignationDetail.tsx
+++ b/src/domains/transaction/components/DelegateResignationDetail/DelegateResignationDetail.tsx
@@ -32,16 +32,18 @@ export const DelegateResignationDetail = ({ isOpen, transaction, onClose }: Tran
 		>
 			<TransactionSender address={transaction.sender()} network={transaction.wallet().network()} border={false} />
 
-			<TransactionDetail
-				label={selectDelegateValidatorTranslation({
-					delegateStr: t("TRANSACTION.DELEGATE_NAME"),
-					network: wallet.network(),
-					validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
-				})}
-				extra={<TransactionDelegateResignationIcon />}
-			>
-				{wallet.username()}
-			</TransactionDetail>
+			{wallet.username() && (
+				<TransactionDetail
+					label={selectDelegateValidatorTranslation({
+						delegateStr: t("TRANSACTION.DELEGATE_NAME"),
+						network: wallet.network(),
+						validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
+					})}
+					extra={<TransactionDelegateResignationIcon />}
+				>
+					{wallet.username()}
+				</TransactionDetail>
+			)}
 
 			<TransactionFee currency={wallet.currency()} value={transaction.fee()} />
 

--- a/src/domains/transaction/pages/SendDelegateResignation/FormStep.tsx
+++ b/src/domains/transaction/pages/SendDelegateResignation/FormStep.tsx
@@ -43,7 +43,7 @@ export const FormStep = ({ senderWallet, profile }: FormStepProperties) => {
 			<TransactionSender address={senderWallet.address()} network={senderWallet.network()} />
 
 			{
-				if(senderWallet.username()) && (<TransactionDetail label={selectDelegateValidatorTranslation({
+				senderWallet.username() && (<TransactionDetail label={selectDelegateValidatorTranslation({
 				delegateStr: t("TRANSACTION.DELEGATE_NAME"),
 				network: senderWallet.network(),
 				validatorStr: t("TRANSACTION.VALIDATOR_NAME"),

--- a/src/domains/transaction/pages/SendDelegateResignation/FormStep.tsx
+++ b/src/domains/transaction/pages/SendDelegateResignation/FormStep.tsx
@@ -42,16 +42,18 @@ export const FormStep = ({ senderWallet, profile }: FormStepProperties) => {
 
 			<TransactionSender address={senderWallet.address()} network={senderWallet.network()} />
 
-			{
-				senderWallet.username() && (<TransactionDetail label={selectDelegateValidatorTranslation({
-				delegateStr: t("TRANSACTION.DELEGATE_NAME"),
-				network: senderWallet.network(),
-				validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
-			})} borderPosition="both">
-				{senderWallet.username()}
-			</TransactionDetail>)
-			}
-
+			{senderWallet.username() && (
+				<TransactionDetail
+					label={selectDelegateValidatorTranslation({
+						delegateStr: t("TRANSACTION.DELEGATE_NAME"),
+						network: senderWallet.network(),
+						validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
+					})}
+					borderPosition="both"
+				>
+					{senderWallet.username()}
+				</TransactionDetail>
+			)}
 
 			<div className="pt-6">
 				<FormField name="fee">

--- a/src/domains/transaction/pages/SendDelegateResignation/FormStep.tsx
+++ b/src/domains/transaction/pages/SendDelegateResignation/FormStep.tsx
@@ -42,13 +42,16 @@ export const FormStep = ({ senderWallet, profile }: FormStepProperties) => {
 
 			<TransactionSender address={senderWallet.address()} network={senderWallet.network()} />
 
-			<TransactionDetail label={selectDelegateValidatorTranslation({
+			{
+				if(senderWallet.username()) && (<TransactionDetail label={selectDelegateValidatorTranslation({
 				delegateStr: t("TRANSACTION.DELEGATE_NAME"),
 				network: senderWallet.network(),
 				validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
 			})} borderPosition="both">
 				{senderWallet.username()}
-			</TransactionDetail>
+			</TransactionDetail>)
+			}
+
 
 			<div className="pt-6">
 				<FormField name="fee">

--- a/src/domains/transaction/pages/SendDelegateResignation/SummaryStep.tsx
+++ b/src/domains/transaction/pages/SendDelegateResignation/SummaryStep.tsx
@@ -16,13 +16,17 @@ export const SummaryStep = ({ senderWallet, transaction }: SummaryStepProperties
 
 	return (
 		<TransactionSuccessful transaction={transaction} senderWallet={senderWallet}>
-			<TransactionDetail label={selectDelegateValidatorTranslation({
-				delegateStr: t("TRANSACTION.DELEGATE_NAME"),
-				network: senderWallet.network(),
-				validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
-			})}>
-				{senderWallet.username()}
-			</TransactionDetail>
+			{senderWallet.username() && (
+				<TransactionDetail
+					label={selectDelegateValidatorTranslation({
+						delegateStr: t("TRANSACTION.DELEGATE_NAME"),
+						network: senderWallet.network(),
+						validatorStr: t("TRANSACTION.VALIDATOR_NAME"),
+					})}
+				>
+					{senderWallet.username()}
+				</TransactionDetail>
+			)}
 
 			<TransactionFee currency={senderWallet.currency()} value={transaction.fee()} paddingPosition="top" />
 		</TransactionSuccessful>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dt8x4q4

> since the resignation no longer has a username asset, we should hide this field on the mainsail networks where it doesn't exist

For Ark network addresses have to have a username to see the validator resignation step, so as a solution I hid the username field if username doesn't exist. 

When an address doesn't have a username:

![image](https://github.com/ArdentHQ/arkvault/assets/132887516/f7105380-f5ec-45c2-8b86-b9e57092ecf1)

When an address has a username:
![image](https://github.com/ArdentHQ/arkvault/assets/132887516/5b2f1b23-4ac0-47b8-8644-87ba2a93e9f1)


Detail:

![image](https://github.com/ArdentHQ/arkvault/assets/132887516/bc0e8cfc-40fb-4b41-9782-7205c0400bb8)

Resign Tx summary:

![image](https://github.com/ArdentHQ/arkvault/assets/132887516/25afdac6-9113-4bb7-a0c5-62803828063c)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
