### PR TITLE
chore: allow snapshots to update on failure

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,4 +1,4 @@
-name: Dependencies
+name: Snapshots
 
 on:
     workflow_dispatch:
@@ -43,6 +43,7 @@ jobs:
               run: pnpm rebuild
 
             - name: Update Snapshots
+              continue-on-error: true # Continue on error to allow the commit action to run
               run: pnpm test
 
             - uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adjusts the workflow to continue even on errors during the `pnpm test` step

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
