### PR TITLE
fix: prevent sanitizing issues on currency input

### DIFF
--- a/src/app/components/Input/InputCurrency.tsx
+++ b/src/app/components/Input/InputCurrency.tsx
@@ -22,7 +22,7 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 
 		useEffect(() => {
 			// when value is changed outside, update amount as well
-			setAmount(sanitize(value?.toString()));
+			setAmount(sanitize(value?.toString(), 999));
 		}, [value]);
 
 		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/components/Input/InputCurrency.tsx
+++ b/src/app/components/Input/InputCurrency.tsx
@@ -22,14 +22,17 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 
 		useEffect(() => {
 			// when value is changed outside, update amount as well
-			setAmount(sanitize(value?.toString(), 999));
+			setAmount(sanitize(value?.toString()));
 		}, [value]);
 
 		const parseValue = (value: string, limitLength = true) => {
 			const sanitizedValue = sanitize(value, limitLength ? undefined : 999);
 
 			setAmount(sanitizedValue);
-			onChange?.(sanitizedValue);
+
+			if (value !== sanitizedValue) {
+				onChange?.(sanitizedValue);
+			}
 		};
 
 		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/app/components/Input/InputCurrency.tsx
+++ b/src/app/components/Input/InputCurrency.tsx
@@ -38,7 +38,7 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 		};
 
 		const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-			// parseValue(event.target.value);
+			parseValue(event.target.value);
 
 			onBlur?.(event);
 		};

--- a/src/app/components/Input/InputCurrency.tsx
+++ b/src/app/components/Input/InputCurrency.tsx
@@ -25,20 +25,22 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 			setAmount(sanitize(value?.toString()));
 		}, [value]);
 
-		const parseValue = (value: string, limitLength = true) => {
-			const sanitizedValue = sanitize(value, limitLength ? undefined : 999);
+		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+			const sanitizedValue = sanitize(event.target.value, 999);
 
 			setAmount(sanitizedValue);
 
 			onChange?.(sanitizedValue);
 		};
 
-		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-			parseValue(event.target.value, false);
-		};
-
 		const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-			parseValue(event.target.value);
+			const sanitizedValue = sanitize(event.target.value);
+
+			setAmount(sanitizedValue);
+
+			if (value !== sanitizedValue) {
+				onChange?.(sanitizedValue);
+			}
 
 			onBlur?.(event);
 		};

--- a/src/app/components/Input/InputCurrency.tsx
+++ b/src/app/components/Input/InputCurrency.tsx
@@ -14,22 +14,32 @@ type InputCurrencyProperties = {
 	noShadow?: boolean;
 } & Omit<React.InputHTMLAttributes<any>, "onChange" | "defaultValue">;
 
-const sanitize = (value?: string) => Currency.fromString(value || "").display;
+const sanitize = (value?: string, magnitude?: number) => Currency.fromString(value || "", magnitude).display;
 
 export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyProperties>(
-	({ onChange, value, ...properties }: InputCurrencyProperties, reference) => {
+	({ onChange, value, onBlur, ...properties }: InputCurrencyProperties, reference) => {
 		const [amount, setAmount] = useState<string>(sanitize(value?.toString()));
 
 		useEffect(() => {
 			// when value is changed outside, update amount as well
-			setAmount(sanitize(value?.toString()));
+			setAmount(sanitize(value?.toString(), 999));
 		}, [value]);
 
-		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-			const sanitizedValue = sanitize(event.target.value);
+		const parseValue = (value: string, limitLength = true) => {
+			const sanitizedValue = sanitize(value, limitLength ? undefined : 999);
 
 			setAmount(sanitizedValue);
 			onChange?.(sanitizedValue);
+		};
+
+		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+			parseValue(event.target.value, false);
+		};
+
+		const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+			parseValue(event.target.value);
+
+			onBlur?.(event);
 		};
 
 		return (
@@ -37,6 +47,7 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 				<Input
 					data-testid="InputCurrency"
 					onChange={handleInput}
+					onBlur={handleBlur}
 					ref={reference}
 					type="text"
 					value={amount}

--- a/src/app/components/Input/InputCurrency.tsx
+++ b/src/app/components/Input/InputCurrency.tsx
@@ -30,9 +30,7 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 
 			setAmount(sanitizedValue);
 
-			if (value !== sanitizedValue) {
-				onChange?.(sanitizedValue);
-			}
+			onChange?.(sanitizedValue);
 		};
 
 		const handleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +38,7 @@ export const InputCurrency = React.forwardRef<HTMLInputElement, InputCurrencyPro
 		};
 
 		const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-			parseValue(event.target.value);
+			// parseValue(event.target.value);
 
 			onBlur?.(event);
 		};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Issue described on ticket is caused by the value being sanitized while typing, the adjustment applies the decimals limit sanitization until input is blurred

Other than testing, ensure that this does not cause any side-effect on other places when the currency input is used

https://app.clickup.com/t/86dtace5v

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
