### PR TITLE
refactor: adjust network param handling in delegate validation

### DIFF
--- a/src/app/hooks/use-validation.ts
+++ b/src/app/hooks/use-validation.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Networks } from "@ardenthq/sdk";
 import {
 	authentication,
 	common,
@@ -21,18 +20,16 @@ import { password } from "@/app/validations/password";
 import { receiveFunds } from "@/domains/wallet/validations";
 import { useEnvironmentContext } from "@/app/contexts";
 
-export const useValidation = (properties?: {
-	network?: Networks.Network;
-}) => {
+export const useValidation = () => {
 	const { t } = useTranslation();
 	const { env } = useEnvironmentContext();
-	
+
 	return useMemo(
 		() => ({
 			authentication: authentication(t),
 			common: common(t),
 			createProfile: createProfile(t, env),
-			delegateRegistration: delegateRegistration(t, properties?.network),
+			delegateRegistration: delegateRegistration(t),
 			exchangeOrder: exchangeOrder(t),
 			multiSignatureRegistration: multiSignatureRegistration(t),
 			network: network(t),
@@ -47,8 +44,7 @@ export const useValidation = (properties?: {
 			usernameRegistration: usernameRegistration(t),
 			validatorRegistration: validatorRegistration(t),
 			verifyMessage: verifyMessage(t),
-			
 		}),
-		[t, env, properties?.network],
+		[t, env],
 	);
 };

--- a/src/domains/transaction/components/DelegateRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/DelegateRegistrationForm/FormStep.tsx
@@ -1,9 +1,11 @@
-import { FormField, FormLabel } from "@/app/components/Form";
 import React, { ChangeEvent, useEffect, useMemo, useState } from "react";
+import { Contracts } from "@ardenthq/sdk-profiles";
+import { useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { FormField, FormLabel } from "@/app/components/Form";
 import { TransactionNetwork, TransactionSender } from "@/domains/transaction/components/TransactionDetail";
 
 import { Alert } from "@/app/components/Alert";
-import { Contracts } from "@ardenthq/sdk-profiles";
 import { FeeField } from "@/domains/transaction/components/FeeField";
 import { FormStepProperties } from "@/domains/transaction/pages/SendRegistration/SendRegistration.contracts";
 import { InputDefault } from "@/app/components/Input";
@@ -11,15 +13,13 @@ import { StepHeader } from "@/app/components/StepHeader";
 import { isMainsailNetwork } from "@/utils/network-utils";
 import { selectDelegateValidatorTranslation } from "@/domains/wallet/utils/selectDelegateValidatorTranslation";
 import { useEnvironmentContext } from "@/app/contexts";
-import { useFormContext } from "react-hook-form";
-import { useTranslation } from "react-i18next";
 import { useValidation } from "@/app/hooks";
 
 export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: FormStepProperties) => {
 	const { t } = useTranslation();
 	const { env } = useEnvironmentContext();
 
-	const { delegateRegistration, validatorRegistration } = useValidation({ network: wallet.network() });
+	const { delegateRegistration, validatorRegistration } = useValidation();
 
 	const { register, setValue, getValues } = useFormContext();
 	const { username, validatorPublicKey } = getValues(["username", "validatorPublicKey"]);

--- a/src/domains/transaction/validations/DelegateRegistration.ts
+++ b/src/domains/transaction/validations/DelegateRegistration.ts
@@ -1,39 +1,21 @@
-import { Networks } from "@ardenthq/sdk";
-import { selectDelegateValidatorTranslation } from "@/domains/wallet/utils/selectDelegateValidatorTranslation";
 import { validatePattern } from "@/utils/validations";
 
-export const delegateRegistration = (t: any, currentNetwork?: Networks.Network) => ({
-	username: (usernames: string[]) => {
-		if (currentNetwork === undefined) {
-			throw new Error(
-				"You need to provide a network to the `useValidation` hook to use the delegateRegistration.username validation.",
-			);
-		}
-
-		return {
-			maxLength: {
-				message: t("COMMON.VALIDATION.MAX_LENGTH", {
-					field: selectDelegateValidatorTranslation({
-						delegateStr: t("COMMON.DELEGATE_NAME"),
-						network: currentNetwork,
-						validatorStr: t("COMMON.VALIDATOR_NAME"),
-					}),
-					maxLength: 20,
-				}),
-				value: 20,
-			},
-			required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
-				field: selectDelegateValidatorTranslation({
-					delegateStr: t("COMMON.DELEGATE_NAME"),
-					network: currentNetwork,
-					validatorStr: t("COMMON.VALIDATOR_NAME"),
-				}),
+export const delegateRegistration = (t: any) => ({
+	username: (usernames: string[]) => ({
+		maxLength: {
+			message: t("COMMON.VALIDATION.MAX_LENGTH", {
+				field: t("COMMON.DELEGATE_NAME"),
+				maxLength: 20,
 			}),
-			validate: {
-				pattern: (value: string) => validatePattern(t, value, /[\d!$&.@_a-z]+/),
-				unique: (value: string) =>
-					!usernames.includes(value) || t("COMMON.VALIDATION.EXISTS", { field: t("COMMON.DELEGATE_NAME") }),
-			},
-		};
-	},
+			value: 20,
+		},
+		required: t("COMMON.VALIDATION.FIELD_REQUIRED", {
+			field: t("COMMON.DELEGATE_NAME"),
+		}),
+		validate: {
+			pattern: (value: string) => validatePattern(t, value, /[\d!$&.@_a-z]+/),
+			unique: (value: string) =>
+				!usernames.includes(value) || t("COMMON.VALIDATION.EXISTS", { field: t("COMMON.DELEGATE_NAME") }),
+		},
+	}),
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Additional adjustments for https://app.clickup.com/t/86dt8g7cu to resolve prop drilling for network parameter in delegate validation hook. Network parameter is only passed in `delegateRegistration.username()` where is needed.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
