### PR TITLE
fix: collapsible alert dark mode chevron color

### DIFF
--- a/src/app/components/Alert/Alert.styles.ts
+++ b/src/app/components/Alert/Alert.styles.ts
@@ -32,11 +32,11 @@ const getBodyVariant = (variant?: Color) => {
 };
 const getChevronVariant = (variant?: Color) => {
 	const variants = {
-		danger: () => tw`text-theme-danger-700`,
-		hint: () => tw`text-theme-hint-700`,
-		info: () => tw`text-theme-info-700`,
-		success: () => tw`text-theme-success-700`,
-		warning: () => tw`text-theme-warning-700`,
+		danger: () => tw`text-theme-danger-700 dark:text-white`,
+		hint: () => tw`text-theme-hint-700 dark:text-white`,
+		info: () => tw`text-theme-info-700 dark:text-white`,
+		success: () => tw`text-theme-success-700 dark:text-white`,
+		warning: () => tw`text-theme-warning-700 dark:text-white`,
 	};
 
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/app/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/app/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`Alert > should render as collapsible 1`] = `
         Warning
       </span>
       <span
-        class="css-1vsq8bq"
+        class="css-1j8xkwl"
         data-testid="Alert__chevron"
       >
         <div

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -2532,7 +2532,7 @@ exports[`ImportWallet > should render method step 1`] = `
             Need help with importing?
           </span>
           <span
-            class="css-hnyr3"
+            class="css-iuqies"
             data-testid="Alert__chevron"
           >
             <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes comment on https://app.clickup.com/t/86dt1nuk1

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
