### PR TITLE
fix: use inner group to scope hover state in link component

### DIFF
--- a/src/app/components/Link/Link.tsx
+++ b/src/app/components/Link/Link.tsx
@@ -37,7 +37,7 @@ const Content = styled.span<{ isDisabled?: boolean; showExternalIcon?: boolean }
 		];
 
 		if (!isDisabled && showExternalIcon) {
-			styles.push(tw`group-hover:border-current`);
+			styles.push(tw`group-hover/inner:border-current`);
 		}
 
 		if (!isDisabled && !showExternalIcon) {
@@ -60,7 +60,7 @@ const Anchor = React.forwardRef<HTMLAnchorElement, AnchorProperties>(
 		reference,
 	) => (
 		<AnchorStyled
-			className={cn("ring-focus group inline-block", className)}
+			className={cn("ring-focus group/inner inline-block", className)}
 			data-testid="Link"
 			rel={isExternal ? "noopener noreferrer" : rel}
 			ref={reference}

--- a/src/app/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/app/components/Link/__snapshots__/Link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Link > should do nothing on click when disabled 1`] = `
 <DocumentFragment>
   <a
-    class="ring-focus group inline-block css-1flyqpm"
+    class="ring-focus group/inner inline-block css-1flyqpm"
     data-ring-focus-margin="-m-1"
     data-testid="Link"
     href="https://app.arkvault.io/"
@@ -45,14 +45,14 @@ exports[`Link > should do nothing on click when disabled 1`] = `
 exports[`Link > should open an external link 1`] = `
 <DocumentFragment>
   <a
-    class="ring-focus group inline-block css-7nwwrh"
+    class="ring-focus group/inner inline-block css-7nwwrh"
     data-ring-focus-margin="-m-1"
     data-testid="Link"
     href="https://app.arkvault.io/"
     rel="noopener noreferrer"
   >
     <span
-      class="css-170792"
+      class="css-bxx244"
     />
     <div
       class="mb-[3px] shrink-0 align-middle duration-200 css-v0ob3f"
@@ -85,7 +85,7 @@ exports[`Link > should open an external link 1`] = `
 exports[`Link > should render 1`] = `
 <DocumentFragment>
   <a
-    class="ring-focus group inline-block css-7nwwrh"
+    class="ring-focus group/inner inline-block css-7nwwrh"
     data-ring-focus-margin="-m-1"
     data-testid="Link"
     href="#/test"
@@ -102,14 +102,14 @@ exports[`Link > should render 1`] = `
 exports[`Link > should render external without children 1`] = `
 <DocumentFragment>
   <a
-    class="ring-focus group inline-block css-7nwwrh"
+    class="ring-focus group/inner inline-block css-7nwwrh"
     data-ring-focus-margin="-m-1"
     data-testid="Link"
     href="https://app.arkvault.io"
     rel="noopener noreferrer"
   >
     <span
-      class="css-170792"
+      class="css-bxx244"
     />
     <div
       class="mb-[3px] shrink-0 align-middle duration-200 css-v0ob3f"
@@ -142,7 +142,7 @@ exports[`Link > should render external without children 1`] = `
 exports[`Link > should render with tooltip 1`] = `
 <DocumentFragment>
   <a
-    class="ring-focus group inline-block css-7nwwrh"
+    class="ring-focus group/inner inline-block css-7nwwrh"
     data-ring-focus-margin="-m-1"
     data-testid="Link"
     href="#/test"
@@ -159,14 +159,14 @@ exports[`Link > should render with tooltip 1`] = `
 exports[`Link > should show a toast when trying to open an invalid external link 1`] = `
 <DocumentFragment>
   <a
-    class="ring-focus group inline-block css-7nwwrh"
+    class="ring-focus group/inner inline-block css-7nwwrh"
     data-ring-focus-margin="-m-1"
     data-testid="Link"
     href="invalid-url"
     rel="noopener noreferrer"
   >
     <span
-      class="css-170792"
+      class="css-bxx244"
     />
     <div
       class="mb-[3px] shrink-0 align-middle duration-200 css-v0ob3f"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dux5gwx 
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
