### PR TITLE
refactor: add border when no load more button is shown

### DIFF
--- a/src/domains/transaction/components/Transactions/Transactions.tsx
+++ b/src/domains/transaction/components/Transactions/Transactions.tsx
@@ -209,7 +209,7 @@ export const Transactions = memo(function Transactions({
 					)}
 				</>
 			) : (
-				<TableWrapper className={cn("border-none", { "!rounded-b-none": hasMore })}>
+				<TableWrapper className={cn({ "!rounded-b-none": hasMore })}>
 					<div className="flex w-full flex-col items-start justify-between gap-3 border-b-0 border-b-theme-secondary-300 pb-4 pt-3 dark:border-b-theme-secondary-800 sm:flex-row md:items-center md:border-b md:px-6 md:py-4">
 						<span className="text-base font-semibold leading-5 text-theme-secondary-700 dark:text-theme-secondary-500">
 							{t("COMMON.SHOWING_RESULTS", { count: transactions.length })}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction tables] add bottom border when no "Load More" button](https://app.clickup.com/t/86duzmvdt)

## Summary

- Bottom border is now being shown when no "Load more" button is present in the transactions table.

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/9280794a-9d51-4201-aa1b-ec13c43e38fe">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
