### PR TITLE
fix: transaction label border in dark mode

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -1608,7 +1608,7 @@ exports[`Dashboard > should render 1`] = `
                         class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                       >
                         <div
-                          class="rounded p-1 css-1dx994f"
+                          class="rounded px-1 dark:border css-1dx994f"
                           color="secondary"
                           data-testid="TransactionRow__type"
                         >
@@ -1772,7 +1772,7 @@ exports[`Dashboard > should render 1`] = `
                         class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                       >
                         <div
-                          class="rounded p-1 css-1dx994f"
+                          class="rounded px-1 dark:border css-1dx994f"
                           color="secondary"
                           data-testid="TransactionRow__type"
                         >
@@ -1936,7 +1936,7 @@ exports[`Dashboard > should render 1`] = `
                         class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                       >
                         <div
-                          class="rounded p-1 css-1dx994f"
+                          class="rounded px-1 dark:border css-1dx994f"
                           color="secondary"
                           data-testid="TransactionRow__type"
                         >
@@ -2100,7 +2100,7 @@ exports[`Dashboard > should render 1`] = `
                         class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                       >
                         <div
-                          class="rounded p-1 css-1dx994f"
+                          class="rounded px-1 dark:border css-1dx994f"
                           color="secondary"
                           data-testid="TransactionRow__type"
                         >

--- a/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`Signed Transaction Table > should handle the onRowClick function when t
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -1014,7 +1014,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -1739,7 +1739,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -2460,7 +2460,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -3192,7 +3192,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -3874,7 +3874,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                   >
                     Unvote
@@ -4501,7 +4501,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                   >
                     Vote
@@ -5178,7 +5178,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -5861,7 +5861,7 @@ exports[`Signed Transaction Table > should render pending transfers when isCompa
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                   >
                     Transfer
