### PR TITLE
refactor: green background for selected rows

### DIFF
--- a/src/app/components/Table/TableCell.styles.ts
+++ b/src/app/components/Table/TableCell.styles.ts
@@ -1,9 +1,9 @@
-const baseStyle = "flex items-center px-3 my-1 transition-colors duration-100 min-h-11";
+const baseStyle = "flex px-3 items-center my-1 transition-colors duration-100 min-h-11";
 
-const getVariant = (variant: "start" | "middle" | "end", size?: "sm" | "base"): string | null => {
+const getVariant = (isSelected: boolean, variant: "start" | "middle" | "end", size?: "sm" | "base"): string | null => {
 	if (variant === "start") {
 		const variants = {
-			base: "pl-6 rounded-l",
+			base: isSelected ? "pl-3 ml-3 bg-theme-success-100 rounded-l" : "pl-6 rounded-l",
 			sm: "pl-2 -ml-2 rounded-l",
 		};
 
@@ -12,14 +12,14 @@ const getVariant = (variant: "start" | "middle" | "end", size?: "sm" | "base"): 
 
 	if (variant === "end") {
 		const variants = {
-			base: "pr-6 rounded-r",
+			base: isSelected ? "pr-3 mr-3 bg-theme-success-100 rounded-r" : "pr-6 rounded-r",
 			sm: "pr-2 -mr-2 rounded-r",
 		};
 
 		return variants[size as keyof typeof variants] || variants.base;
 	}
 
-	return "";
+	return isSelected ? "bg-theme-success-100" : "";
 };
 
-export const getStyles = ({ variant, size }: any) => `${baseStyle} ${getVariant(variant, size)}`;
+export const getStyles = ({ variant, size, isSelected }: any) => `${baseStyle} ${getVariant(isSelected, variant, size)}`;

--- a/src/app/components/Table/TableCell.tsx
+++ b/src/app/components/Table/TableCell.tsx
@@ -8,6 +8,7 @@ type TableCellProperties = {
 	className?: string;
 	innerClassName?: string;
 	children: React.ReactNode;
+	isSelected?: boolean;
 } & Omit<React.HTMLProps<any>, "size">;
 
 const TableCellInnerWrapper = ({ ...props }) => <div {...props} />;
@@ -18,10 +19,11 @@ export const TableCell = ({
 	className,
 	innerClassName,
 	children,
+	isSelected = false,
 	...properties
 }: TableCellProperties) => (
 	<td className={className} {...properties}>
-		<TableCellInnerWrapper className={twMerge(getStyles({ size, variant }), innerClassName)}>
+		<TableCellInnerWrapper className={twMerge(getStyles({ size, variant, isSelected }), innerClassName)}>
 			{children}
 		</TableCellInnerWrapper>
 	</td>

--- a/src/domains/transaction/components/SearchRecipient/SearchRecipient.tsx
+++ b/src/domains/transaction/components/SearchRecipient/SearchRecipient.tsx
@@ -28,9 +28,10 @@ const SearchRecipientListItem: FC<SearchRecipientListItemProperties> = ({
 	selectedAddress,
 }) => {
 	const { t } = useTranslation();
+	const isSelected = useMemo(() => selectedAddress === recipient.address, [selectedAddress, recipient]);
 
 	const renderButton = () => {
-		if (selectedAddress === recipient.address) {
+		if (isSelected) {
 			return (
 				<Button
 					data-testid={`RecipientListItem__selected-button-${index}`}
@@ -57,9 +58,10 @@ const SearchRecipientListItem: FC<SearchRecipientListItemProperties> = ({
 		);
 	};
 
+
 	return (
 		<TableRow key={recipient.id} border className="relative">
-			<TableCell variant="start" innerClassName="space-x-4 pl-6">
+			<TableCell variant="start" innerClassName="space-x-4 my-0.5" isSelected={isSelected} >
 				<Address
 					walletName={recipient.alias}
 					address={recipient.address}
@@ -69,7 +71,7 @@ const SearchRecipientListItem: FC<SearchRecipientListItemProperties> = ({
 				/>
 			</TableCell>
 
-			<TableCell>
+			<TableCell isSelected={isSelected} innerClassName="my-0.5">
 				<span
 					data-testid="RecipientListItem__type"
 					className="whitespace-nowrap text-sm font-semibold leading-[17px] text-theme-secondary-700 dark:text-theme-secondary-500"
@@ -78,7 +80,7 @@ const SearchRecipientListItem: FC<SearchRecipientListItemProperties> = ({
 				</span>
 			</TableCell>
 
-			<TableCell variant="end" innerClassName="justify-end">
+			<TableCell variant="end" innerClassName="justify-end my-0.5" isSelected={isSelected}>
 				{renderButton()}
 			</TableCell>
 		</TableRow>

--- a/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
+++ b/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
@@ -33,8 +33,10 @@ const SearchWalletListItem = ({
 }: SearchWalletListItemProperties) => {
 	const { t } = useTranslation();
 
+	const isSelected = useMemo(() => selectedAddress === wallet.address(), [selectedAddress, wallet]);
+
 	const renderButton = () => {
-		if (selectedAddress === wallet.address()) {
+		if (isSelected) {
 			return (
 				<Button
 					data-testid={`SearchWalletListItem__selected-${index}`}
@@ -68,7 +70,7 @@ const SearchWalletListItem = ({
 
 	return (
 		<TableRow className="relative">
-			<TableCell variant="start" innerClassName="space-x-4" className="w-full">
+			<TableCell variant="start" innerClassName="space-x-4 my-0.5" className="w-full" isSelected={isSelected}>
 				<Address
 					walletName={alias}
 					address={wallet.address()}
@@ -77,12 +79,12 @@ const SearchWalletListItem = ({
 				/>
 			</TableCell>
 
-			<TableCell innerClassName="font-semibold justify-end">
+			<TableCell innerClassName="font-semibold justify-end my-0.5" isSelected={isSelected}>
 				<Amount value={wallet.balance()} ticker={wallet.currency()} className="text-sm leading-[17px]" />
 			</TableCell>
 
 			{showConvertedValue && (
-				<TableCell innerClassName="text-theme-secondary-text justify-end" className="hidden xl:table-cell">
+				<TableCell innerClassName="text-theme-secondary-text justify-end" className="hidden xl:table-cell" isSelected={isSelected}>
 					<Amount
 						value={wallet.convertedBalance()}
 						ticker={exchangeCurrency}
@@ -91,7 +93,7 @@ const SearchWalletListItem = ({
 				</TableCell>
 			)}
 
-			<TableCell variant="end" innerClassName="justify-end">
+			<TableCell variant="end" innerClassName="justify-end my-0.5" isSelected={isSelected}>
 				{renderButton()}
 			</TableCell>
 		</TableRow>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[sender/recipient modals] add green background to "selected" address](https://app.clickup.com/t/86duzmkku)

## Summary

- `TableCell` component and styles have been refactored to support `isSelected` props.
- Both the "Select sender" and "Select recipient" tables have been refactored.

## Screenshots

<img width="832" alt="image" src="https://github.com/user-attachments/assets/a7644ceb-1d3b-45c4-8c73-a7acda211903">
<img width="837" alt="image" src="https://github.com/user-attachments/assets/ea5d737f-f268-4e3f-96ed-4a31c69739df">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
