### PR TITLE
fix: adjust font weight of total amount in transaction summary

### DIFF
--- a/src/domains/transaction/components/TotalAmountBox/TotalAmountBox.tsx
+++ b/src/domains/transaction/components/TotalAmountBox/TotalAmountBox.tsx
@@ -49,7 +49,7 @@ export const TotalAmountBox = ({ ticker, ...properties }: Properties) => {
 
 			<div className="justfiy-center flex flex-col items-center rounded-b-lg border-t border-theme-secondary-300 bg-theme-secondary-100 py-4 dark:border-theme-secondary-800 dark:bg-theme-secondary-800 sm:py-5">
 				<AmountLabel>{t("TRANSACTION.TOTAL_AMOUNT")}</AmountLabel>
-				<Amount ticker={ticker} value={total} className="text-md font-bold sm:text-lg" />
+				<Amount ticker={ticker} value={total} className="text-md font-semibold sm:text-lg" />
 			</div>
 		</div>
 	);

--- a/src/domains/transaction/components/TransactionDetail/TransactionSummary/TransactionSummary.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionSummary/TransactionSummary.tsx
@@ -48,7 +48,7 @@ export const TransactionSummary = ({ transaction, senderWallet, labelClassName }
 					<Amount
 						ticker={senderWallet.exchangeCurrency()}
 						value={transaction.convertedAmount()}
-						className="font-bold leading-5"
+						className="font-semibold leading-5"
 					/>
 				</div>
 			</div>

--- a/src/domains/transaction/components/TransactionDetail/TransactionSummary/TransactionSummary.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionSummary/TransactionSummary.tsx
@@ -48,7 +48,7 @@ export const TransactionSummary = ({ transaction, senderWallet, labelClassName }
 					<Amount
 						ticker={senderWallet.exchangeCurrency()}
 						value={transaction.convertedAmount()}
-						className="font-semibold leading-5"
+						className="font-bold leading-5"
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dux77th

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
