### PR TITLE
refactor: rename switch vote to vote swap

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowRecipientLabel.test.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowRecipientLabel.test.tsx
@@ -137,7 +137,7 @@ describe("TransactionRowRecipientLabel", () => {
 			expect(screen.getByTestId("TransactionRowVoteLabel")).toHaveTextContent("+1");
 		});
 
-		it("should show a switch vote label", () => {
+		it("should show a vote swap label", () => {
 			render(
 				<TransactionRowRecipientLabel
 					transaction={{

--- a/src/domains/transaction/i18n.ts
+++ b/src/domains/transaction/i18n.ts
@@ -378,7 +378,7 @@ export const translations = {
 		UNLOCK_TOKEN: "Unlock Balance",
 		UNVOTE: "Unvote",
 		VOTE: "Vote",
-		VOTE_COMBINATION: "Switch Vote",
+		VOTE_COMBINATION: "Vote Swap",
 	},
 
 	TYPE: "Type",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[General] rename "Switch Vote" to "Vote Swap"](https://app.clickup.com/t/86dtu5m7g)

## Summary

- The implementations of `Switch vote` have been renamed to `Vote swap`

<img width="1294" alt="image" src="https://github.com/ArdentHQ/arkvault/assets/55117912/acde3528-faf5-49f6-8f2c-6b7251f7faad">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
