### PR TITLE
fix: amount label height in transaction row

### DIFF
--- a/src/app/components/Amount/AmountLabel.tsx
+++ b/src/app/components/Amount/AmountLabel.tsx
@@ -72,7 +72,7 @@ export const AmountLabel: React.VFC<AmountLabelProperties> = ({
 			size={size}
 			data-testid="AmountLabel__wrapper"
 		>
-			<div className={cn("flex items-center space-x-1 h-full")}>
+			<div className={cn("flex h-full items-center space-x-1")}>
 				{hint && <AmountLabelHint tooltipContent={hint} className={hintClassName} isCompact={isCompact} />}
 				<Amount
 					showSign={value !== 0}

--- a/src/app/components/Amount/AmountLabel.tsx
+++ b/src/app/components/Amount/AmountLabel.tsx
@@ -72,7 +72,7 @@ export const AmountLabel: React.VFC<AmountLabelProperties> = ({
 			size={size}
 			data-testid="AmountLabel__wrapper"
 		>
-			<div className={cn("flex items-center space-x-1")}>
+			<div className={cn("flex items-center space-x-1 h-full")}>
 				{hint && <AmountLabelHint tooltipContent={hint} className={hintClassName} isCompact={isCompact} />}
 				<Amount
 					showSign={value !== 0}

--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`AmountLabel > should render 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <span
         class="whitespace-nowrap text-sm"
@@ -29,7 +29,7 @@ exports[`AmountLabel > should render compact 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <span
         class="whitespace-nowrap text-sm"
@@ -50,7 +50,7 @@ exports[`AmountLabel > should render compact with hint 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <div
         aria-describedby="tippy-2"
@@ -106,7 +106,7 @@ exports[`AmountLabel > should render negative 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <span
         class="whitespace-nowrap text-sm"
@@ -127,7 +127,7 @@ exports[`AmountLabel > should render with hint 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <div
         aria-describedby="tippy-1"
@@ -183,7 +183,7 @@ exports[`AmountLabel > should render zero 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <span
         class="whitespace-nowrap text-sm"

--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`AmountLabel > should render 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <span
         class="whitespace-nowrap text-sm"
@@ -29,7 +29,7 @@ exports[`AmountLabel > should render compact 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <span
         class="whitespace-nowrap text-sm"
@@ -50,7 +50,7 @@ exports[`AmountLabel > should render compact with hint 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <div
         aria-describedby="tippy-2"
@@ -106,7 +106,7 @@ exports[`AmountLabel > should render negative 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <span
         class="whitespace-nowrap text-sm"
@@ -127,7 +127,7 @@ exports[`AmountLabel > should render with hint 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <div
         aria-describedby="tippy-1"
@@ -183,7 +183,7 @@ exports[`AmountLabel > should render zero 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <span
         class="whitespace-nowrap text-sm"

--- a/src/app/components/Notifications/__snapshots__/NotificationTransactionItem.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationTransactionItem.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Notifications > should render in xs 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -153,7 +153,7 @@ exports[`Notifications > should render in xs 2`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -273,7 +273,7 @@ exports[`Notifications > should render in xs 3`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -393,7 +393,7 @@ exports[`Notifications > should render in xs 4`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -513,7 +513,7 @@ exports[`Notifications > should render in xs 5`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -633,7 +633,7 @@ exports[`Notifications > should render notification item 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"

--- a/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`Notifications > should emit transactionClick event 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -332,7 +332,7 @@ exports[`Notifications > should emit transactionClick event 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -443,7 +443,7 @@ exports[`Notifications > should emit transactionClick event 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -776,7 +776,7 @@ exports[`Notifications > should render with plugins 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -887,7 +887,7 @@ exports[`Notifications > should render with plugins 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -998,7 +998,7 @@ exports[`Notifications > should render with plugins 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -1243,7 +1243,7 @@ exports[`Notifications > should render with transactions and plugins 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -1354,7 +1354,7 @@ exports[`Notifications > should render with transactions and plugins 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -1465,7 +1465,7 @@ exports[`Notifications > should render with transactions and plugins 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -389,7 +389,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -500,7 +500,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -1014,7 +1014,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                                 data-testid="AmountLabel__wrapper"
                               >
                                 <div
-                                  class="flex items-center space-x-1"
+                                  class="flex h-full items-center space-x-1"
                                 >
                                   <span
                                     class="whitespace-nowrap text-sm"
@@ -1663,7 +1663,7 @@ exports[`Notifications > should render with transactions in lg 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -1774,7 +1774,7 @@ exports[`Notifications > should render with transactions in lg 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -1885,7 +1885,7 @@ exports[`Notifications > should render with transactions in lg 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -2192,7 +2192,7 @@ exports[`Notifications > should render with transactions in md 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -2303,7 +2303,7 @@ exports[`Notifications > should render with transactions in md 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -2414,7 +2414,7 @@ exports[`Notifications > should render with transactions in md 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -2695,7 +2695,7 @@ exports[`Notifications > should render with transactions in sm 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -2772,7 +2772,7 @@ exports[`Notifications > should render with transactions in sm 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -2849,7 +2849,7 @@ exports[`Notifications > should render with transactions in sm 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -3156,7 +3156,7 @@ exports[`Notifications > should render with transactions in xl 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -3267,7 +3267,7 @@ exports[`Notifications > should render with transactions in xl 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -3378,7 +3378,7 @@ exports[`Notifications > should render with transactions in xl 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -3666,7 +3666,7 @@ exports[`Notifications > should render with transactions in xs 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -3743,7 +3743,7 @@ exports[`Notifications > should render with transactions in xs 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"
@@ -3820,7 +3820,7 @@ exports[`Notifications > should render with transactions in xs 1`] = `
                                     data-testid="AmountLabel__wrapper"
                                   >
                                     <div
-                                      class="flex items-center space-x-1"
+                                      class="flex h-full items-center space-x-1"
                                     >
                                       <span
                                         class="whitespace-nowrap text-sm"

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -1664,12 +1664,12 @@ exports[`Dashboard > should render 1`] = `
                           class="flex flex-col items-end gap-1"
                         >
                           <div
-                            class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                            class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                             color="danger-bg"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -1828,12 +1828,12 @@ exports[`Dashboard > should render 1`] = `
                           class="flex flex-col items-end gap-1"
                         >
                           <div
-                            class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                            class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                             color="danger-bg"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -1992,12 +1992,12 @@ exports[`Dashboard > should render 1`] = `
                           class="flex flex-col items-end gap-1"
                         >
                           <div
-                            class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                            class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                             color="danger-bg"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -2156,12 +2156,12 @@ exports[`Dashboard > should render 1`] = `
                           class="flex flex-col items-end gap-1"
                         >
                           <div
-                            class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                            class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                             color="danger-bg"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
@@ -375,7 +375,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -391,7 +391,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -449,7 +449,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -473,7 +473,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -674,7 +674,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -690,7 +690,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -748,7 +748,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -772,7 +772,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -973,7 +973,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -989,7 +989,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -1047,7 +1047,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1071,7 +1071,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -1584,7 +1584,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1600,7 +1600,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -1658,7 +1658,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1682,7 +1682,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -1883,7 +1883,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1899,7 +1899,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -1957,7 +1957,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1981,7 +1981,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -2182,7 +2182,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -2198,7 +2198,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -2256,7 +2256,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -2280,7 +2280,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -2793,7 +2793,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -2809,7 +2809,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -2867,7 +2867,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -2891,7 +2891,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -3092,7 +3092,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3108,7 +3108,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -3166,7 +3166,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3190,7 +3190,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -3391,7 +3391,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3407,7 +3407,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -3465,7 +3465,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3489,7 +3489,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -4002,7 +4002,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4018,7 +4018,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -4076,7 +4076,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4100,7 +4100,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -4301,7 +4301,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4317,7 +4317,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -4375,7 +4375,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4399,7 +4399,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -4600,7 +4600,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4616,7 +4616,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -4674,7 +4674,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4698,7 +4698,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -5211,7 +5211,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -5227,7 +5227,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -5285,7 +5285,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -5309,7 +5309,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -5510,7 +5510,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -5526,7 +5526,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -5584,7 +5584,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -5608,7 +5608,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -5809,7 +5809,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -5825,7 +5825,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -5883,7 +5883,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -5907,7 +5907,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -6236,7 +6236,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -6265,7 +6265,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <div
                               class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"
@@ -6486,7 +6486,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -6515,7 +6515,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <div
                               class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"
@@ -6736,7 +6736,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -6765,7 +6765,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <div
                               class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"
@@ -7014,7 +7014,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -7043,7 +7043,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <div
                               class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"
@@ -7264,7 +7264,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -7293,7 +7293,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <div
                               class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"
@@ -7514,7 +7514,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -7543,7 +7543,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <div
                               class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRow.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRow.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -91,7 +91,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -115,7 +115,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -139,7 +139,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -323,7 +323,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -339,7 +339,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -363,7 +363,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -387,7 +387,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -562,7 +562,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -578,7 +578,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -602,7 +602,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -626,7 +626,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -801,7 +801,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -817,7 +817,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <div
                   class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -875,7 +875,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -899,7 +899,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <div
                   class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 -ml-1.5 px-2"
@@ -1109,7 +1109,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1125,7 +1125,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1149,7 +1149,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1173,7 +1173,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1353,7 +1353,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1369,7 +1369,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1393,7 +1393,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1417,7 +1417,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1597,7 +1597,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1613,7 +1613,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1637,7 +1637,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1661,7 +1661,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRowMobile.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRowMobile.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Expired) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -212,7 +212,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Expired) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -407,7 +407,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Failed) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -436,7 +436,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Failed) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -631,7 +631,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Finished) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -660,7 +660,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Finished) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -856,7 +856,7 @@ exports[`ExchangeTransactionsRowMobile > should render (New) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -885,7 +885,7 @@ exports[`ExchangeTransactionsRowMobile > should render (New) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         class="flex items-center justify-center bg-theme-success-200 dark:bg-theme-success-700 text-theme-success-700 dark:text-white/70 dark:bg-theme-success-700 h-5 w-5"
@@ -1119,7 +1119,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Refunded) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1148,7 +1148,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Refunded) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1348,7 +1348,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Verifying) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1377,7 +1377,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Verifying) 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -1569,7 +1569,7 @@ exports[`ExchangeTransactionsRowMobile > should render N/A if no orderId 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -1598,7 +1598,7 @@ exports[`ExchangeTransactionsRowMobile > should render N/A if no orderId 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -1791,7 +1791,7 @@ exports[`ExchangeTransactionsRowMobile > should render transaction provider 1`] 
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -1820,7 +1820,7 @@ exports[`ExchangeTransactionsRowMobile > should render transaction provider 1`] 
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`MultiPaymentDetail > should render a modal 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -880,7 +880,7 @@ exports[`MultiPaymentDetail > should render hint icon with tooltip when it's a r
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <div
                         aria-describedby="tippy-16"
@@ -1517,7 +1517,7 @@ exports[`MultiPaymentDetail > should render with recipients 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`MultiSignatureDetail > should fail to broadcast transaction and show er
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -796,7 +796,7 @@ exports[`MultiSignatureDetail > should not broadcast if wallet is not ready to d
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -1381,7 +1381,7 @@ exports[`MultiSignatureDetail > should not show send button when waiting for con
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -1940,7 +1940,7 @@ exports[`MultiSignatureDetail > should render summary step and handle exception 
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -3458,7 +3458,7 @@ exports[`MultiSignatureDetail > should render summary step for transfer 1`] = `
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"
@@ -4851,7 +4851,7 @@ exports[`MultiSignatureDetail > should show sign button when able to sign 1`] = 
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
-                              class="flex items-center space-x-1"
+                              class="flex h-full items-center space-x-1"
                             >
                               <span
                                 class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/SentStep.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/SentStep.test.tsx.snap
@@ -762,7 +762,7 @@ exports[`Multisignature Detail Sent Step > should render sent step %s 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionDetail/TransactionAmount/__snapshots__/TransactionAmount.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetail/TransactionAmount/__snapshots__/TransactionAmount.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`TransactionAmount > should render currency amount 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"
@@ -94,7 +94,7 @@ exports[`TransactionAmount > should render in lg 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"
@@ -164,7 +164,7 @@ exports[`TransactionAmount > should render in md 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"
@@ -237,7 +237,7 @@ exports[`TransactionAmount > should render in sm 1`] = `
             data-testid="AmountLabel__wrapper"
           >
             <div
-              class="flex items-center space-x-1"
+              class="flex h-full items-center space-x-1"
             >
               <span
                 class="whitespace-nowrap text-sm"
@@ -278,7 +278,7 @@ exports[`TransactionAmount > should render in xl 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"
@@ -351,7 +351,7 @@ exports[`TransactionAmount > should render in xs 1`] = `
             data-testid="AmountLabel__wrapper"
           >
             <div
-              class="flex items-center space-x-1"
+              class="flex h-full items-center space-x-1"
             >
               <span
                 class="whitespace-nowrap text-sm"
@@ -392,7 +392,7 @@ exports[`TransactionAmount > should render label for multiple recipients 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"
@@ -462,7 +462,7 @@ exports[`TransactionAmount > should render label for multiple recipients 2`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -471,7 +471,7 @@ exports[`TransactionDetailModal > should render a delegate registration modal 1`
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -1268,7 +1268,7 @@ exports[`TransactionDetailModal > should render a delegate resignation modal 1`]
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -2065,7 +2065,7 @@ exports[`TransactionDetailModal > should render a ipfs modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -2788,7 +2788,7 @@ exports[`TransactionDetailModal > should render a magistrate modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -3593,7 +3593,7 @@ exports[`TransactionDetailModal > should render a multi payment modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -4412,7 +4412,7 @@ exports[`TransactionDetailModal > should render a multi signature modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -5423,7 +5423,7 @@ exports[`TransactionDetailModal > should render a second signature modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -6220,7 +6220,7 @@ exports[`TransactionDetailModal > should render a transfer modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -7019,7 +7019,7 @@ exports[`TransactionDetailModal > should render a transfer modal with memo 1`] =
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -7845,7 +7845,7 @@ exports[`TransactionDetailModal > should render a unvote modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -8671,7 +8671,7 @@ exports[`TransactionDetailModal > should render a vote modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -9523,7 +9523,7 @@ exports[`TransactionDetailModal > should render a voteCombination modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"
@@ -10246,7 +10246,7 @@ exports[`TransactionDetailModal > should render an unlock tokens modal 1`] = `
                               data-testid="AmountLabel__wrapper"
                             >
                               <div
-                                class="flex items-center space-x-1"
+                                class="flex h-full items-center space-x-1"
                               >
                                 <span
                                   class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionSuccessful/__snapshots__/MultiSignatureSuccessful.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionSuccessful/__snapshots__/MultiSignatureSuccessful.test.tsx.snap
@@ -995,7 +995,7 @@ exports[`MultiSignatureSuccessful > should render in lg 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -1856,7 +1856,7 @@ exports[`MultiSignatureSuccessful > should render in md 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -2670,7 +2670,7 @@ exports[`MultiSignatureSuccessful > should render in sm 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -3505,7 +3505,7 @@ exports[`MultiSignatureSuccessful > should render in xl 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -4319,7 +4319,7 @@ exports[`MultiSignatureSuccessful > should render in xs 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -5154,7 +5154,7 @@ exports[`MultiSignatureSuccessful > should render with delegate sender wallet 1`
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -5835,7 +5835,7 @@ exports[`MultiSignatureSuccessful > should render with ledger sender wallet 1`] 
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"
@@ -6516,7 +6516,7 @@ exports[`MultiSignatureSuccessful > should render without generated address 1`] 
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`Signed Transaction Table > should handle the onRowClick function when t
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -652,7 +652,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -1103,7 +1103,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1377,7 +1377,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -1816,7 +1816,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2098,7 +2098,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -2548,7 +2548,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2830,7 +2830,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -3280,7 +3280,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3512,7 +3512,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -3959,7 +3959,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4139,7 +4139,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -4586,7 +4586,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4816,7 +4816,7 @@ exports[`Signed Transaction Table > should render different status > should show
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -5265,7 +5265,7 @@ exports[`Signed Transaction Table > should render different status > should show
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5499,7 +5499,7 @@ exports[`Signed Transaction Table > should render pending transfers on mobile 1`
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -5948,7 +5948,7 @@ exports[`Signed Transaction Table > should render pending transfers when isCompa
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6395,7 +6395,7 @@ exports[`Signed Transaction Table > should render pending transfers when isCompa
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6832,7 +6832,7 @@ exports[`Signed Transaction Table > should render ready to broadcast transaction
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7321,7 +7321,7 @@ exports[`Signed Transaction Table > should render signed transactions and handle
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7812,7 +7812,7 @@ exports[`Signed Transaction Table > should show as awaiting confirmations 1`] = 
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7994,7 +7994,7 @@ exports[`Signed Transaction Table > should show as awaiting confirmations on mob
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
-                            class="flex items-center space-x-1"
+                            class="flex h-full items-center space-x-1"
                           >
                             <span
                               class="whitespace-nowrap text-sm"
@@ -8433,7 +8433,7 @@ exports[`Signed Transaction Table > should show the sign button with isCompact =
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8922,7 +8922,7 @@ exports[`Signed Transaction Table > should show the sign button with isCompact =
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -111,6 +111,7 @@ export const TransactionRow = memo(
 							isNegative={true}
 							ticker={transaction.wallet().currency()}
 							isCompact
+							className="h-[21px]"
 						/>
 						<span
 							className="text-xs font-semibold text-theme-secondary-700 lg:hidden"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowMobile.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowMobile.tsx
@@ -76,6 +76,7 @@ export const TransactionRowMobile = memo(
 									isNegative={true}
 									ticker={transaction.wallet().currency()}
 									isCompact
+									className="h-[21px]"
 								/>
 							</MobileSection>
 

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1 h-full"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -313,7 +313,7 @@ exports[`TransactionRow > should render 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1 h-full"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -486,7 +486,7 @@ exports[`TransactionRow > should render responsive 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1 h-full"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -655,7 +655,7 @@ exports[`TransactionRow > should render responsive 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1 h-full"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -977,7 +977,7 @@ exports[`TransactionRow > should render with currency 1`] = `
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1 h-full"
+                  class="flex h-full items-center space-x-1"
                 >
                   <span
                     class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -124,12 +124,12 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
               class="flex flex-col items-end gap-1"
             >
               <div
-                class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                 color="danger-bg"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex items-center space-x-1 h-full"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -308,12 +308,12 @@ exports[`TransactionRow > should render 1`] = `
               class="flex flex-col items-end gap-1"
             >
               <div
-                class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                 color="danger-bg"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex items-center space-x-1 h-full"
                 >
                   <span
                     class="whitespace-nowrap text-sm"
@@ -481,12 +481,12 @@ exports[`TransactionRow > should render responsive 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex items-center space-x-1 h-full"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -650,12 +650,12 @@ exports[`TransactionRow > should render responsive 2`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex items-center space-x-1 h-full"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -972,12 +972,12 @@ exports[`TransactionRow > should render with currency 1`] = `
               class="flex flex-col items-end gap-1"
             >
               <div
-                class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                 color="danger-bg"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
-                  class="flex items-center space-x-1"
+                  class="flex items-center space-x-1 h-full"
                 >
                   <span
                     class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowAmount.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowAmount.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`TransactionRowAmount > should show as received 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1 h-full"
+      class="flex h-full items-center space-x-1"
     >
       <span
         class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowAmount.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowAmount.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`TransactionRowAmount > should show as received 1`] = `
     data-testid="AmountLabel__wrapper"
   >
     <div
-      class="flex items-center space-x-1"
+      class="flex items-center space-x-1 h-full"
     >
       <span
         class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
@@ -124,12 +124,12 @@ exports[`TransactionRowMobile > should render 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex items-center space-x-1 h-full"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -293,12 +293,12 @@ exports[`TransactionRowMobile > should render 2`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex items-center space-x-1 h-full"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -743,12 +743,12 @@ exports[`TransactionRowMobile > should render with currency 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex items-center space-x-1 h-full"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -901,12 +901,12 @@ exports[`TransactionRowMobile > should render with currency 2`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex items-center space-x-1 h-full"
                     >
                       <span
                         class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`TransactionRowMobile > should render 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1 h-full"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -298,7 +298,7 @@ exports[`TransactionRowMobile > should render 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1 h-full"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -748,7 +748,7 @@ exports[`TransactionRowMobile > should render with currency 1`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1 h-full"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -906,7 +906,7 @@ exports[`TransactionRowMobile > should render with currency 2`] = `
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1 h-full"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/UnconfirmedTransactionTable/__snapshots__/UnconfirmedTransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/UnconfirmedTransactionTable/__snapshots__/UnconfirmedTransactionTable.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`Unconfirmed transaction table > should not render in lg 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -317,7 +317,7 @@ exports[`Unconfirmed transaction table > should not render in lg 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -538,7 +538,7 @@ exports[`Unconfirmed transaction table > should not render in md 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -654,7 +654,7 @@ exports[`Unconfirmed transaction table > should not render in md 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -783,7 +783,7 @@ exports[`Unconfirmed transaction table > should not render in sm 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -921,7 +921,7 @@ exports[`Unconfirmed transaction table > should not render in sm 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -1142,7 +1142,7 @@ exports[`Unconfirmed transaction table > should not render in xl 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -1258,7 +1258,7 @@ exports[`Unconfirmed transaction table > should not render in xl 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -1387,7 +1387,7 @@ exports[`Unconfirmed transaction table > should not render in xs 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"
@@ -1525,7 +1525,7 @@ exports[`Unconfirmed transaction table > should not render in xs 1`] = `
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
-                    class="flex items-center space-x-1"
+                    class="flex h-full items-center space-x-1"
                   >
                     <span
                       class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3137,12 +3137,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3312,12 +3312,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3476,12 +3476,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3640,12 +3640,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3804,12 +3804,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -3968,12 +3968,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4132,12 +4132,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4296,12 +4296,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4460,12 +4460,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4635,12 +4635,12 @@ exports[`TransactionTable > should render compact 1`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -4812,12 +4812,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -4972,12 +4972,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -5121,12 +5121,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -5270,12 +5270,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -5419,12 +5419,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -5568,12 +5568,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -5717,12 +5717,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -5866,12 +5866,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6015,12 +6015,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6175,12 +6175,12 @@ exports[`TransactionTable > should render responsive 1`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6348,12 +6348,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6508,12 +6508,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6657,12 +6657,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6806,12 +6806,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -6955,12 +6955,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -7104,12 +7104,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -7253,12 +7253,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -7402,12 +7402,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -7551,12 +7551,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -7711,12 +7711,12 @@ exports[`TransactionTable > should render responsive 2`] = `
                       class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                     >
                       <div
-                        class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                        class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                         color="danger-bg"
                         data-testid="AmountLabel__wrapper"
                       >
                         <div
-                          class="flex items-center space-x-1"
+                          class="flex h-full items-center space-x-1"
                         >
                           <span
                             class="whitespace-nowrap text-sm"
@@ -8087,12 +8087,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -8262,12 +8262,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -8426,12 +8426,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -8590,12 +8590,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -8754,12 +8754,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -8918,12 +8918,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -9082,12 +9082,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -9246,12 +9246,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -9410,12 +9410,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -9585,12 +9585,12 @@ exports[`TransactionTable > should render responsive 3`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -9965,12 +9965,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -10140,12 +10140,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -10304,12 +10304,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -10468,12 +10468,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -10632,12 +10632,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -10796,12 +10796,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -10960,12 +10960,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -11124,12 +11124,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -11288,12 +11288,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -11463,12 +11463,12 @@ exports[`TransactionTable > should render responsive 4`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -11843,12 +11843,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -12018,12 +12018,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -12182,12 +12182,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -12346,12 +12346,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -12510,12 +12510,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -12674,12 +12674,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -12838,12 +12838,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -13002,12 +13002,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -13166,12 +13166,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"
@@ -13341,12 +13341,12 @@ exports[`TransactionTable > should render responsive 5`] = `
                   class="flex flex-col items-end gap-1"
                 >
                   <div
-                    class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                    class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                     color="danger-bg"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
-                      class="flex items-center space-x-1"
+                      class="flex h-full items-center space-x-1"
                     >
                       <span
                         class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -553,12 +553,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -705,12 +705,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -857,12 +857,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1009,12 +1009,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1161,12 +1161,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1313,12 +1313,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1465,12 +1465,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1617,12 +1617,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1792,12 +1792,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -1967,12 +1967,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2142,12 +2142,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2317,12 +2317,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2481,12 +2481,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2645,12 +2645,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2809,12 +2809,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -2973,12 +2973,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3137,12 +3137,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3301,12 +3301,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3465,12 +3465,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3629,12 +3629,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3793,12 +3793,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -3957,12 +3957,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4121,12 +4121,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4285,12 +4285,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4449,12 +4449,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4613,12 +4613,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4777,12 +4777,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -4941,12 +4941,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5105,12 +5105,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5269,12 +5269,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5433,12 +5433,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5597,12 +5597,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5761,12 +5761,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -5925,12 +5925,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6089,12 +6089,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6253,12 +6253,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6417,12 +6417,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6581,12 +6581,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6745,12 +6745,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -6909,12 +6909,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7073,12 +7073,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7237,12 +7237,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7401,12 +7401,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7565,12 +7565,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7729,12 +7729,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -7893,12 +7893,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8057,12 +8057,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8221,12 +8221,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8385,12 +8385,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8549,12 +8549,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8713,12 +8713,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -8877,12 +8877,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9029,12 +9029,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9181,12 +9181,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9333,12 +9333,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9485,12 +9485,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9649,12 +9649,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9813,12 +9813,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -9977,12 +9977,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -10141,12 +10141,12 @@ exports[`Transactions > should fetch more transactions 1`] = `
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -10757,12 +10757,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -10909,12 +10909,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -11061,12 +11061,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -11213,12 +11213,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -11388,12 +11388,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -11563,12 +11563,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -11727,12 +11727,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -11891,12 +11891,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -12055,12 +12055,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -12219,12 +12219,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -12383,12 +12383,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -12547,12 +12547,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -12711,12 +12711,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -12875,12 +12875,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -13039,12 +13039,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -13203,12 +13203,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -13367,12 +13367,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -13531,12 +13531,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -13695,12 +13695,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -13859,12 +13859,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14023,12 +14023,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14187,12 +14187,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14351,12 +14351,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14515,12 +14515,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14679,12 +14679,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14843,12 +14843,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -14995,12 +14995,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -15147,12 +15147,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -15311,12 +15311,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -15475,12 +15475,12 @@ exports[`Transactions > should hide view more button when there are no next page
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -16091,12 +16091,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -16243,12 +16243,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -16395,12 +16395,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -16547,12 +16547,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -16722,12 +16722,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -16897,12 +16897,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -17061,12 +17061,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -17225,12 +17225,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -17389,12 +17389,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -17553,12 +17553,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -17717,12 +17717,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -17881,12 +17881,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -18045,12 +18045,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -18209,12 +18209,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -18373,12 +18373,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -18537,12 +18537,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -18701,12 +18701,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -18865,12 +18865,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -19029,12 +19029,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -19193,12 +19193,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -19357,12 +19357,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -19521,12 +19521,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -19685,12 +19685,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -19849,12 +19849,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -20013,12 +20013,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -20177,12 +20177,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -20329,12 +20329,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -20481,12 +20481,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -20645,12 +20645,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"
@@ -20809,12 +20809,12 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
+                      class="flex items-center justify-center rounded px-1.5 h-[21px] css-xqt0aw"
                       color="danger-bg"
                       data-testid="AmountLabel__wrapper"
                     >
                       <div
-                        class="flex items-center space-x-1"
+                        class="flex h-full items-center space-x-1"
                       >
                         <span
                           class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/UnlockTokens/blocks/UnlockTokensSelect/__snapshots__/UnlockTokensSelect.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/blocks/UnlockTokensSelect/__snapshots__/UnlockTokensSelect.test.tsx.snap
@@ -518,7 +518,7 @@ exports[`UnlockTokensSelect > should render 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"
@@ -544,7 +544,7 @@ exports[`UnlockTokensSelect > should render 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/UnlockTokens/blocks/UnlockTokensSelect/__snapshots__/UnlockTokensTotal.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/blocks/UnlockTokensSelect/__snapshots__/UnlockTokensTotal.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`UnlockTokensTotal > should render 1`] = `
         data-testid="AmountLabel__wrapper"
       >
         <div
-          class="flex items-center space-x-1"
+          class="flex h-full items-center space-x-1"
         >
           <span
             class="whitespace-nowrap text-sm"
@@ -46,7 +46,7 @@ exports[`UnlockTokensTotal > should render 1`] = `
         data-testid="AmountLabel__wrapper"
       >
         <div
-          class="flex items-center space-x-1"
+          class="flex h-full items-center space-x-1"
         >
           <span
             class="whitespace-nowrap text-sm"
@@ -136,7 +136,7 @@ exports[`UnlockTokensTotal > should render loading fee 1`] = `
         data-testid="AmountLabel__wrapper"
       >
         <div
-          class="flex items-center space-x-1"
+          class="flex h-full items-center space-x-1"
         >
           <span
             class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/UnlockTokens/blocks/__snapshots__/UnlockTokensReview.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/blocks/__snapshots__/UnlockTokensReview.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`UnlockTokensReview > should render 1`] = `
           data-testid="AmountLabel__wrapper"
         >
           <div
-            class="flex items-center space-x-1"
+            class="flex h-full items-center space-x-1"
           >
             <span
               class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/components/UnlockTokens/blocks/__snapshots__/UnlockTokensSummary.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/blocks/__snapshots__/UnlockTokensSummary.test.tsx.snap
@@ -317,7 +317,7 @@ exports[`UnlockTokensSummary > should render 1`] = `
               data-testid="AmountLabel__wrapper"
             >
               <div
-                class="flex items-center space-x-1"
+                class="flex h-full items-center space-x-1"
               >
                 <span
                   class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.Fees.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.Fees.test.tsx.snap
@@ -1097,7 +1097,7 @@ exports[`SendTransfer Fee Handling > should send a single transfer with a high f
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"
@@ -2393,7 +2393,7 @@ exports[`SendTransfer Fee Handling > should send a single transfer with a low fe
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -974,7 +974,7 @@ exports[`SendTransfer > should display unconfirmed transactions modal when submi
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"
@@ -1432,7 +1432,7 @@ exports[`SendTransfer > should display unconfirmed transactions modal when submi
                                       data-testid="AmountLabel__wrapper"
                                     >
                                       <div
-                                        class="flex items-center space-x-1"
+                                        class="flex h-full items-center space-x-1"
                                       >
                                         <span
                                           class="whitespace-nowrap text-sm"
@@ -7312,7 +7312,7 @@ exports[`SendTransfer > should send a single transfer and handle undefined expir
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"
@@ -8485,7 +8485,7 @@ exports[`SendTransfer > should send a single transfer and show unconfirmed trans
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"
@@ -8943,7 +8943,7 @@ exports[`SendTransfer > should send a single transfer and show unconfirmed trans
                                       data-testid="AmountLabel__wrapper"
                                     >
                                       <div
-                                        class="flex items-center space-x-1"
+                                        class="flex h-full items-center space-x-1"
                                       >
                                         <span
                                           class="whitespace-nowrap text-sm"
@@ -9059,7 +9059,7 @@ exports[`SendTransfer > should send a single transfer and show unconfirmed trans
                                       data-testid="AmountLabel__wrapper"
                                     >
                                       <div
-                                        class="flex items-center space-x-1"
+                                        class="flex h-full items-center space-x-1"
                                       >
                                         <span
                                           class="whitespace-nowrap text-sm"
@@ -10212,7 +10212,7 @@ exports[`SendTransfer > should send a single transfer using wallet with encrypti
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"
@@ -11385,7 +11385,7 @@ exports[`SendTransfer > should send a single transfer with keyboard 1`] = `
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"
@@ -12558,7 +12558,7 @@ exports[`SendTransfer > should send a single transfer without keyboard 1`] = `
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div
-                                    class="flex items-center space-x-1"
+                                    class="flex h-full items-center space-x-1"
                                   >
                                     <span
                                       class="whitespace-nowrap text-sm"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[wallet] amount not centered at 640 view](https://app.clickup.com/t/86duqcph4)

## Summary

- The height of the amount label has been fixed in the transaction rows.

<img width="636" alt="image" src="https://github.com/user-attachments/assets/047ba8e7-8859-4274-806e-eeae160bb5cc">




<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
