### PR TITLE
fix: correct tab border colors in dark mode

### DIFF
--- a/src/app/components/Tabs/Tabs.tsx
+++ b/src/app/components/Tabs/Tabs.tsx
@@ -118,7 +118,7 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProperties>((propertie
 			data-testid={`tabs__tab-button-${properties.tabId}`}
 			role="tab"
 			type="button"
-			className={twMerge("ring-focus mx-6", properties.className)}
+			className={twMerge("ring-focus mx-6 before:bg-theme-secondary-300 before:dark:bg-theme-secondary-800", properties.className)}
 			ref={reference}
 			aria-selected={isActive}
 			tabIndex={isActive ? 0 : -1}
@@ -169,7 +169,7 @@ export const TabList = styled.div<{ noBackground?: boolean }>`
 		}
 
 		& + ${TabButton}:before {
-			${tw`content h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800 absolute -left-6 top-1/2 -translate-y-1/2 block`};
+			${tw`content h-4 w-px absolute -left-6 top-1/2 -translate-y-1/2 block`};
 		}
 	}
 `;

--- a/src/app/components/Tabs/Tabs.tsx
+++ b/src/app/components/Tabs/Tabs.tsx
@@ -118,7 +118,10 @@ export const Tab = React.forwardRef<HTMLButtonElement, TabProperties>((propertie
 			data-testid={`tabs__tab-button-${properties.tabId}`}
 			role="tab"
 			type="button"
-			className={twMerge("ring-focus mx-6 before:bg-theme-secondary-300 before:dark:bg-theme-secondary-800", properties.className)}
+			className={twMerge(
+				"ring-focus mx-6 before:bg-theme-secondary-300 before:dark:bg-theme-secondary-800",
+				properties.className,
+			)}
 			ref={reference}
 			aria-selected={isActive}
 			tabIndex={isActive ? 0 : -1}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dux79a1
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
