### PR TITLE
fix: search bar width in mobile view

### DIFF
--- a/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
+++ b/src/app/components/Header/HeaderSearchBar/HeaderSearchBar.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/app/components/Input";
 import { clickOutsideHandler, useDebounce } from "@/app/hooks";
 
 const SearchBarInputWrapper = styled.div`
-	${tw`[min-width:300px] sm:[min-width:448px] dark:border dark:border-theme-secondary-800`}
+	${tw`xs:[min-width:300px] sm:[min-width:448px] dark:border dark:border-theme-secondary-800`}
 `;
 
 export const HeaderSearchBar: FC<HeaderSearchBarProperties> = ({

--- a/src/app/components/Header/HeaderSearchInput/HeaderSearchInput.tsx
+++ b/src/app/components/Header/HeaderSearchInput/HeaderSearchInput.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/app/components/Input";
 import { useDebounce } from "@/app/hooks";
 
 const SearchBarInputWrapper = styled.div`
-	${tw`[min-width:300px] sm:[min-width:448px] dark:border dark:border-theme-secondary-800`}
+	${tw`xs:[min-width:300px] sm:[min-width:448px] dark:border dark:border-theme-secondary-800`}
 `;
 
 export const HeaderSearchInput: FC<HeaderSearchInputProperties> = ({

--- a/src/app/components/Header/HeaderSearchInput/__snapshots__/HeaderSearchInput.test.tsx.snap
+++ b/src/app/components/Header/HeaderSearchInput/__snapshots__/HeaderSearchInput.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`HeaderSearchInput > should render 1`] = `
     data-testid="HeaderSearchInput"
   >
     <div
-      class="flex items-center overflow-hidden rounded-lg border border-theme-secondary-400 bg-theme-background px-4 text-base dark:border-theme-secondary-700 css-e93eg4"
+      class="flex items-center overflow-hidden rounded-lg border border-theme-secondary-400 bg-theme-background px-4 text-base dark:border-theme-secondary-700 css-1ltrfa0"
       data-testid="HeaderSearchInput__input"
     >
       <button


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[General] Select sender/recipient/participant search bar incorrect width mobile](https://app.clickup.com/t/86duqehjc)

## Summary

- The width for the search bar has been fixed in mobile views.
- The padding effect from tables has been also removed from mobile views.

<img width="312" alt="image" src="https://github.com/user-attachments/assets/be3b284b-9734-43f2-8de1-55f5df35c459">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
