### PR TITLE
fix: portfolio header padding

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -572,7 +572,7 @@ exports[`Dashboard > should render 1`] = `
             data-testid="Portfolio__Header"
           >
             <div
-              class="text-lg font-bold leading- sm:text-2xl"
+              class="text-lg font-bold leading-5 sm:text-2xl"
             >
               Portfolio
             </div>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -568,11 +568,11 @@ exports[`Dashboard > should render 1`] = `
           class="mx-auto px-6 lg:container md:px-10"
         >
           <div
-            class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-8 py-4 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+            class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
             data-testid="Portfolio__Header"
           >
             <div
-              class="text-lg font-bold sm:text-2xl"
+              class="text-lg font-bold leading- sm:text-2xl"
             >
               Portfolio
             </div>

--- a/src/domains/wallet/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/wallet/components/PortfolioHeader/PortfolioHeader.tsx
@@ -15,10 +15,10 @@ export const PortfolioHeader: React.VFC = () => {
 	return (
 		<>
 			<div
-				className="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-8 py-4 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+				className="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
 				data-testid="Portfolio__Header"
 			>
-				<div className="text-lg font-bold sm:text-2xl">{t("COMMON.PORTFOLIO")}</div>
+				<div className="text-lg font-bold leading-5 sm:text-2xl">{t("COMMON.PORTFOLIO")}</div>
 
 				<div className="-mr-4 text-right sm:mr-0">
 					<WalletsControls

--- a/src/domains/wallet/components/PortfolioHeader/__snapshots__/PortfolioHeader.test.tsx.snap
+++ b/src/domains/wallet/components/PortfolioHeader/__snapshots__/PortfolioHeader.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Portfolio grouped networks > should apply ledger import 1`] = `
 <DocumentFragment>
   <div
-    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-8 py-4 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
     data-testid="Portfolio__Header"
   >
     <div
-      class="text-lg font-bold sm:text-2xl"
+      class="text-lg font-bold leading-5 sm:text-2xl"
     >
       Portfolio
     </div>
@@ -770,11 +770,11 @@ exports[`Portfolio grouped networks > should apply ledger import 1`] = `
 exports[`Portfolio grouped networks > should render list 1`] = `
 <DocumentFragment>
   <div
-    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-8 py-4 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
     data-testid="Portfolio__Header"
   >
     <div
-      class="text-lg font-bold sm:text-2xl"
+      class="text-lg font-bold leading-5 sm:text-2xl"
     >
       Portfolio
     </div>
@@ -1537,11 +1537,11 @@ exports[`Portfolio grouped networks > should render list 1`] = `
 exports[`Portfolio grouped networks > should render without testnet wallets 1`] = `
 <DocumentFragment>
   <div
-    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-8 py-4 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
     data-testid="Portfolio__Header"
   >
     <div
-      class="text-lg font-bold sm:text-2xl"
+      class="text-lg font-bold leading-5 sm:text-2xl"
     >
       Portfolio
     </div>

--- a/src/domains/wallet/components/WalletsGroup/__snapshots__/WalletsGroup.test.tsx.snap
+++ b/src/domains/wallet/components/WalletsGroup/__snapshots__/WalletsGroup.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`WalletsGroup > should handle list wallet click 1`] = `
 <DocumentFragment>
   <div
-    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-8 py-4 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+    class="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
     data-testid="Portfolio__Header"
   >
     <div
-      class="text-lg font-bold sm:text-2xl"
+      class="text-lg font-bold leading-5 sm:text-2xl"
     >
       Portfolio
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dux5t9u

Added a task to fix other paddings: https://app.clickup.com/t/86dux6jfm



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
