### PR TITLE
fix: minor transaction table fixes

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.test.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.test.tsx
@@ -58,7 +58,7 @@ describe("TransactionRowAddressing", () => {
 
 		render(<TransactionRowAddressing transaction={aliasFixture as any} profile={profile} />);
 
-		expect(screen.getByTestId("TransactionRowAddressing__address-container")).toHaveClass("w-40 md:w-50");
+		expect(screen.getByTestId("TransactionRowAddressing__address-container")).toHaveClass("w-40 lg:w-50");
 	});
 
 	it("should not expand width of address container if the wallet has no alias", () => {

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -99,7 +99,7 @@ export const TransactionRowAddressing = ({
 			<div
 				className={cn({
 					"w-30": !alias,
-					"w-40 md:w-50": alias,
+					"w-40 lg:w-50": alias,
 				})}
 				data-testid="TransactionRowAddressing__address-container"
 			>

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`TransactionRow > should render 1`] = `
                 To
               </div>
               <div
-                class="w-40 md:w-50"
+                class="w-40 lg:w-50"
                 data-testid="TransactionRowAddressing__address-container"
               >
                 <div
@@ -434,7 +434,7 @@ exports[`TransactionRow > should render responsive 1`] = `
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -603,7 +603,7 @@ exports[`TransactionRow > should render responsive 2`] = `
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`TransactionRowMobile > should render 1`] = `
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -246,7 +246,7 @@ exports[`TransactionRowMobile > should render 2`] = `
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div

--- a/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
@@ -19,7 +19,7 @@ export const useTransactionTableColumns = ({ coin }: { coin?: string }) => {
 				Header: t("COMMON.AGE"),
 				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 				accessor: (transaction) => transaction.timestamp?.()?.toUNIX(),
-				headerClassName: "hidden xl:table-cell no-border",
+				headerClassName: "hidden lg:table-cell no-border",
 				id: "date",
 				sortDescFirst: true,
 			},

--- a/src/domains/transaction/components/TransactionTable/TransactionTable.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.tsx
@@ -7,6 +7,7 @@ import { TransactionTableProperties } from "./TransactionTable.contracts";
 import { Table } from "@/app/components/Table";
 import { useTransactionTableColumns } from "@/domains/transaction/components/TransactionTable/TransactionTable.helpers";
 import { useBreakpoint } from "@/app/hooks";
+import cn from 'classnames';
 
 export const TransactionTable: FC<TransactionTableProperties> = ({
 	transactions,
@@ -18,7 +19,7 @@ export const TransactionTable: FC<TransactionTableProperties> = ({
 	profile,
 	coinName,
 }) => {
-	const { isXs, isSm } = useBreakpoint();
+	const { isXs, isSm, isMdAndAbove } = useBreakpoint();
 	const columns = useTransactionTableColumns({ coin: coinName });
 	const initialState = useMemo<Partial<TableState<DTO.ExtendedConfirmedTransactionData>>>(
 		() => ({
@@ -62,7 +63,7 @@ export const TransactionTable: FC<TransactionTableProperties> = ({
 				columns={columns}
 				data={data}
 				initialState={initialState}
-				className="md:with-x-padding"
+				className={cn({"with-x-padding": isMdAndAbove})}
 			>
 				{renderTableRow}
 			</Table>

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`TransactionTable > loading state > should render 1`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -35,7 +35,7 @@ exports[`TransactionTable > loading state > should render 1`] = `
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -943,7 +943,7 @@ exports[`TransactionTable > loading state > should render compact 1`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -971,7 +971,7 @@ exports[`TransactionTable > loading state > should render compact 1`] = `
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -1879,7 +1879,7 @@ exports[`TransactionTable > loading state > should render with currency column 1
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -1907,7 +1907,7 @@ exports[`TransactionTable > loading state > should render with currency column 1
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -2815,7 +2815,7 @@ exports[`TransactionTable > should render compact 1`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -2843,7 +2843,7 @@ exports[`TransactionTable > should render compact 1`] = `
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -3269,7 +3269,7 @@ exports[`TransactionTable > should render compact 1`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -4592,7 +4592,7 @@ exports[`TransactionTable > should render compact 1`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -4693,7 +4693,7 @@ exports[`TransactionTable > should render responsive 1`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="css-1m6rt2i"
       role="table"
     >
       <table
@@ -4925,7 +4925,7 @@ exports[`TransactionTable > should render responsive 1`] = `
                           To
                         </div>
                         <div
-                          class="w-40 md:w-50"
+                          class="w-40 lg:w-50"
                           data-testid="TransactionRowAddressing__address-container"
                         >
                           <div
@@ -6128,7 +6128,7 @@ exports[`TransactionTable > should render responsive 1`] = `
                           To
                         </div>
                         <div
-                          class="w-40 md:w-50"
+                          class="w-40 lg:w-50"
                           data-testid="TransactionRowAddressing__address-container"
                         >
                           <div
@@ -6229,7 +6229,7 @@ exports[`TransactionTable > should render responsive 2`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="css-1m6rt2i"
       role="table"
     >
       <table
@@ -6461,7 +6461,7 @@ exports[`TransactionTable > should render responsive 2`] = `
                           To
                         </div>
                         <div
-                          class="w-40 md:w-50"
+                          class="w-40 lg:w-50"
                           data-testid="TransactionRowAddressing__address-container"
                         >
                           <div
@@ -7664,7 +7664,7 @@ exports[`TransactionTable > should render responsive 2`] = `
                           To
                         </div>
                         <div
-                          class="w-40 md:w-50"
+                          class="w-40 lg:w-50"
                           data-testid="TransactionRowAddressing__address-container"
                         >
                           <div
@@ -7765,7 +7765,7 @@ exports[`TransactionTable > should render responsive 3`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -7793,7 +7793,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -8219,7 +8219,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -9542,7 +9542,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -9643,7 +9643,7 @@ exports[`TransactionTable > should render responsive 4`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -9671,7 +9671,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -10097,7 +10097,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -11420,7 +11420,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -11521,7 +11521,7 @@ exports[`TransactionTable > should render responsive 5`] = `
     data-testid="TransactionTable"
   >
     <div
-      class="md:with-x-padding css-1m6rt2i"
+      class="with-x-padding css-1m6rt2i"
       role="table"
     >
       <table
@@ -11549,7 +11549,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               </div>
             </th>
             <th
-              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+              class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
               colspan="1"
               data-testid="table__th--1"
               role="columnheader"
@@ -11975,7 +11975,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div
@@ -13298,7 +13298,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                     To
                   </div>
                   <div
-                    class="w-40 md:w-50"
+                    class="w-40 lg:w-50"
                     data-testid="TransactionRowAddressing__address-container"
                   >
                     <div

--- a/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -243,7 +243,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
       data-testid="TransactionTable"
     >
       <div
-        class="md:with-x-padding css-1m6rt2i"
+        class="with-x-padding css-1m6rt2i"
         role="table"
       >
         <table
@@ -271,7 +271,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 </div>
               </th>
               <th
-                class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+                class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
                 colspan="1"
                 data-testid="table__th--1"
                 role="columnheader"
@@ -1749,7 +1749,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -1924,7 +1924,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                       From
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -2099,7 +2099,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -2274,7 +2274,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                       From
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -10447,7 +10447,7 @@ exports[`Transactions > should hide view more button when there are no next page
       data-testid="TransactionTable"
     >
       <div
-        class="md:with-x-padding css-1m6rt2i"
+        class="with-x-padding css-1m6rt2i"
         role="table"
       >
         <table
@@ -10475,7 +10475,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 </div>
               </th>
               <th
-                class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+                class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
                 colspan="1"
                 data-testid="table__th--1"
                 role="columnheader"
@@ -11345,7 +11345,7 @@ exports[`Transactions > should hide view more button when there are no next page
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -11520,7 +11520,7 @@ exports[`Transactions > should hide view more button when there are no next page
                       From
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -15781,7 +15781,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
       data-testid="TransactionTable"
     >
       <div
-        class="md:with-x-padding css-1m6rt2i"
+        class="with-x-padding css-1m6rt2i"
         role="table"
       >
         <table
@@ -15809,7 +15809,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 </div>
               </th>
               <th
-                class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden xl:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
+                class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-theme-secondary-800  hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl"
                 colspan="1"
                 data-testid="table__th--1"
                 role="columnheader"
@@ -16679,7 +16679,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                       To
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div
@@ -16854,7 +16854,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                       From
                     </div>
                     <div
-                      class="w-40 md:w-50"
+                      class="w-40 lg:w-50"
                       data-testid="TransactionRowAddressing__address-container"
                     >
                       <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[wallet details] grey column header doesn't fill to border](https://app.clickup.com/t/86dunux1x)

## Summary

- Grey column header now fills the border on 1024px screens and more.
- The alias width for the receiver has been fixed in tablet screens.
- Padding for table has been fixed (it stopped appearing after last update).

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/c881805e-32e5-487c-9d7d-448b597d80da">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
