### PR TITLE
refactor: adjust transaction addressing section width

### DIFF
--- a/src/domains/transaction/components/TransactionDetail/TransactionAddresses/TransactionAddresses.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionAddresses/TransactionAddresses.tsx
@@ -39,7 +39,7 @@ export const TransactionAddresses = ({
 					showCopyButton
 					walletNameClass="text-theme-text text-sm leading-[17px] sm:leading-5 sm:text-base"
 					addressClass="text-theme-secondary-500 dark:text-theme-secondary-700 text-sm leading-[17px] sm:leading-5 sm:text-base"
-					wrapperClass="justify-end sm:justify-start"
+					wrapperClass="justify-end sm:justify-start sm:max-w-[350px]"
 				/>
 			</div>
 
@@ -62,7 +62,7 @@ export const TransactionAddresses = ({
 						showCopyButton
 						walletNameClass="text-theme-text text-sm leading-[17px] sm:leading-5 sm:text-base"
 						addressClass="text-theme-secondary-500 dark:text-theme-secondary-700 text-sm leading-[17px] sm:leading-5 sm:text-base"
-						wrapperClass="justify-end sm:justify-start"
+						wrapperClass="justify-end sm:justify-start sm:max-w-[350px]"
 					/>
 				</div>
 			))}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction] addressing sections exceeds allowed width](https://app.clickup.com/t/86dunuwff)

## Summary

- Max width for the transaction addressing section has been fixed to maintain the width in all the sections.
- Snapshots have been updated to support this change.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/2afac5ae-037e-422f-9a70-685c61e8799c">


## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
