### PR TITLE
refactor: camera permission denied alert

### DIFF
--- a/src/app/components/Alert/Alert.styles.ts
+++ b/src/app/components/Alert/Alert.styles.ts
@@ -1,12 +1,15 @@
 import tw from "twin.macro";
 import { Color } from "@/types";
 
+export type AlertColor = Color | "danger-dark";
+
 const chevronBaseStyle = tw`transform !ml-auto duration-100 transition-transform`;
 const headerBaseStyle = tw`flex items-center py-2 px-4 space-x-2 text-sm font-semibold dark:text-white`;
 const bodyBaseStyle = tw`w-full p-4 text-sm leading-relaxed break-words text-left dark:bg-theme-secondary-800`;
 
-const getHeaderVariant = (variant?: Color) => {
+const getHeaderVariant = (variant?: AlertColor) => {
 	const variants = {
+		"danger-dark": () => tw`text-white bg-theme-danger-500`,
 		danger: () => tw`text-theme-danger-700 bg-theme-danger-100 dark:bg-theme-danger-500`,
 		hint: () => tw`text-theme-hint-700 bg-theme-hint-100 dark:bg-theme-hint-700`,
 		info: () => tw`text-theme-info-700 bg-theme-info-100 dark:bg-theme-info-700`,
@@ -18,8 +21,9 @@ const getHeaderVariant = (variant?: Color) => {
 	return (variants[variant as keyof typeof variants] || variants.warning)();
 };
 
-const getBodyVariant = (variant?: Color) => {
+const getBodyVariant = (variant?: AlertColor) => {
 	const variants = {
+		"danger-dark": () => tw`bg-theme-secondary-800 text-theme-secondary-200`,
 		danger: () => tw`bg-theme-danger-50`,
 		hint: () => tw`bg-theme-hint-50`,
 		info: () => tw`bg-theme-info-50`,
@@ -30,8 +34,9 @@ const getBodyVariant = (variant?: Color) => {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 	return (variants[variant as keyof typeof variants] || variants.warning)();
 };
-const getChevronVariant = (variant?: Color) => {
+const getChevronVariant = (variant?: AlertColor) => {
 	const variants = {
+		"danger-dark": () => tw`text-white`,
 		danger: () => tw`text-theme-danger-700 dark:text-white`,
 		hint: () => tw`text-theme-hint-700 dark:text-white`,
 		info: () => tw`text-theme-info-700 dark:text-white`,
@@ -43,13 +48,13 @@ const getChevronVariant = (variant?: Color) => {
 	return (variants[variant as keyof typeof variants] || variants.warning)();
 };
 
-const getHeaderStyles = ({ variant, collapsible }: { variant?: Color; collapsible?: boolean }) => [
+const getHeaderStyles = ({ variant, collapsible }: { variant?: AlertColor; collapsible?: boolean }) => [
 	headerBaseStyle,
 	getHeaderVariant(variant),
 	collapsible === true && tw`cursor-pointer`,
 ];
-const getBodyStyles = ({ variant }: { variant?: Color }) => [bodyBaseStyle, getBodyVariant(variant)];
-const getChevronProperties = ({ variant, collapsed }: { variant?: Color; collapsed: boolean }) => [
+const getBodyStyles = ({ variant }: { variant?: AlertColor }) => [bodyBaseStyle, getBodyVariant(variant)];
+const getChevronProperties = ({ variant, collapsed }: { variant?: AlertColor; collapsed: boolean }) => [
 	chevronBaseStyle,
 	collapsed ? tw`rotate-0` : tw`rotate-180`,
 	getChevronVariant(variant),

--- a/src/app/components/Alert/Alert.test.tsx
+++ b/src/app/components/Alert/Alert.test.tsx
@@ -30,7 +30,7 @@ describe("Alert", () => {
 		expect(asFragment()).toMatchSnapshot();
 	});
 
-	it.each(["info", "success", "warning", "danger", "hint"])("should render as %s alert", (variant) => {
+	it.each(["info", "success", "warning", "danger", "hint", "warning-dark"])("should render as %s alert", (variant) => {
 		const { container, asFragment } = render(
 			<Alert variant={variant as Color}>
 				<span>Hello World!</span>

--- a/src/app/components/Alert/Alert.tsx
+++ b/src/app/components/Alert/Alert.tsx
@@ -3,22 +3,21 @@ import React, { useState } from "react";
 import { styled } from "twin.macro";
 import { useTranslation } from "react-i18next";
 
-import { getBodyStyles, getChevronProperties, getHeaderStyles } from "./Alert.styles";
-import { Color } from "@/types";
-
+import { AlertColor, getBodyStyles, getChevronProperties, getHeaderStyles } from "./Alert.styles";
 import { Icon } from "@/app/components/Icon";
 
 interface AlertProperties extends React.HTMLAttributes<HTMLDivElement> {
 	children: React.ReactNode;
 	className?: string;
 	title?: string;
-	variant?: Color;
+	variant?: AlertColor;
 	collapsible?: boolean;
 }
 
-const TypeIcon = ({ variant }: { variant: Color }) => {
-	const iconVariant: Record<Color, string> = {
+const TypeIcon = ({ variant }: { variant: AlertColor }) => {
+	const iconVariant: Record<AlertColor, string> = {
 		danger: "CircleCross",
+		"danger-dark": "CircleCross",
 		hint: "CircleQuestionMark",
 		info: "CircleInfo",
 		success: "CircleCheckMark",

--- a/src/app/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/app/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -424,3 +424,31 @@ exports[`Alert > should render as warning alert 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`Alert > should render as warning-dark alert 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-col overflow-hidden rounded-xl"
+  >
+    <div
+      class="css-rzhg83"
+    >
+      <div
+        class="css-v0ob3f"
+        height="16"
+        width="16"
+      />
+      <span>
+        COMMON.ALERT.WARNING-DARK
+      </span>
+    </div>
+    <div
+      class="css-trjt6n"
+    >
+      <span>
+        Hello World!
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/app/components/QRFileUpload/QRFileUpload.tsx
+++ b/src/app/components/QRFileUpload/QRFileUpload.tsx
@@ -40,8 +40,7 @@ export const QRFileUpload = ({ onError, onRead }: QRFileUploadProperties) => {
 	return (
 		<Button
 			variant="secondary"
-			theme={isSmAndAbove ? "dark" : "light"}
-			className="z-20 space-x-2"
+			className="z-20 space-x-2 sm:bg-theme-secondary-800 sm:text-theme-secondary-200"
 			onClick={handeQRFileScan}
 			data-testid="QRFileUpload__upload"
 		>

--- a/src/app/components/QRFileUpload/__snapshots__/QRFileUpload.test.tsx.snap
+++ b/src/app/components/QRFileUpload/__snapshots__/QRFileUpload.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`QRFileUpload > should render 1`] = `
 <DocumentFragment>
   <button
-    class="px-5 py-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white z-20 space-x-2"
+    class="px-5 py-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white z-20 space-x-2 sm:bg-theme-secondary-800 sm:text-theme-secondary-200"
     data-testid="QRFileUpload__upload"
     type="button"
   >

--- a/src/app/components/QRModal/QRModal.tsx
+++ b/src/app/components/QRModal/QRModal.tsx
@@ -142,8 +142,8 @@ export const QRModal = ({ isOpen, onCancel, onRead }: QRModalProperties) => {
 					{error && (
 						<Alert
 							title={error.title}
-							variant="danger"
-							className="z-10 mt-6 w-full max-w-[531px]"
+							variant="danger-dark"
+							className="z-10 mt-6 w-full max-w-[300px] sm:max-w-[531px]"
 							collapsible={!isSmAndAbove}
 						>
 							{error.message}

--- a/src/app/components/QRModal/__snapshots__/QRModal.test.tsx.snap
+++ b/src/app/components/QRModal/__snapshots__/QRModal.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`QRModal > should render 1`] = `
                     class="css-j6ajdm"
                   >
                     <button
-                      class="px-5 py-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white z-20 space-x-2"
+                      class="px-5 py-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed rounded dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-700 hover:text-white z-20 space-x-2 sm:bg-theme-secondary-800 sm:text-theme-secondary-200"
                       data-testid="QRFileUpload__upload"
                       type="button"
                     >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] adjust alerts](https://app.clickup.com/t/86du64r5z)

## Summary

- New `warning-dark` variant for alerts.
- Button colors in camera permission denied warning have been updated.
- Tests have been updated to match these designs.

## Screenshots

- 320px:
<img width="320" alt="image" src="https://github.com/user-attachments/assets/34d63fe0-38a4-41c7-836c-a6220dde1eb2">

- 640px:
<img width="636" alt="image" src="https://github.com/user-attachments/assets/9dfc2300-994d-4514-8119-4c1ad3276afe">



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
