### PR TITLE
refactor: address search box

### DIFF
--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.contracts.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.contracts.tsx
@@ -12,4 +12,5 @@ export interface HeaderSearchBarProperties {
 	debounceTimeout?: number;
 	defaultQuery?: string;
 	resetFields?: boolean;
+	alwaysDisplayClearButton?: boolean;
 }

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
@@ -144,4 +144,23 @@ describe("HeaderSearchBar", () => {
 
 		expect(onSearch).toHaveBeenCalledWith("test");
 	});
+
+	it("should always show clear button", async () => {
+		render(<HeaderSearchBar alwaysDisplayClearButton />);
+
+		await userEvent.click(screen.getByRole("button"));
+
+		expect(screen.getByTestId("header-search-bar__reset")).toBeInTheDocument();
+		expect(screen.getByTestId("header-search-bar__reset-icon")).toHaveClass("w-4");
+		expect(screen.getByTestId("header-search-bar__reset")).toHaveClass("mr-4");
+	})
+
+	it("should not always show clear button by default", async () => {
+		render(<HeaderSearchBar />);
+
+		await userEvent.click(screen.getByRole("button"));
+
+		expect(screen.getByTestId("header-search-bar__reset-icon")).toHaveClass("w-0");
+		expect(screen.getByTestId("header-search-bar__reset")).not.toHaveClass("mr-4");
+	});
 });

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.test.tsx
@@ -153,7 +153,7 @@ describe("HeaderSearchBar", () => {
 		expect(screen.getByTestId("header-search-bar__reset")).toBeInTheDocument();
 		expect(screen.getByTestId("header-search-bar__reset-icon")).toHaveClass("w-4");
 		expect(screen.getByTestId("header-search-bar__reset")).toHaveClass("mr-4");
-	})
+	});
 
 	it("should not always show clear button by default", async () => {
 		render(<HeaderSearchBar />);

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -49,7 +49,6 @@ export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({
 			handleQueryReset();
 		}
 	}, [resetFields, handleQueryReset]);
-	console.log(alwaysDisplayClearButton);
 	return (
 		<div data-testid="HeaderSearchBar" className="-my-2" {...properties}>
 			<ControlButton

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -25,6 +25,7 @@ export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({
 	defaultQuery = "",
 	debounceTimeout = 500,
 	resetFields = false,
+	alwaysDisplayClearButton = false,
 	...properties
 }) => {
 	const { t } = useTranslation();
@@ -48,7 +49,7 @@ export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({
 			handleQueryReset();
 		}
 	}, [resetFields, handleQueryReset]);
-
+console.log(alwaysDisplayClearButton)
 	return (
 		<div data-testid="HeaderSearchBar" className="-my-2" {...properties}>
 			<ControlButton
@@ -68,7 +69,7 @@ export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({
 					data-testid="HeaderSearchBar__input"
 					ref={reference}
 					className={cn(
-						"absolute z-50 -mx-10 flex items-center rounded-lg bg-theme-background px-10 py-2.5 text-base shadow-xl",
+						"absolute z-50 -mx-10 flex items-center rounded-lg bg-theme-background px-6 py-2.5 text-base shadow-xl",
 						offsetClassName || "top-1/2 -translate-y-1/2",
 						{
 							"right-0": noToggleBorder,
@@ -85,18 +86,21 @@ export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({
 
 					<button
 						data-testid="header-search-bar__reset"
-						className={cn("transition-all duration-300 focus:outline-none", { "mr-4": query !== "" })}
+						className={cn("transition-all duration-300 focus:outline-none", { 
+							"mr-4": query !== "" || alwaysDisplayClearButton,
+						})}
 						onClick={handleQueryReset}
 						type="button"
 					>
 						<Icon
 							className={cn(
 								"text-theme-text transition-all duration-300",
-								{ "w-0": query === "" },
-								{ "w-4": query !== "" },
+								{ "w-0": query === "" && !alwaysDisplayClearButton },
+								{ "w-4": query !== "" || alwaysDisplayClearButton },
 							)}
 							name="Cross"
 							size="md"
+							data-testid="header-search-bar__reset-icon"
 						/>
 					</button>
 

--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -49,7 +49,7 @@ export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({
 			handleQueryReset();
 		}
 	}, [resetFields, handleQueryReset]);
-console.log(alwaysDisplayClearButton)
+	console.log(alwaysDisplayClearButton);
 	return (
 		<div data-testid="HeaderSearchBar" className="-my-2" {...properties}>
 			<ControlButton
@@ -86,7 +86,7 @@ console.log(alwaysDisplayClearButton)
 
 					<button
 						data-testid="header-search-bar__reset"
-						className={cn("transition-all duration-300 focus:outline-none", { 
+						className={cn("transition-all duration-300 focus:outline-none", {
 							"mr-4": query !== "" || alwaysDisplayClearButton,
 						})}
 						onClick={handleQueryReset}

--- a/src/domains/transaction/components/SearchRecipient/SearchRecipient.tsx
+++ b/src/domains/transaction/components/SearchRecipient/SearchRecipient.tsx
@@ -168,6 +168,7 @@ export const SearchRecipient: FC<SearchRecipientProperties> = ({
 						onReset={() => setSearchKeyword("")}
 						debounceTimeout={100}
 						noToggleBorder
+						alwaysDisplayClearButton
 					/>
 				),
 				accessor: "id",

--- a/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
+++ b/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
@@ -189,11 +189,12 @@ export const SearchWallet: FC<SearchWalletProperties> = ({
 					Header: (
 						<HeaderSearchBar
 							placeholder={searchPlaceholder}
-							offsetClassName="top-1/3 -translate-y-16 -translate-x-6"
+							offsetClassName="top-1/3 -translate-y-8 -translate-x-6"
 							onSearch={setSearchKeyword}
 							onReset={() => setSearchKeyword("")}
 							debounceTimeout={100}
 							noToggleBorder
+							alwaysDisplayClearButton
 						/>
 					),
 					accessor: "search",
@@ -209,11 +210,12 @@ export const SearchWallet: FC<SearchWalletProperties> = ({
 				Header: (
 					<HeaderSearchBar
 						placeholder={searchPlaceholder}
-						offsetClassName="top-1/3 -translate-y-16 -translate-x-6"
+						offsetClassName="top-1/3 -translate-y-8 -translate-x-6"
 						onSearch={setSearchKeyword}
 						onReset={() => setSearchKeyword("")}
 						debounceTimeout={100}
 						noToggleBorder
+						alwaysDisplayClearButton
 					/>
 				),
 				accessor: "search",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[select Sender/Recipient] Search box should contain 'X' at all times](https://app.clickup.com/t/86ductpne)

## Summary

- `HeaderSearchBar` component has been refactored and now supports the option to always display the `clear` button.
- Recipient and Sender search bars have been updated to always display this button ignoring if they have content or not.
- Styles for the search bar have been updated.

<img width="844" alt="image" src="https://github.com/user-attachments/assets/4dac27c1-2c73-4512-b507-a39c4fe1fa2c">

<img width="841" alt="image" src="https://github.com/user-attachments/assets/0a995e5d-6b62-4be3-9697-ccbab13b5a32">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
