### PR TITLE
fix: portfolio breakdown padding

### DIFF
--- a/src/domains/dashboard/components/PortfolioBreakdown/PortfolioBreakdown.tsx
+++ b/src/domains/dashboard/components/PortfolioBreakdown/PortfolioBreakdown.tsx
@@ -110,7 +110,7 @@ export const PortfolioBreakdown: React.VFC<PortfolioBreakdownProperties> = ({
 	return (
 		<>
 			<div
-				className="-mx-8 flex flex-col bg-theme-secondary-100 px-6 py-4 dark:bg-black sm:mx-0 sm:rounded-xl lg:flex-row"
+				className="-mx-6 flex flex-col bg-theme-secondary-100 px-6 py-4 dark:bg-black sm:mx-0 sm:rounded-xl lg:flex-row"
 				data-testid="PortfolioBreakdown"
 			>
 				<div className="flex">

--- a/src/domains/dashboard/components/PortfolioBreakdown/PortfolioBreakdown.tsx
+++ b/src/domains/dashboard/components/PortfolioBreakdown/PortfolioBreakdown.tsx
@@ -110,7 +110,7 @@ export const PortfolioBreakdown: React.VFC<PortfolioBreakdownProperties> = ({
 	return (
 		<>
 			<div
-				className="-mx-8 flex flex-col bg-theme-secondary-100 px-8 py-4 dark:bg-black sm:mx-0 sm:rounded-xl sm:px-4 lg:flex-row"
+				className="-mx-8 flex flex-col bg-theme-secondary-100 px-6 py-4 dark:bg-black sm:mx-0 sm:rounded-xl lg:flex-row"
 				data-testid="PortfolioBreakdown"
 			>
 				<div className="flex">

--- a/src/domains/wallet/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/wallet/components/PortfolioHeader/PortfolioHeader.tsx
@@ -15,7 +15,7 @@ export const PortfolioHeader: React.VFC = () => {
 	return (
 		<>
 			<div
-				className="-mx-8 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
+				className="-mx-6 -mt-8 flex items-center justify-between border-b border-theme-secondary-300 bg-theme-secondary-100 px-6 py-1.5 dark:border-theme-secondary-800 dark:bg-black sm:mx-0 sm:mb-6 sm:mt-0 sm:border-b-0 sm:bg-transparent sm:px-0 sm:py-0 sm:dark:bg-transparent"
 				data-testid="Portfolio__Header"
 			>
 				<div className="text-lg font-bold leading-5 sm:text-2xl">{t("COMMON.PORTFOLIO")}</div>

--- a/src/domains/wallet/pages/CreateWallet/ConfirmPassphraseStep.tsx
+++ b/src/domains/wallet/pages/CreateWallet/ConfirmPassphraseStep.tsx
@@ -44,10 +44,11 @@ export const ConfirmPassphraseStep = () => {
 
 			<Divider />
 
-			<label className="inline-flex cursor-pointer items-center space-x-3 text-theme-secondary-text">
+			<label className="inline-flex cursor-pointer space-x-3 text-theme-secondary-text">
 				<Checkbox
 					data-testid="CreateWallet__ConfirmPassphraseStep__passphraseDisclaimer"
 					checked={passphraseDisclaimer}
+					className="mt-1 sm:mt-0.5"
 					onChange={(event) => setValue("passphraseDisclaimer", event.target.checked)}
 				/>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dux6jfm

This PR is about this part of the page: 

![image](https://github.com/user-attachments/assets/636916e3-0d83-437e-9947-78f28208fba4)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
