### PR TITLE
refactor: ledger tables padding

### DIFF
--- a/src/app/components/Table/TableWrapper.tsx
+++ b/src/app/components/Table/TableWrapper.tsx
@@ -4,7 +4,7 @@ import cn from "classnames";
 export const TableWrapper = ({ className, children }: { className?: string; children: React.ReactNode }) => (
 	<div
 		className={cn(
-			"hidden rounded-xl outline outline-1 outline-transparent sm:block md:outline-theme-secondary-300 dark:md:outline-theme-secondary-800 border-transparent md:border-b-[5px] md:border-b-theme-secondary-200 dark:md:border-theme-secondary-800",
+			"hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800",
 			className,
 		)}
 		data-testid="TableWrapper"

--- a/src/app/components/Table/TableWrapper.tsx
+++ b/src/app/components/Table/TableWrapper.tsx
@@ -4,7 +4,7 @@ import cn from "classnames";
 export const TableWrapper = ({ className, children }: { className?: string; children: React.ReactNode }) => (
 	<div
 		className={cn(
-			"rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800",
+			"hidden rounded-xl outline outline-1 outline-transparent sm:block md:outline-theme-secondary-300 dark:md:outline-theme-secondary-800 border-transparent md:border-b-[5px] md:border-b-theme-secondary-200 dark:md:border-theme-secondary-800",
 			className,
 		)}
 		data-testid="TableWrapper"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div
@@ -1203,7 +1203,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div
@@ -2400,7 +2400,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div
@@ -3597,7 +3597,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div
@@ -4794,7 +4794,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div
@@ -5991,7 +5991,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div
@@ -6763,7 +6763,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
     data-testid="ExchangeTransactionsTable"
   >
     <div
-      class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+      class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
       data-testid="TableWrapper"
     >
       <div

--- a/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
+++ b/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
@@ -19,6 +19,7 @@ import { Balance, ReceiverItemMobile } from "@/app/components/WalletListItem/Wal
 import { Tooltip } from "@/app/components/Tooltip";
 import { isLedgerWalletCompatible } from "@/utils/wallet-utils";
 import { TruncateMiddleDynamic } from "@/app/components/TruncateMiddleDynamic";
+import { TableWrapper } from "@/app/components/Table/TableWrapper";
 
 const SearchWalletListItem = ({
 	index,
@@ -67,7 +68,7 @@ const SearchWalletListItem = ({
 	};
 
 	return (
-		<TableRow>
+		<TableRow className="relative">
 			<TableCell isCompact={isCompact} variant="start" innerClassName="space-x-4" className="w-full">
 				<Address walletName={alias} address={wallet.address()} truncateOnTable />
 			</TableCell>
@@ -299,11 +300,12 @@ export const SearchWallet: FC<SearchWalletProperties> = ({
 					/>
 				)}
 
-				<div className="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800">
+				<TableWrapper>
 					<Table
 						columns={columns}
 						data={filteredWallets as Contracts.IReadWriteWallet[]}
 						hideHeader={useResponsive}
+						className="with-x-padding"
 					>
 						{renderTableRow}
 					</Table>
@@ -315,7 +317,7 @@ export const SearchWallet: FC<SearchWalletProperties> = ({
 							subtitle={t("COMMON.EMPTY_RESULTS.SUBTITLE")}
 						/>
 					)}
-				</div>
+				</TableWrapper>
 			</div>
 		</Modal>
 	);

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -74,10 +74,11 @@ exports[`SearchWallet uses fiat value = false > should render 1`] = `
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -272,7 +273,7 @@ exports[`SearchWallet uses fiat value = false > should render 1`] = `
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -344,7 +345,7 @@ exports[`SearchWallet uses fiat value = false > should render 1`] = `
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -502,10 +503,11 @@ exports[`SearchWallet uses fiat value = false > should render compact on md scre
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -700,7 +702,7 @@ exports[`SearchWallet uses fiat value = false > should render compact on md scre
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -772,7 +774,7 @@ exports[`SearchWallet uses fiat value = false > should render compact on md scre
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -930,10 +932,11 @@ exports[`SearchWallet uses fiat value = false > should render compact with selec
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -1128,7 +1131,7 @@ exports[`SearchWallet uses fiat value = false > should render compact with selec
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -1198,7 +1201,7 @@ exports[`SearchWallet uses fiat value = false > should render compact with selec
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -1356,10 +1359,11 @@ exports[`SearchWallet uses fiat value = false > should render expanded on > md s
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -1554,7 +1558,7 @@ exports[`SearchWallet uses fiat value = false > should render expanded on > md s
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -1626,7 +1630,7 @@ exports[`SearchWallet uses fiat value = false > should render expanded on > md s
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -1894,10 +1898,11 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 1`
                 </div>
               </div>
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -2208,10 +2213,11 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 2`
                 </div>
               </div>
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -2522,10 +2528,11 @@ exports[`SearchWallet uses fiat value = false > should render responsive with se
                 </div>
               </div>
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -2726,10 +2733,11 @@ exports[`SearchWallet uses fiat value = false > should render with incompatible 
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -2924,7 +2932,7 @@ exports[`SearchWallet uses fiat value = false > should render with incompatible 
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -3072,10 +3080,11 @@ exports[`SearchWallet uses fiat value = false > should render with selected addr
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -3270,7 +3279,7 @@ exports[`SearchWallet uses fiat value = false > should render with selected addr
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -3340,7 +3349,7 @@ exports[`SearchWallet uses fiat value = false > should render with selected addr
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -3498,10 +3507,11 @@ exports[`SearchWallet uses fiat value = false > should render with the default e
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -3696,7 +3706,7 @@ exports[`SearchWallet uses fiat value = false > should render with the default e
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -3768,7 +3778,7 @@ exports[`SearchWallet uses fiat value = false > should render with the default e
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -3926,10 +3936,11 @@ exports[`SearchWallet uses fiat value = true > should render 1`] = `
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -4170,7 +4181,7 @@ exports[`SearchWallet uses fiat value = true > should render 1`] = `
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -4256,7 +4267,7 @@ exports[`SearchWallet uses fiat value = true > should render 1`] = `
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -4428,10 +4439,11 @@ exports[`SearchWallet uses fiat value = true > should render compact on md scree
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -4672,7 +4684,7 @@ exports[`SearchWallet uses fiat value = true > should render compact on md scree
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -4758,7 +4770,7 @@ exports[`SearchWallet uses fiat value = true > should render compact on md scree
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -4930,10 +4942,11 @@ exports[`SearchWallet uses fiat value = true > should render compact with select
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -5174,7 +5187,7 @@ exports[`SearchWallet uses fiat value = true > should render compact with select
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -5258,7 +5271,7 @@ exports[`SearchWallet uses fiat value = true > should render compact with select
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -5430,10 +5443,11 @@ exports[`SearchWallet uses fiat value = true > should render expanded on > md sc
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -5674,7 +5688,7 @@ exports[`SearchWallet uses fiat value = true > should render expanded on > md sc
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -5760,7 +5774,7 @@ exports[`SearchWallet uses fiat value = true > should render expanded on > md sc
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -6042,10 +6056,11 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 1`]
                 </div>
               </div>
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -6356,10 +6371,11 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 2`]
                 </div>
               </div>
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -6670,10 +6686,11 @@ exports[`SearchWallet uses fiat value = true > should render responsive with sel
                 </div>
               </div>
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -6874,10 +6891,11 @@ exports[`SearchWallet uses fiat value = true > should render with incompatible l
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -7118,7 +7136,7 @@ exports[`SearchWallet uses fiat value = true > should render with incompatible l
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -7280,10 +7298,11 @@ exports[`SearchWallet uses fiat value = true > should render with selected addre
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -7524,7 +7543,7 @@ exports[`SearchWallet uses fiat value = true > should render with selected addre
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -7608,7 +7627,7 @@ exports[`SearchWallet uses fiat value = true > should render with selected addre
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -7780,10 +7799,11 @@ exports[`SearchWallet uses fiat value = true > should render with the default ex
               class="mt-4"
             >
               <div
-                class="rounded-xl border border-b-[5px] border-transparent md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+                class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800"
+                data-testid="TableWrapper"
               >
                 <div
-                  class="css-1m6rt2i"
+                  class="with-x-padding css-1m6rt2i"
                   role="table"
                 >
                   <table
@@ -8024,7 +8044,7 @@ exports[`SearchWallet uses fiat value = true > should render with the default ex
                       role="rowgroup"
                     >
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td
@@ -8110,7 +8130,7 @@ exports[`SearchWallet uses fiat value = true > should render with the default ex
                         </td>
                       </tr>
                       <tr
-                        class=" css-16ynu5g"
+                        class="relative css-16ynu5g"
                         data-testid="TableRow"
                       >
                         <td

--- a/src/domains/wallet/pages/ImportWallet/Ledger/LedgerImportStep.tsx
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/LedgerImportStep.tsx
@@ -15,6 +15,7 @@ import { ImportedLedgerMobileItem, SectionHeaderMobile, SingleImport } from "./L
 import { Table, TableCell, TableRow } from "@/app/components/Table";
 import { Column } from "react-table";
 import { AmountWrapper } from "./LedgerScanStep.blocks";
+import { TableWrapper } from "@/app/components/Table/TableWrapper";
 
 const MultipleImport = ({
 	network,
@@ -57,7 +58,7 @@ const MultipleImport = ({
 			assertWallet(importedWallet);
 
 			return (
-				<TableRow>
+				<TableRow className="relative">
 					<TableCell variant="start" innerClassName="justify-center" isCompact={isCompact}>
 						<div className="flex flex-1 flex-col py-2">
 							<Address
@@ -116,13 +117,11 @@ const MultipleImport = ({
 					})}
 				</div>
 			) : (
-				<div className="hidden rounded-xl border border-transparent sm:block md:border-theme-secondary-300 dark:md:border-theme-secondary-800">
-					<div>
-						<Table columns={columns} data={data}>
-							{renderTableRow}
-						</Table>
-					</div>
-				</div>
+				<TableWrapper className="md:border-b-0">
+					<Table columns={columns} data={data} className="with-x-padding">
+						{renderTableRow}
+					</Table>
+				</TableWrapper>
 			)}
 		</div>
 	);

--- a/src/domains/wallet/pages/ImportWallet/Ledger/LedgerScanStep.tsx
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/LedgerScanStep.tsx
@@ -87,7 +87,7 @@ export const LedgerTable: FC<LedgerTableProperties> = ({
 		(wallet: LedgerData) => {
 			if (showSkeleton) {
 				return (
-					<TableRow>
+					<TableRow className="relative">
 						<TableCell variant="start" isCompact={isCompact}>
 							<Skeleton height={20} width={20} />
 						</TableCell>
@@ -105,7 +105,7 @@ export const LedgerTable: FC<LedgerTableProperties> = ({
 			}
 
 			return (
-				<TableRow isSelected={isSelected(wallet.path)}>
+				<TableRow isSelected={isSelected(wallet.path)} className="relative">
 					<TableCell variant="start" innerClassName="justify-center" isCompact={isCompact}>
 						<Checkbox
 							checked={isSelected(wallet.path)}
@@ -140,7 +140,7 @@ export const LedgerTable: FC<LedgerTableProperties> = ({
 		<div>
 			<div className="hidden rounded-xl border border-transparent sm:block md:border-theme-secondary-300 dark:md:border-theme-secondary-800">
 				<div>
-					<Table columns={columns} data={showAll ? data : data.slice(0, 6)}>
+					<Table columns={columns} data={showAll ? data : data.slice(0, 6)} className="with-x-padding">
 						{renderTableRow}
 					</Table>
 				</div>

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
@@ -452,373 +452,372 @@ exports[`LedgerImportStep > should render with multiple import 2`] = `
         </div>
       </div>
       <div
-        class="hidden rounded-xl border border-transparent sm:block md:border-theme-secondary-300 dark:md:border-theme-secondary-800"
+        class="hidden rounded-xl border-transparent outline outline-1 outline-transparent sm:block md:border-b-[5px] md:border-b-theme-secondary-200 md:outline-theme-secondary-300 dark:md:border-theme-secondary-800 dark:md:outline-theme-secondary-800 md:border-b-0"
+        data-testid="TableWrapper"
       >
-        <div>
-          <div
-            class="css-1m6rt2i"
-            role="table"
+        <div
+          class="with-x-padding css-1m6rt2i"
+          role="table"
+        >
+          <table
+            cellpadding="0"
+            class="w-full table-auto"
           >
-            <table
-              cellpadding="0"
-              class="w-full table-auto"
-            >
-              <thead>
-                <tr
-                  role="row"
-                >
-                  <th
-                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800 first:rounded-tl-table last:rounded-tr-table no-border"
-                    colspan="1"
-                    data-testid="table__th--0"
-                    role="columnheader"
-                    style="cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    <div
-                      class="flex flex-inline align-top"
-                    >
-                      <div
-                        class=""
-                      >
-                        Address
-                      </div>
-                      <div
-                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
-                      >
-                        <div
-                          class="transition-transform rotate-180 css-15txs7d"
-                          height="10"
-                          role="img"
-                          width="10"
-                        >
-                          <svg
-                            id="chevron-down-small"
-                            viewBox="0 0 10 10"
-                            x="0"
-                            xml:space="preserve"
-                            xmlns="http://www.w3.org/2000/svg"
-                            y="0"
-                          >
-                            <path
-                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </th>
-                  <th
-                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800 first:rounded-tl-table last:rounded-tr-table no-border"
-                    colspan="1"
-                    data-testid="table__th--1"
-                    role="columnheader"
-                    style="cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    <div
-                      class="flex flex-inline align-top justify-end flex-row-reverse"
-                    >
-                      <div
-                        class=""
-                      >
-                        Edit Name
-                      </div>
-                      <div
-                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
-                      >
-                        <div
-                          class="transition-transform rotate-180 css-15txs7d"
-                          height="10"
-                          role="img"
-                          width="10"
-                        >
-                          <svg
-                            id="chevron-down-small"
-                            viewBox="0 0 10 10"
-                            x="0"
-                            xml:space="preserve"
-                            xmlns="http://www.w3.org/2000/svg"
-                            y="0"
-                          >
-                            <path
-                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                            />
-                          </svg>
-                        </div>
-                      </div>
-                    </div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                role="rowgroup"
+            <thead>
+              <tr
+                role="row"
               >
-                <tr
-                  class=" css-16ynu5g"
-                  data-testid="TableRow"
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800 first:rounded-tl-table last:rounded-tr-table no-border"
+                  colspan="1"
+                  data-testid="table__th--0"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
                 >
-                  <td>
+                  <div
+                    class="flex flex-inline align-top"
+                  >
                     <div
-                      class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pl-6 rounded-l-xl justify-center"
+                      class=""
+                    >
+                      Address
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
                     >
                       <div
-                        class="flex flex-1 flex-col py-2"
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
                       >
-                        <div
-                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
                         >
-                          <span
-                            class="font-semibold text-base text-theme-text"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures css-9nx3be"
-                              data-testid="TruncateEnd"
-                            >
-                              ARK Devnet #3
-                            </span>
-                          </span>
-                          <div
-                            class="relative grow text-left"
-                          >
-                            <span
-                              class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-500 dark:text-theme-secondary-700 font-semibold text-base absolute w-full"
-                              data-testid="Address__address"
-                            >
-                              DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq
-                            </span>
-                            <span>
-                               
-                            </span>
-                          </div>
-                          <button
-                            class="ring-focus relative focus:outline-none"
-                            data-ring-focus-margin="-m-1"
-                            data-testid="clipboard-icon__wrapper"
-                            type="button"
-                          >
-                            <div
-                              class="text-theme-primary-400 dark:text-theme-secondary-700 dark:hover:text-theme-secondary-500 css-v0ob3f"
-                              height="16"
-                              width="16"
-                            >
-                              <svg
-                                id="copy"
-                                viewBox="0 0 20 20"
-                                x="0"
-                                xml:space="preserve"
-                                xmlns="http://www.w3.org/2000/svg"
-                                y="0"
-                              >
-                                <g
-                                  fill="none"
-                                  stroke="currentColor"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                >
-                                  <path
-                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
-                                  />
-                                  <path
-                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
-                                  />
-                                </g>
-                              </svg>
-                            </div>
-                          </button>
-                        </div>
-                        <div>
-                          <span
-                            class="whitespace-nowrap text-sm font-semibold text-theme-secondary-700 dark:text-theme-secondary-500"
-                            data-testid="Amount"
-                          >
-                            0 DARK
-                          </span>
-                        </div>
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
                       </div>
                     </div>
-                  </td>
-                  <td>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800 first:rounded-tl-table last:rounded-tr-table no-border"
+                  colspan="1"
+                  data-testid="table__th--1"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-end flex-row-reverse"
+                  >
                     <div
-                      class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pr-6 rounded-r-xl justify-end font-semibold"
+                      class=""
                     >
-                      <button
-                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white"
-                        data-testid="LedgerImportStep__edit-alias"
-                        type="button"
+                      Edit Name
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
                       >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              role="rowgroup"
+            >
+              <tr
+                class="relative css-16ynu5g"
+                data-testid="TableRow"
+              >
+                <td>
+                  <div
+                    class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pl-6 rounded-l-xl justify-center"
+                  >
+                    <div
+                      class="flex flex-1 flex-col py-2"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-theme-text"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Devnet #3
+                          </span>
+                        </span>
                         <div
-                          class="flex items-center space-x-2"
+                          class="relative grow text-left"
+                        >
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-500 dark:text-theme-secondary-700 font-semibold text-base absolute w-full"
+                            data-testid="Address__address"
+                          >
+                            DJpFwW39QnQvQRQJF2MCfAoKvsX4DJ28jq
+                          </span>
+                          <span>
+                             
+                          </span>
+                        </div>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
                         >
                           <div
-                            class="css-1cn0px"
-                            height="14"
-                            width="14"
+                            class="text-theme-primary-400 dark:text-theme-secondary-700 dark:hover:text-theme-secondary-500 css-v0ob3f"
+                            height="16"
+                            width="16"
                           >
                             <svg
-                              id="pencil"
+                              id="copy"
                               viewBox="0 0 20 20"
                               x="0"
                               xml:space="preserve"
                               xmlns="http://www.w3.org/2000/svg"
                               y="0"
                             >
-                              <path
-                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                              <g
                                 fill="none"
                                 stroke="currentColor"
                                 stroke-linecap="round"
                                 stroke-linejoin="round"
                                 stroke-width="2"
-                              />
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
                             </svg>
                           </div>
-                        </div>
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class=" css-16ynu5g"
-                  data-testid="TableRow"
-                >
-                  <td>
-                    <div
-                      class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pl-6 rounded-l-xl justify-center"
-                    >
-                      <div
-                        class="flex flex-1 flex-col py-2"
-                      >
-                        <div
-                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        </button>
+                      </div>
+                      <div>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold text-theme-secondary-700 dark:text-theme-secondary-500"
+                          data-testid="Amount"
                         >
-                          <span
-                            class="font-semibold text-base text-theme-text"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures css-9nx3be"
-                              data-testid="TruncateEnd"
-                            >
-                              ARK Devnet #4
-                            </span>
-                          </span>
-                          <div
-                            class="relative grow text-left"
-                          >
-                            <span
-                              class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-500 dark:text-theme-secondary-700 font-semibold text-base absolute w-full"
-                              data-testid="Address__address"
-                            >
-                              DRgF3PvzeGWndQjET7dZsSmnrc6uAy23ES
-                            </span>
-                            <span>
-                               
-                            </span>
-                          </div>
-                          <button
-                            class="ring-focus relative focus:outline-none"
-                            data-ring-focus-margin="-m-1"
-                            data-testid="clipboard-icon__wrapper"
-                            type="button"
-                          >
-                            <div
-                              class="text-theme-primary-400 dark:text-theme-secondary-700 dark:hover:text-theme-secondary-500 css-v0ob3f"
-                              height="16"
-                              width="16"
-                            >
-                              <svg
-                                id="copy"
-                                viewBox="0 0 20 20"
-                                x="0"
-                                xml:space="preserve"
-                                xmlns="http://www.w3.org/2000/svg"
-                                y="0"
-                              >
-                                <g
-                                  fill="none"
-                                  stroke="currentColor"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                >
-                                  <path
-                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
-                                  />
-                                  <path
-                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
-                                  />
-                                </g>
-                              </svg>
-                            </div>
-                          </button>
-                        </div>
-                        <div>
-                          <span
-                            class="whitespace-nowrap text-sm font-semibold text-theme-secondary-700 dark:text-theme-secondary-500"
-                            data-testid="Amount"
-                          >
-                            0 DARK
-                          </span>
-                        </div>
+                          0 DARK
+                        </span>
                       </div>
                     </div>
-                  </td>
-                  <td>
-                    <div
-                      class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pr-6 rounded-r-xl justify-end font-semibold"
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pr-6 rounded-r-xl justify-end font-semibold"
+                  >
+                    <button
+                      class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white"
+                      data-testid="LedgerImportStep__edit-alias"
+                      type="button"
                     >
-                      <button
-                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white"
-                        data-testid="LedgerImportStep__edit-alias"
-                        type="button"
+                      <div
+                        class="flex items-center space-x-2"
                       >
                         <div
-                          class="flex items-center space-x-2"
+                          class="css-1cn0px"
+                          height="14"
+                          width="14"
+                        >
+                          <svg
+                            id="pencil"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="relative css-16ynu5g"
+                data-testid="TableRow"
+              >
+                <td>
+                  <div
+                    class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pl-6 rounded-l-xl justify-center"
+                  >
+                    <div
+                      class="flex flex-1 flex-col py-2"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-theme-text"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Devnet #4
+                          </span>
+                        </span>
+                        <div
+                          class="relative grow text-left"
+                        >
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-500 dark:text-theme-secondary-700 font-semibold text-base absolute w-full"
+                            data-testid="Address__address"
+                          >
+                            DRgF3PvzeGWndQjET7dZsSmnrc6uAy23ES
+                          </span>
+                          <span>
+                             
+                          </span>
+                        </div>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
                         >
                           <div
-                            class="css-1cn0px"
-                            height="14"
-                            width="14"
+                            class="text-theme-primary-400 dark:text-theme-secondary-700 dark:hover:text-theme-secondary-500 css-v0ob3f"
+                            height="16"
+                            width="16"
                           >
                             <svg
-                              id="pencil"
+                              id="copy"
                               viewBox="0 0 20 20"
                               x="0"
                               xml:space="preserve"
                               xmlns="http://www.w3.org/2000/svg"
                               y="0"
                             >
-                              <path
-                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                              <g
                                 fill="none"
                                 stroke="currentColor"
                                 stroke-linecap="round"
                                 stroke-linejoin="round"
                                 stroke-width="2"
-                              />
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
                             </svg>
                           </div>
-                        </div>
-                      </button>
+                        </button>
+                      </div>
+                      <div>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold text-theme-secondary-700 dark:text-theme-secondary-500"
+                          data-testid="Amount"
+                        >
+                          0 DARK
+                        </span>
+                      </div>
                     </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex items-center px-3 my-1 transition-colors duration-100 min-h-11 pr-6 rounded-r-xl justify-end font-semibold"
+                  >
+                    <button
+                      class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white"
+                      data-testid="LedgerImportStep__edit-alias"
+                      type="button"
+                    >
+                      <div
+                        class="flex items-center space-x-2"
+                      >
+                        <div
+                          class="css-1cn0px"
+                          height="14"
+                          width="14"
+                        >
+                          <svg
+                            id="pencil"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[ledger] adjust paddings and borders in import tables](https://app.clickup.com/t/86duj742z)

## Summary

- Table padding and borders have been refactored to match the new designs.
- `TableWrapper` styles have been refactored.

## Screenshots

- Skeleton scan table:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/75d5e9c7-0e46-4d08-9831-d067c0dc266d">

- Wallet scan table:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/e43d049e-4261-494e-82e5-273bd46ce4b5">

- Imported wallets table:
<img width="649" alt="image" src="https://github.com/user-attachments/assets/acccefd7-f7ea-42a6-a8cb-967cf3ec24b1">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