@@ -6308,7 +6308,7 @@ exports[`Signed Transaction Table > should render pending transfers when isCompa
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                   >
                     Transfer
@@ -6755,7 +6755,7 @@ exports[`Signed Transaction Table > should render ready to broadcast transaction
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -7244,7 +7244,7 @@ exports[`Signed Transaction Table > should render signed transactions and handle
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -7725,7 +7725,7 @@ exports[`Signed Transaction Table > should show as awaiting confirmations 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                   >
                     Transfer
@@ -8356,7 +8356,7 @@ exports[`Signed Transaction Table > should show the sign button with isCompact =
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -8845,7 +8845,7 @@ exports[`Signed Transaction Table > should show the sign button with isCompact =
                   class="flex px-3 my-1 transition-colors duration-100 min-h-11 items-start xl:min-h-0"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/PendingTransferRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/PendingTransferRow.tsx
@@ -59,7 +59,7 @@ export const PendingTransferRow = ({
 			</TableCell>
 
 			<TableCell innerClassName="items-start xl:min-h-0 my-0 py-3">
-				<Label color="secondary" size="xs" noBorder className="rounded p-1">
+				<Label color="secondary" size="xs" noBorder className="rounded px-1 dark:border">
 					{getLabel(transaction.type())}
 				</Label>
 			</TableCell>

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/SignedTransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/SignedTransactionRow.tsx
@@ -139,7 +139,7 @@ export const SignedTransactionRow = ({
 					color="secondary"
 					size="xs"
 					noBorder
-					className="rounded p-1"
+					className="rounded px-1 dark:border"
 					data-testid="TransactionRowRecipientLabel"
 				>
 					{getLabel(transaction.type())}

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -93,7 +93,7 @@ export const TransactionRow = memo(
 						color="secondary"
 						size="xs"
 						noBorder
-						className="rounded p-1"
+						className="rounded px-1 dark:border"
 						data-testid="TransactionRow__type"
 					>
 						{getLabel(transaction.type())}

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
             class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
           >
             <div
-              class="rounded p-1 css-1dx994f"
+              class="rounded px-1 dark:border css-1dx994f"
               color="secondary"
               data-testid="TransactionRow__type"
             >
@@ -241,7 +241,7 @@ exports[`TransactionRow > should render 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
           >
             <div
-              class="rounded p-1 css-1dx994f"
+              class="rounded px-1 dark:border css-1dx994f"
               color="secondary"
               data-testid="TransactionRow__type"
             >
@@ -916,7 +916,7 @@ exports[`TransactionRow > should render with currency 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
           >
             <div
-              class="rounded p-1 css-1dx994f"
+              class="rounded px-1 dark:border css-1dx994f"
               color="secondary"
               data-testid="TransactionRow__type"
             >

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3081,7 +3081,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -3245,7 +3245,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -3420,7 +3420,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -3584,7 +3584,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -3748,7 +3748,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -3912,7 +3912,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -4076,7 +4076,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -4240,7 +4240,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -4404,7 +4404,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -4568,7 +4568,7 @@ exports[`TransactionTable > should render compact 1`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8031,7 +8031,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8195,7 +8195,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8370,7 +8370,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8534,7 +8534,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8698,7 +8698,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8862,7 +8862,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9026,7 +9026,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9190,7 +9190,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9354,7 +9354,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9518,7 +9518,7 @@ exports[`TransactionTable > should render responsive 3`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9909,7 +9909,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10073,7 +10073,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10248,7 +10248,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10412,7 +10412,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10576,7 +10576,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10740,7 +10740,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10904,7 +10904,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11068,7 +11068,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11232,7 +11232,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11396,7 +11396,7 @@ exports[`TransactionTable > should render responsive 4`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11787,7 +11787,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11951,7 +11951,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -12126,7 +12126,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -12290,7 +12290,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -12454,7 +12454,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -12618,7 +12618,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -12782,7 +12782,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -12946,7 +12946,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -13110,7 +13110,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -13274,7 +13274,7 @@ exports[`TransactionTable > should render responsive 5`] = `
                 class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
               >
                 <div
-                  class="rounded p-1 css-1dx994f"
+                  class="rounded px-1 dark:border css-1dx994f"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >

--- a/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -509,7 +509,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -661,7 +661,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -813,7 +813,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -965,7 +965,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1117,7 +1117,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1269,7 +1269,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1421,7 +1421,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1573,7 +1573,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1725,7 +1725,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1900,7 +1900,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2075,7 +2075,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2250,7 +2250,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2425,7 +2425,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2589,7 +2589,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2753,7 +2753,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2917,7 +2917,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3081,7 +3081,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3245,7 +3245,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3409,7 +3409,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3573,7 +3573,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3737,7 +3737,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3901,7 +3901,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4065,7 +4065,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4229,7 +4229,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4393,7 +4393,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4557,7 +4557,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4721,7 +4721,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4885,7 +4885,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5049,7 +5049,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5213,7 +5213,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5377,7 +5377,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5541,7 +5541,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5705,7 +5705,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5869,7 +5869,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6033,7 +6033,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6197,7 +6197,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6361,7 +6361,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6525,7 +6525,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6689,7 +6689,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6853,7 +6853,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7017,7 +7017,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7181,7 +7181,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7345,7 +7345,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7509,7 +7509,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7673,7 +7673,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7837,7 +7837,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8001,7 +8001,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8165,7 +8165,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8329,7 +8329,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8493,7 +8493,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8657,7 +8657,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8821,7 +8821,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8985,7 +8985,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9137,7 +9137,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9289,7 +9289,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9441,7 +9441,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9593,7 +9593,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9757,7 +9757,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9921,7 +9921,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -10085,7 +10085,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -10713,7 +10713,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -10865,7 +10865,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11017,7 +11017,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11169,7 +11169,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11321,7 +11321,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11496,7 +11496,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11671,7 +11671,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11835,7 +11835,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11999,7 +11999,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12163,7 +12163,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12327,7 +12327,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12491,7 +12491,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12655,7 +12655,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12819,7 +12819,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12983,7 +12983,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13147,7 +13147,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13311,7 +13311,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13475,7 +13475,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13639,7 +13639,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13803,7 +13803,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13967,7 +13967,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14131,7 +14131,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14295,7 +14295,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14459,7 +14459,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14623,7 +14623,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14787,7 +14787,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14951,7 +14951,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -15103,7 +15103,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -15255,7 +15255,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -15419,7 +15419,7 @@ exports[`Transactions > should hide view more button when there are no next page
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16047,7 +16047,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16199,7 +16199,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16351,7 +16351,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16503,7 +16503,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16655,7 +16655,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16830,7 +16830,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17005,7 +17005,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17169,7 +17169,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17333,7 +17333,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17497,7 +17497,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17661,7 +17661,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17825,7 +17825,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17989,7 +17989,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18153,7 +18153,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18317,7 +18317,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18481,7 +18481,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18645,7 +18645,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18809,7 +18809,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18973,7 +18973,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19137,7 +19137,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19301,7 +19301,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19465,7 +19465,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19629,7 +19629,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19793,7 +19793,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19957,7 +19957,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20121,7 +20121,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20285,7 +20285,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20437,7 +20437,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20589,7 +20589,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20753,7 +20753,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                   class="flex px-3 transition-colors duration-100 min-h-11 items-start xl:min-h-0 my-0 py-3"
                 >
                   <div
-                    class="rounded p-1 css-1dx994f"
+                    class="rounded px-1 dark:border css-1dx994f"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transactions] transaction type missing border in dark mode](https://app.clickup.com/t/86duqcp6t)

## Summary

- Border for transaction type label in dark mode has been fixed.
- Also, the padding and height for this label has been adjusted to match the designs.

<img width="946" alt="image" src="https://github.com/user-attachments/assets/e487c151-86d8-4ff7-b234-8b589852397d">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
