### PR TITLE
fix: long memo overflow

### DIFF
--- a/src/app/components/DetailWrapper/DetailWrapper.tsx
+++ b/src/app/components/DetailWrapper/DetailWrapper.tsx
@@ -37,7 +37,7 @@ export const DetailWrapper = ({
 		{label && <DetailLabel>{label}</DetailLabel>}
 		<div
 			className={cn(
-				"w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words",
+				"w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5",
 				{
 					"mt-0 sm:mt-2": !!label,
 				},

--- a/src/app/components/DetailWrapper/DetailWrapper.tsx
+++ b/src/app/components/DetailWrapper/DetailWrapper.tsx
@@ -37,7 +37,7 @@ export const DetailWrapper = ({
 		{label && <DetailLabel>{label}</DetailLabel>}
 		<div
 			className={cn(
-				"w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5",
+				"w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words",
 				{
 					"mt-0 sm:mt-2": !!label,
 				},

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/LedgerReview.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/LedgerReview.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`TransferLedgerReview > should render 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         <div
           class="flex w-full"
@@ -151,7 +151,7 @@ exports[`TransferLedgerReview > should render 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         123
       </div>
@@ -275,7 +275,7 @@ exports[`TransferLedgerReview > should render skeleton while loading expiration 
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         <div
           class="flex w-full"
@@ -406,7 +406,7 @@ exports[`TransferLedgerReview > should render skeleton while loading expiration 
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         <span
           class="my-0.5 flex"
@@ -547,7 +547,7 @@ exports[`TransferLedgerReview > should render with memo 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         <div
           class="flex w-full"
@@ -641,7 +641,7 @@ exports[`TransferLedgerReview > should render with memo 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         <p
           data-testid="TransactionMemo"
@@ -702,7 +702,7 @@ exports[`TransferLedgerReview > should render with memo 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+        class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
       >
         123
       </div>

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/LedgerReview.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/LedgerReview.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`TransferLedgerReview > should render 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         <div
           class="flex w-full"
@@ -151,7 +151,7 @@ exports[`TransferLedgerReview > should render 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         123
       </div>
@@ -275,7 +275,7 @@ exports[`TransferLedgerReview > should render skeleton while loading expiration 
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         <div
           class="flex w-full"
@@ -406,7 +406,7 @@ exports[`TransferLedgerReview > should render skeleton while loading expiration 
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         <span
           class="my-0.5 flex"
@@ -547,7 +547,7 @@ exports[`TransferLedgerReview > should render with memo 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         <div
           class="flex w-full"
@@ -641,7 +641,7 @@ exports[`TransferLedgerReview > should render with memo 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         <p
           data-testid="TransactionMemo"
@@ -702,7 +702,7 @@ exports[`TransferLedgerReview > should render with memo 1`] = `
         </div>
       </div>
       <div
-        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+        class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
       >
         123
       </div>

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -11797,7 +11797,7 @@ exports[`SendTransfer > should render review step 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="flex w-full"
@@ -11958,7 +11958,7 @@ exports[`SendTransfer > should render review step 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <p>
             test memo
@@ -12225,7 +12225,7 @@ exports[`SendTransfer > should render review step with multiple recipients (with
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="flex w-full"
@@ -12431,7 +12431,7 @@ exports[`SendTransfer > should render review step with multiple recipients (with
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <p>
             memo
@@ -12698,7 +12698,7 @@ exports[`SendTransfer > should render review step with multiple recipients (with
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="flex w-full"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -11797,7 +11797,7 @@ exports[`SendTransfer > should render review step 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="flex w-full"
@@ -11958,7 +11958,7 @@ exports[`SendTransfer > should render review step 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <p>
             test memo
@@ -12225,7 +12225,7 @@ exports[`SendTransfer > should render review step with multiple recipients (with
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="flex w-full"
@@ -12431,7 +12431,7 @@ exports[`SendTransfer > should render review step with multiple recipients (with
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <p>
             memo
@@ -12698,7 +12698,7 @@ exports[`SendTransfer > should render review step with multiple recipients (with
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="flex w-full"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -3350,7 +3350,7 @@ exports[`ImportWallet > should render success step (lg) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="mb-3 flex w-full items-center justify-between leading-5 sm:mb-0 sm:justify-start"
@@ -3451,7 +3451,7 @@ exports[`ImportWallet > should render success step (lg) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="flex w-full items-center justify-between sm:justify-start"
@@ -3614,7 +3614,7 @@ exports[`ImportWallet > should render success step (xs) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="mb-3 flex w-full items-center justify-between leading-5 sm:mb-0 sm:justify-start"
@@ -3715,7 +3715,7 @@ exports[`ImportWallet > should render success step (xs) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
+          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
         >
           <div
             class="flex w-full items-center justify-between sm:justify-start"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -3350,7 +3350,7 @@ exports[`ImportWallet > should render success step (lg) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="mb-3 flex w-full items-center justify-between leading-5 sm:mb-0 sm:justify-start"
@@ -3451,7 +3451,7 @@ exports[`ImportWallet > should render success step (lg) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="flex w-full items-center justify-between sm:justify-start"
@@ -3614,7 +3614,7 @@ exports[`ImportWallet > should render success step (xs) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="mb-3 flex w-full items-center justify-between leading-5 sm:mb-0 sm:justify-start"
@@ -3715,7 +3715,7 @@ exports[`ImportWallet > should render success step (xs) 1`] = `
           </div>
         </div>
         <div
-          class="w-full rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 break-words mt-0 sm:mt-2"
+          class="w-full break-words rounded-lg border-theme-secondary-300 p-3 dark:border-theme-secondary-800 sm:border sm:px-6 sm:py-5 mt-0 sm:mt-2"
         >
           <div
             class="flex w-full items-center justify-between sm:justify-start"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction review] long memo overflow](https://app.clickup.com/t/86duct04d)

## Summary

- Long memos will now break into multiple lines instead of overflowing the texts.
- Snapshots for UTs have been updated.

<img width="1416" alt="image" src="https://github.com/user-attachments/assets/b3d44b0a-5c43-45b9-85fa-bf54f4bf0946">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
