### PR TITLE
refactor: form label hover on delete modal

### DIFF
--- a/src/app/components/Form/FormField.tsx
+++ b/src/app/components/Form/FormField.tsx
@@ -7,11 +7,12 @@ import { FormFieldProvider } from "./useFormField";
 
 type FormFieldProperties = {
 	name: string;
+	disableHover?: boolean;
 } & React.FieldsetHTMLAttributes<any>;
 
-export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean }>`
+export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean, disableHover: boolean }>`
 	&:hover .FormLabel {
-		${({ isInvalid }) => !isInvalid && tw`text-theme-primary-600`};
+		${({ isInvalid, disableHover }) => !isInvalid && !disableHover && tw`text-theme-primary-600`}
 	}
 	.FormLabel {
 		${({ isInvalid }) => isInvalid && tw`text-theme-danger-500`};
@@ -21,7 +22,7 @@ export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean }>`
 	}
 `;
 
-export const FormField: React.FC<FormFieldProperties> = ({ name, ...properties }) => {
+export const FormField: React.FC<FormFieldProperties> = ({ name, disableHover = false,  ...properties }) => {
 	const FormProvider = useFormContext();
 	const { isInvalid, errorMessage } = React.useMemo(() => {
 		const error: { message: string } | undefined = get(FormProvider?.errors, name);
@@ -33,7 +34,7 @@ export const FormField: React.FC<FormFieldProperties> = ({ name, ...properties }
 	}, [FormProvider, name]);
 
 	return (
-		<FormFieldStyled isInvalid={isInvalid} className="flex min-w-0 flex-col" {...properties}>
+		<FormFieldStyled isInvalid={isInvalid} className="flex min-w-0 flex-col" disableHover={disableHover} {...properties}>
 			<FormFieldProvider value={{ errorMessage, isInvalid, name }}>
 				<>{properties.children}</>
 			</FormFieldProvider>

--- a/src/app/components/Form/FormField.tsx
+++ b/src/app/components/Form/FormField.tsx
@@ -10,7 +10,7 @@ type FormFieldProperties = {
 	disableHover?: boolean;
 } & React.FieldsetHTMLAttributes<any>;
 
-export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean, disableHover: boolean }>`
+export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean; disableHover: boolean }>`
 	&:hover .FormLabel {
 		${({ isInvalid, disableHover }) => !isInvalid && !disableHover && tw`text-theme-primary-600`}
 	}
@@ -22,7 +22,7 @@ export const FormFieldStyled = styled.fieldset<{ isInvalid: boolean, disableHove
 	}
 `;
 
-export const FormField: React.FC<FormFieldProperties> = ({ name, disableHover = false,  ...properties }) => {
+export const FormField: React.FC<FormFieldProperties> = ({ name, disableHover = false, ...properties }) => {
 	const FormProvider = useFormContext();
 	const { isInvalid, errorMessage } = React.useMemo(() => {
 		const error: { message: string } | undefined = get(FormProvider?.errors, name);
@@ -34,7 +34,12 @@ export const FormField: React.FC<FormFieldProperties> = ({ name, disableHover = 
 	}, [FormProvider, name]);
 
 	return (
-		<FormFieldStyled isInvalid={isInvalid} className="flex min-w-0 flex-col" disableHover={disableHover} {...properties}>
+		<FormFieldStyled
+			isInvalid={isInvalid}
+			className="flex min-w-0 flex-col"
+			disableHover={disableHover}
+			{...properties}
+		>
 			<FormFieldProvider value={{ errorMessage, isInvalid, name }}>
 				<>{properties.children}</>
 			</FormFieldProvider>

--- a/src/app/components/Form/FormLabel.test.tsx
+++ b/src/app/components/Form/FormLabel.test.tsx
@@ -46,4 +46,10 @@ describe("FormLabel", () => {
 		expect(baseElement).toHaveTextContent("This field is optional");
 		expect(asFragment()).toMatchSnapshot();
 	});
+
+	it("should render with classnames", () => {
+		const { container } = render(<FormLabel label="Test" className="text-red-500" />);
+
+		expect(container.firstChild).toHaveClass("text-red-500");
+	})
 });

--- a/src/app/components/Form/FormLabel.test.tsx
+++ b/src/app/components/Form/FormLabel.test.tsx
@@ -46,10 +46,4 @@ describe("FormLabel", () => {
 		expect(baseElement).toHaveTextContent("This field is optional");
 		expect(asFragment()).toMatchSnapshot();
 	});
-
-	it("should render with classnames", () => {
-		const { container } = render(<FormLabel label="Test" className="text-red-500" />);
-
-		expect(container.firstChild).toHaveClass("text-red-500");
-	})
 });

--- a/src/app/components/Form/FormLabel.tsx
+++ b/src/app/components/Form/FormLabel.tsx
@@ -3,16 +3,17 @@ import { useTranslation } from "react-i18next";
 
 import { useFormField } from "./useFormField";
 import { Tooltip } from "@/app/components/Tooltip";
+import cn from 'classnames';
 
 type FormLabelProperties = {
 	label?: string;
 	optional?: boolean;
+	className?: string;
 } & React.LabelHTMLAttributes<any>;
 
 export function FormLabel(properties: FormLabelProperties) {
 	const fieldContext = useFormField();
-
-	const labelProperties = { ...properties };
+    const { className, ...labelProperties } = properties;
 
 	for (const property of ["label", "optional"]) {
 		// @ts-ignore
@@ -24,7 +25,7 @@ export function FormLabel(properties: FormLabelProperties) {
 	return (
 		<label
 			data-testid="FormLabel"
-			className="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
+			className={cn("FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100", className)}
 			htmlFor={fieldContext?.name}
 			{...labelProperties}
 		>

--- a/src/app/components/Form/FormLabel.tsx
+++ b/src/app/components/Form/FormLabel.tsx
@@ -3,17 +3,16 @@ import { useTranslation } from "react-i18next";
 
 import { useFormField } from "./useFormField";
 import { Tooltip } from "@/app/components/Tooltip";
-import cn from 'classnames';
 
 type FormLabelProperties = {
 	label?: string;
 	optional?: boolean;
-	className?: string;
 } & React.LabelHTMLAttributes<any>;
 
 export function FormLabel(properties: FormLabelProperties) {
 	const fieldContext = useFormField();
-    const { className, ...labelProperties } = properties;
+
+	const labelProperties = { ...properties };
 
 	for (const property of ["label", "optional"]) {
 		// @ts-ignore
@@ -25,7 +24,7 @@ export function FormLabel(properties: FormLabelProperties) {
 	return (
 		<label
 			data-testid="FormLabel"
-			className={cn("FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100", className)}
+			className="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
 			htmlFor={fieldContext?.name}
 			{...labelProperties}
 		>

--- a/src/app/components/Input/__snapshots__/InputDate.test.tsx.snap
+++ b/src/app/components/Input/__snapshots__/InputDate.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`InputDate > should render 1`] = `
 <DocumentFragment>
   <fieldset
-    class="flex min-w-0 flex-col css-1bcidjh"
+    class="flex min-w-0 flex-col css-ea0il3"
   >
     <div
       class="react-datepicker-wrapper"

--- a/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
+++ b/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PasswordValidation > should render password rules 1`] = `
 <DocumentFragment>
   <fieldset
-    class="flex min-w-0 flex-col css-1bcidjh"
+    class="flex min-w-0 flex-col css-ea0il3"
   >
     <label
       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
+++ b/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`PasswordValidation > should render password rules 1`] = `
     </div>
   </div>
   <fieldset
-    class="flex min-w-0 flex-col css-5kz4tk"
+    class="flex min-w-0 flex-col css-s0h7ue"
   >
     <label
       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap.orig
+++ b/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap.orig
@@ -3,7 +3,7 @@
 exports[`PasswordValidation > should render password rules 1`] = `
 <DocumentFragment>
   <fieldset
-    class="flex min-w-0 flex-col css-1bcidjh"
+    class="flex min-w-0 flex-col css-ea0il3"
   >
     <label
       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap.orig
+++ b/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap.orig
@@ -266,7 +266,7 @@ exports[`PasswordValidation > should render password rules 1`] = `
     </div>
   </div>
   <fieldset
-    class="flex min-w-0 flex-col css-5kz4tk"
+    class="flex min-w-0 flex-col css-s0h7ue"
   >
     <label
       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
+++ b/src/app/components/WalletListItem/__snapshots__/WalletListItem.test.tsx.snap
@@ -349,7 +349,7 @@ exports[`WalletListItem > should disable the send button when wallet has no bala
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -944,7 +944,7 @@ exports[`WalletListItem > should render when isCompact = false 1`] = `
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1359,7 +1359,7 @@ exports[`WalletListItem > should render when isCompact = true 1`] = `
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2214,7 +2214,7 @@ exports[`WalletListItem > should render when isLargeScreen = true 1`] = `
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2677,7 +2677,7 @@ exports[`WalletListItem > should render when isLargeScreen = true and wallet is 
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3092,7 +3092,7 @@ exports[`WalletListItem > should render with a N/A for fiat 1`] = `
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3507,7 +3507,7 @@ exports[`WalletListItem > should render with default BTC as default exchangeCurr
                       data-testid="Form"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
+++ b/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`ContactForm > should render responsive 1`] = `
     data-testid="contact-form"
   >
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -37,7 +37,7 @@ exports[`ContactForm > should render responsive 1`] = `
       class="!-mx-4 !mt-4 !p-4 css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -158,7 +158,7 @@ exports[`ContactForm > should render responsive 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
         data-testid="ContactForm__address"
       >
         <label
@@ -244,7 +244,7 @@ exports[`ContactForm > should render responsive 2`] = `
     data-testid="contact-form"
   >
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -274,7 +274,7 @@ exports[`ContactForm > should render responsive 2`] = `
       class="!-mx-4 !mt-4 !p-4 css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -311,13 +311,13 @@ exports[`ContactForm > should render responsive 2`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-3-menu"
+              aria-owns="downshift-4-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-3-input"
-                  id="downshift-3-label"
+                  for="downshift-4-input"
+                  id="downshift-4-label"
                 />
                 <div
                   class="css-14zfvme"
@@ -327,12 +327,12 @@ exports[`ContactForm > should render responsive 2`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-3-menu"
-                      aria-labelledby="downshift-3-label"
+                      aria-controls="downshift-4-menu"
+                      aria-labelledby="downshift-4-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base cursor-default css-1937ogs"
                       data-testid="SelectDropdown__input"
-                      id="downshift-3-input"
+                      id="downshift-4-input"
                       name="network"
                       placeholder="Enter a cryptoasset name"
                       type="text"
@@ -386,8 +386,8 @@ exports[`ContactForm > should render responsive 2`] = `
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-3-label"
-                id="downshift-3-menu"
+                aria-labelledby="downshift-4-label"
+                id="downshift-4-menu"
                 role="listbox"
               />
             </div>
@@ -395,7 +395,7 @@ exports[`ContactForm > should render responsive 2`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
         data-testid="ContactForm__address"
       >
         <label

--- a/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
+++ b/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
@@ -311,13 +311,13 @@ exports[`ContactForm > should render responsive 2`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="downshift-4-menu"
+              aria-owns="downshift-3-menu"
               role="combobox"
             >
               <div>
                 <label
-                  for="downshift-4-input"
-                  id="downshift-4-label"
+                  for="downshift-3-input"
+                  id="downshift-3-label"
                 />
                 <div
                   class="css-14zfvme"
@@ -327,12 +327,12 @@ exports[`ContactForm > should render responsive 2`] = `
                   >
                     <input
                       aria-autocomplete="list"
-                      aria-controls="downshift-4-menu"
-                      aria-labelledby="downshift-4-label"
+                      aria-controls="downshift-3-menu"
+                      aria-labelledby="downshift-3-label"
                       autocomplete="off"
                       class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base cursor-default css-1937ogs"
                       data-testid="SelectDropdown__input"
-                      id="downshift-4-input"
+                      id="downshift-3-input"
                       name="network"
                       placeholder="Enter a cryptoasset name"
                       type="text"
@@ -386,8 +386,8 @@ exports[`ContactForm > should render responsive 2`] = `
                 </div>
               </div>
               <div
-                aria-labelledby="downshift-4-label"
-                id="downshift-4-menu"
+                aria-labelledby="downshift-3-label"
+                id="downshift-3-menu"
                 role="listbox"
               />
             </div>

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`CreateContact > should render 1`] = `
                 data-testid="contact-form"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -108,7 +108,7 @@ exports[`CreateContact > should render 1`] = `
                   class="!-mx-4 !mt-4 !p-4 css-1mwq138"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -229,7 +229,7 @@ exports[`CreateContact > should render 1`] = `
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                     data-testid="ContactForm__address"
                   >
                     <label

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`UpdateContact > should render responsive 1`] = `
                 data-testid="contact-form"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -103,7 +103,7 @@ exports[`UpdateContact > should render responsive 1`] = `
                   class="!-mx-4 !mt-4 !p-4 css-1mwq138"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -224,7 +224,7 @@ exports[`UpdateContact > should render responsive 1`] = `
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                     data-testid="ContactForm__address"
                   >
                     <label
@@ -502,7 +502,7 @@ exports[`UpdateContact > should render responsive 2`] = `
                 data-testid="contact-form"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -532,7 +532,7 @@ exports[`UpdateContact > should render responsive 2`] = `
                   class="!-mx-4 !mt-4 !p-4 css-1mwq138"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -653,7 +653,7 @@ exports[`UpdateContact > should render responsive 2`] = `
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                     data-testid="ContactForm__address"
                   >
                     <label
@@ -975,7 +975,7 @@ exports[`UpdateContact > should render responsive 3`] = `
                 data-testid="contact-form"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1005,7 +1005,7 @@ exports[`UpdateContact > should render responsive 3`] = `
                   class="!-mx-4 !mt-4 !p-4 css-1mwq138"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1126,7 +1126,7 @@ exports[`UpdateContact > should render responsive 3`] = `
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                     data-testid="ContactForm__address"
                   >
                     <label

--- a/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
@@ -470,7 +470,7 @@ exports[`ExchangeForm > should render exchange form 1`] = `
                 class="w-2/5"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -602,7 +602,7 @@ exports[`ExchangeForm > should render exchange form 1`] = `
                 class="w-3/5"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -707,7 +707,7 @@ exports[`ExchangeForm > should render exchange form 1`] = `
                   class="w-2/5"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -839,7 +839,7 @@ exports[`ExchangeForm > should render exchange form 1`] = `
                   class="w-3/5"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -876,7 +876,7 @@ exports[`ExchangeForm > should render exchange form 1`] = `
                 data-testid="ExchangeForm__recipient-address"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2014,7 +2014,7 @@ exports[`FormStep > should render 1`] = `
         class="w-2/5"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2148,7 +2148,7 @@ exports[`FormStep > should render 1`] = `
         class="w-3/5"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2253,7 +2253,7 @@ exports[`FormStep > should render 1`] = `
           class="w-2/5"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2387,7 +2387,7 @@ exports[`FormStep > should render 1`] = `
           class="w-3/5"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2424,7 +2424,7 @@ exports[`FormStep > should render 1`] = `
         data-testid="ExchangeForm__recipient-address"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2644,7 +2644,7 @@ exports[`ReviewStep > should render 1`] = `
     </div>
     <div>
       <fieldset
-        class="sm:pt-2 css-1bcidjh"
+        class="sm:pt-2 css-ea0il3"
       >
         <label
           class="flex cursor-pointer items-center space-x-3"

--- a/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -688,7 +688,7 @@ exports[`SignMessage > Sign with Wallet > should render (lg) 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -739,7 +739,7 @@ exports[`SignMessage > Sign with Wallet > should render (lg) 1`] = `
                       </button>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -789,7 +789,7 @@ exports[`SignMessage > Sign with Wallet > should render (lg) 1`] = `
                       data-testid="AuthenticationStep"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1588,7 +1588,7 @@ exports[`SignMessage > Sign with Wallet > should render (xs) 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1639,7 +1639,7 @@ exports[`SignMessage > Sign with Wallet > should render (xs) 1`] = `
                       </button>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1689,7 +1689,7 @@ exports[`SignMessage > Sign with Wallet > should render (xs) 1`] = `
                       data-testid="AuthenticationStep"
                     >
                       <fieldset
-                        class="flex min-w-0 flex-col css-1bcidjh"
+                        class="flex min-w-0 flex-col css-ea0il3"
                       >
                         <label
                           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/message/pages/SignMessage/__snapshots__/SuccessStep.test.tsx.snap
+++ b/src/domains/message/pages/SignMessage/__snapshots__/SuccessStep.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`SignMessage success step > should render success step in lg 1`] = `
       </div>
       <div>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div
             class="border-l-2 border-x-theme-primary-400 bg-theme-secondary-100 px-3 py-2 dark:bg-black sm:border-none sm:bg-transparent sm:p-0 dark:sm:bg-transparent"
@@ -336,7 +336,7 @@ exports[`SignMessage success step > should render success step in xs 1`] = `
       </div>
       <div>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div
             class="border-l-2 border-x-theme-primary-400 bg-theme-secondary-100 px-3 py-2 dark:bg-black sm:border-none sm:bg-transparent sm:p-0 dark:sm:bg-transparent"

--- a/src/domains/message/pages/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/message/pages/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -727,7 +727,7 @@ exports[`VerifyMessage > should render (lg) 1`] = `
                     data-testid="VerifyMessage__manual"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -754,7 +754,7 @@ exports[`VerifyMessage > should render (lg) 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -781,7 +781,7 @@ exports[`VerifyMessage > should render (lg) 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1573,7 +1573,7 @@ exports[`VerifyMessage > should render (xs) 1`] = `
                     data-testid="VerifyMessage__manual"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1600,7 +1600,7 @@ exports[`VerifyMessage > should render (xs) 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1627,7 +1627,7 @@ exports[`VerifyMessage > should render (xs) 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
+++ b/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`PasswordModal > should render with title and description 1`] = `
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`SignIn > should render a modal 1`] = `
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/setting/components/PasswordRemovalConfirmModal/__snapshots__/PasswordRemovalConfirmModal.test.tsx.snap
+++ b/src/domains/setting/components/PasswordRemovalConfirmModal/__snapshots__/PasswordRemovalConfirmModal.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`PasswordRemovalConfirmModal > should render 1`] = `
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
+++ b/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
@@ -1030,7 +1030,7 @@ exports[`General Settings > should disable submit button when profile is not res
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1057,7 +1057,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1193,7 +1193,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1333,7 +1333,7 @@ exports[`General Settings > should disable submit button when profile is not res
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1469,7 +1469,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1605,7 +1605,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1764,7 +1764,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -3077,7 +3077,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3104,7 +3104,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3240,7 +3240,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3380,7 +3380,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3516,7 +3516,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3652,7 +3652,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3811,7 +3811,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -5088,7 +5088,7 @@ exports[`General Settings > should render 1`] = `
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5115,7 +5115,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5251,7 +5251,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5391,7 +5391,7 @@ exports[`General Settings > should render 1`] = `
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5527,7 +5527,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5663,7 +5663,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5822,7 +5822,7 @@ exports[`General Settings > should render 1`] = `
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -7100,7 +7100,7 @@ exports[`General Settings > should show identicon when removing image if name is
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7127,7 +7127,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7263,7 +7263,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7403,7 +7403,7 @@ exports[`General Settings > should show identicon when removing image if name is
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7539,7 +7539,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7675,7 +7675,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7834,7 +7834,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -9112,7 +9112,7 @@ exports[`General Settings > should update profile 1`] = `
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9139,7 +9139,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9275,7 +9275,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9415,7 +9415,7 @@ exports[`General Settings > should update profile 1`] = `
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9551,7 +9551,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9687,7 +9687,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9846,7 +9846,7 @@ exports[`General Settings > should update profile 1`] = `
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -11124,7 +11124,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11151,7 +11151,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11287,7 +11287,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11427,7 +11427,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11563,7 +11563,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11699,7 +11699,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11858,7 +11858,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -13128,7 +13128,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-5kz4tk"
+                          class="flex min-w-0 flex-col css-s0h7ue"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13203,7 +13203,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13339,7 +13339,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13479,7 +13479,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="mt-5 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13615,7 +13615,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13751,7 +13751,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-5 css-1bcidjh"
+                          class="mt-5 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13910,7 +13910,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label

--- a/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap.orig
+++ b/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap.orig
@@ -13058,7 +13058,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-5kz4tk"
+                          class="flex min-w-0 flex-col css-s0h7ue"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap.orig
+++ b/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap.orig
@@ -1040,7 +1040,7 @@ exports[`General Settings > should disable submit button when profile is not res
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1067,7 +1067,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1199,7 +1199,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1335,7 +1335,7 @@ exports[`General Settings > should disable submit button when profile is not res
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1467,7 +1467,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1599,7 +1599,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1754,7 +1754,7 @@ exports[`General Settings > should disable submit button when profile is not res
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -3073,7 +3073,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3104,7 +3104,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3236,7 +3236,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3372,7 +3372,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3504,7 +3504,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3636,7 +3636,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3791,7 +3791,7 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -5074,7 +5074,7 @@ exports[`General Settings > should render 1`] = `
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5101,7 +5101,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5233,7 +5233,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5369,7 +5369,7 @@ exports[`General Settings > should render 1`] = `
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5501,7 +5501,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5633,7 +5633,7 @@ exports[`General Settings > should render 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5788,7 +5788,7 @@ exports[`General Settings > should render 1`] = `
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -7072,7 +7072,7 @@ exports[`General Settings > should show identicon when removing image if name is
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7099,7 +7099,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7231,7 +7231,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7367,7 +7367,7 @@ exports[`General Settings > should show identicon when removing image if name is
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7499,7 +7499,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7631,7 +7631,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7786,7 +7786,7 @@ exports[`General Settings > should show identicon when removing image if name is
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -9070,7 +9070,7 @@ exports[`General Settings > should update profile 1`] = `
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9097,7 +9097,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9229,7 +9229,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9365,7 +9365,7 @@ exports[`General Settings > should update profile 1`] = `
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9497,7 +9497,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9629,7 +9629,7 @@ exports[`General Settings > should update profile 1`] = `
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -9784,7 +9784,7 @@ exports[`General Settings > should update profile 1`] = `
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -11068,7 +11068,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="flex flex-col sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11095,7 +11095,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11227,7 +11227,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11363,7 +11363,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11495,7 +11495,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11627,7 +11627,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -11782,7 +11782,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label
@@ -13133,7 +13133,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13265,7 +13265,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13401,7 +13401,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                         class="mt-8 flex flex-col sm:ml-5 sm:mt-0 sm:w-2/4"
                       >
                         <fieldset
-                          class="flex min-w-0 flex-col css-1bcidjh"
+                          class="flex min-w-0 flex-col css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13533,7 +13533,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13665,7 +13665,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           </div>
                         </fieldset>
                         <fieldset
-                          class="mt-8 css-1bcidjh"
+                          class="mt-8 css-ea0il3"
                         >
                           <label
                             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -13820,7 +13820,7 @@ exports[`General Settings > should update the avatar when removing focus from na
                           data-testid="list-divided-item__content"
                         >
                           <fieldset
-                            class="flex min-w-0 flex-col css-1bcidjh"
+                            class="flex min-w-0 flex-col css-ea0il3"
                             data-testid="General-settings__auto-signout"
                           >
                             <label

--- a/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
+++ b/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
@@ -951,7 +951,7 @@ exports[`Password Settings > should render password settings 1`] = `
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1024,7 +1024,7 @@ exports[`Password Settings > should render password settings 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2074,7 +2074,7 @@ exports[`Password Settings > should set a password 1`] = `
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2146,7 +2146,7 @@ exports[`Password Settings > should set a password 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2219,7 +2219,7 @@ exports[`Password Settings > should set a password 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3308,7 +3308,7 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3380,7 +3380,7 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3727,7 +3727,7 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-5kz4tk"
+                      class="flex min-w-0 flex-col css-s0h7ue"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap.orig
+++ b/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap.orig
@@ -5257,7 +5257,7 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-5kz4tk"
+                      class="flex min-w-0 flex-col css-s0h7ue"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap.orig
+++ b/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap.orig
@@ -961,7 +961,7 @@ exports[`Password Settings > should render password settings 1`] = `
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1034,7 +1034,7 @@ exports[`Password Settings > should render password settings 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2094,7 +2094,7 @@ exports[`Password Settings > should set a password 1`] = `
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2166,7 +2166,7 @@ exports[`Password Settings > should set a password 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2239,7 +2239,7 @@ exports[`Password Settings > should set a password 1`] = `
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3338,7 +3338,7 @@ exports[`Password Settings > should show an error toast if the current password 
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3410,7 +3410,7 @@ exports[`Password Settings > should show an error toast if the current password 
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3740,7 +3740,7 @@ exports[`Password Settings > should show an error toast if the current password 
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -4838,7 +4838,7 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                     class="space-y-5"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -4910,7 +4910,7 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -212,7 +212,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -407,7 +407,7 @@ exports[`AddRecipient > should render 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -531,7 +531,7 @@ exports[`AddRecipient > should render 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -711,7 +711,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -835,7 +835,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1015,7 +1015,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1139,7 +1139,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1319,7 +1319,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1443,7 +1443,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1556,7 +1556,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1680,7 +1680,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1860,7 +1860,7 @@ exports[`AddRecipient > should set available amount 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1984,7 +1984,7 @@ exports[`AddRecipient > should set available amount 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2164,7 +2164,7 @@ exports[`AddRecipient > should show available balance after fee 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -2288,7 +2288,7 @@ exports[`AddRecipient > should show available balance after fee 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2483,7 +2483,7 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -2607,7 +2607,7 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-5kz4tk"
+          class="flex min-w-0 flex-col css-s0h7ue"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap.orig
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap.orig
@@ -88,7 +88,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -212,7 +212,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -388,7 +388,7 @@ exports[`AddRecipient > should render 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -512,7 +512,7 @@ exports[`AddRecipient > should render 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -673,7 +673,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -797,7 +797,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -958,7 +958,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1082,7 +1082,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1243,7 +1243,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1367,7 +1367,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1461,7 +1461,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1585,7 +1585,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1746,7 +1746,7 @@ exports[`AddRecipient > should set available amount 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -1870,7 +1870,7 @@ exports[`AddRecipient > should set available amount 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2031,7 +2031,7 @@ exports[`AddRecipient > should show available balance after fee 1`] = `
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div
@@ -2155,7 +2155,7 @@ exports[`AddRecipient > should show available balance after fee 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2331,7 +2331,7 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
         class="space-y-4"
       >
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div>
             <div

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap.orig
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap.orig
@@ -2455,7 +2455,7 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
           </div>
         </fieldset>
         <fieldset
-          class="flex min-w-0 flex-col css-5kz4tk"
+          class="flex min-w-0 flex-col css-s0h7ue"
         >
           <label
             class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`AuthenticationStep (message) > should request WIF if wallet was importe
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -435,7 +435,7 @@ exports[`AuthenticationStep (message) > should request private key if wallet was
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -541,7 +541,7 @@ exports[`AuthenticationStep (message) > should request secret if wallet was impo
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1341,7 +1341,7 @@ exports[`AuthenticationStep (transaction) > should request WIF if wallet was imp
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1447,7 +1447,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic and second m
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1966,7 +1966,7 @@ exports[`AuthenticationStep (transaction) > should request private key if wallet
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2072,7 +2072,7 @@ exports[`AuthenticationStep (transaction) > should request secret and second sec
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2144,7 +2144,7 @@ exports[`AuthenticationStep (transaction) > should request secret and second sec
       </div>
     </fieldset>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2250,7 +2250,7 @@ exports[`AuthenticationStep (transaction) > should request secret if wallet was 
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`AuthenticationStep (message) > should request mnemonic if wallet was im
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -286,7 +286,7 @@ exports[`AuthenticationStep (message) > should request mnemonic if wallet was im
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1519,7 +1519,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic and second m
       </div>
     </fieldset>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1668,7 +1668,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic if wallet wa
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1817,7 +1817,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic if wallet wa
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap.orig
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap.orig
@@ -137,7 +137,7 @@ exports[`AuthenticationStep (message) > should request mnemonic if wallet was im
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -290,7 +290,7 @@ exports[`AuthenticationStep (message) > should request mnemonic if wallet was im
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1527,7 +1527,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic and second m
       </div>
     </fieldset>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1680,7 +1680,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic if wallet wa
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1833,7 +1833,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic if wallet wa
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-5kz4tk"
+      class="flex min-w-0 flex-col css-s0h7ue"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap.orig
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap.orig
@@ -31,7 +31,7 @@ exports[`AuthenticationStep (message) > should request WIF if wallet was importe
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -443,7 +443,7 @@ exports[`AuthenticationStep (message) > should request private key if wallet was
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -549,7 +549,7 @@ exports[`AuthenticationStep (message) > should request secret if wallet was impo
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1349,7 +1349,7 @@ exports[`AuthenticationStep (transaction) > should request WIF if wallet was imp
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1455,7 +1455,7 @@ exports[`AuthenticationStep (transaction) > should request mnemonic and second m
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1986,7 +1986,7 @@ exports[`AuthenticationStep (transaction) > should request private key if wallet
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2092,7 +2092,7 @@ exports[`AuthenticationStep (transaction) > should request secret and second sec
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2164,7 +2164,7 @@ exports[`AuthenticationStep (transaction) > should request secret and second sec
       </div>
     </fieldset>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2270,7 +2270,7 @@ exports[`AuthenticationStep (transaction) > should request secret if wallet was 
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/ConfirmRemovePendingTransaction/__snapshots__/ConfirmRemovePendingTransaction.test.tsx.snap
+++ b/src/domains/transaction/components/ConfirmRemovePendingTransaction/__snapshots__/ConfirmRemovePendingTransaction.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`ConfirmRemovePendingTransaction > should render multisignature registra
                   data-testid="AuthenticationStep"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -493,7 +493,7 @@ exports[`ConfirmRemovePendingTransaction > should render multisignature transact
                   data-testid="AuthenticationStep"
                 >
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`DelegateRegistrationForm > should error if username is too long 1`] = `
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-5kz4tk"
+            class="flex min-w-0 flex-col css-s0h7ue"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1637,7 +1637,7 @@ exports[`DelegateRegistrationForm > should show error if username already exists
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-5kz4tk"
+            class="flex min-w-0 flex-col css-s0h7ue"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2039,7 +2039,7 @@ exports[`DelegateRegistrationForm > should show error if username contains illeg
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-5kz4tk"
+            class="flex min-w-0 flex-col css-s0h7ue"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`DelegateRegistrationForm > should error if username is too long 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -600,7 +600,7 @@ exports[`DelegateRegistrationForm > should render form step 1`] = `
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -627,7 +627,7 @@ exports[`DelegateRegistrationForm > should render form step 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1260,7 +1260,7 @@ exports[`DelegateRegistrationForm > should set fee 1`] = `
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1287,7 +1287,7 @@ exports[`DelegateRegistrationForm > should set fee 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1712,7 +1712,7 @@ exports[`DelegateRegistrationForm > should show error if username already exists
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2114,7 +2114,7 @@ exports[`DelegateRegistrationForm > should show error if username contains illeg
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap.orig
+++ b/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap.orig
@@ -198,7 +198,7 @@ exports[`DelegateRegistrationForm > should error if username is too long 1`] = `
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-5kz4tk"
+            class="flex min-w-0 flex-col css-s0h7ue"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1591,7 +1591,7 @@ exports[`DelegateRegistrationForm > should show error if username already exists
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-5kz4tk"
+            class="flex min-w-0 flex-col css-s0h7ue"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1993,7 +1993,7 @@ exports[`DelegateRegistrationForm > should show error if username contains illeg
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-5kz4tk"
+            class="flex min-w-0 flex-col css-s0h7ue"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap.orig
+++ b/src/domains/transaction/components/DelegateRegistrationForm/__snapshots__/DelegateRegistrationForm.test.tsx.snap.orig
@@ -273,7 +273,7 @@ exports[`DelegateRegistrationForm > should error if username is too long 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -600,7 +600,7 @@ exports[`DelegateRegistrationForm > should render form step 1`] = `
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -627,7 +627,7 @@ exports[`DelegateRegistrationForm > should render form step 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1214,7 +1214,7 @@ exports[`DelegateRegistrationForm > should set fee 1`] = `
           class="space-y-6 pt-6"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1241,7 +1241,7 @@ exports[`DelegateRegistrationForm > should set fee 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1666,7 +1666,7 @@ exports[`DelegateRegistrationForm > should show error if username already exists
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2068,7 +2068,7 @@ exports[`DelegateRegistrationForm > should show error if username contains illeg
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/FeeWarning/__snapshots__/FeeWarning.test.tsx.snap
+++ b/src/domains/transaction/components/FeeWarning/__snapshots__/FeeWarning.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`FeeWarning > should render a warning for a fee that is too HIGH 1`] = `
               class="mt-4"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="flex w-max cursor-pointer items-center space-x-3"
@@ -374,7 +374,7 @@ exports[`FeeWarning > should render a warning for a fee that is too LOW 1`] = `
               class="mt-4"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="flex w-max cursor-pointer items-center space-x-3"

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/__snapshots__/MultiSignatureRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/__snapshots__/MultiSignatureRegistrationForm.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`MultiSignature Registration Form > should render form step 1`] = `
           class="space-y-4 pt-5"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <div
               data-testid="DetailWrapper"
@@ -140,7 +140,7 @@ exports[`MultiSignature Registration Form > should render form step 1`] = `
                 class="css-1mwq138"
               >
                 <fieldset
-                  class="flex min-w-0 flex-col css-1bcidjh"
+                  class="flex min-w-0 flex-col css-ea0il3"
                 >
                   <label
                     class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -421,7 +421,7 @@ exports[`MultiSignature Registration Form > should render form step 1`] = `
             </div>
           </div>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -464,7 +464,7 @@ exports[`MultiSignature Registration Form > should render form step 1`] = `
             </div>
           </fieldset>
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -617,7 +617,7 @@ exports[`MultiSignature Registration Form > should render review step 1`] = `
           class="-mx-3 space-y-4 pt-5 sm:mx-0"
         >
           <fieldset
-            class="flex min-w-0 flex-col css-1bcidjh"
+            class="flex min-w-0 flex-col css-ea0il3"
           >
             <div
               data-testid="DetailWrapper"

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap
@@ -1908,7 +1908,7 @@ exports[`Add Participant > should render custom participants 1`] = `
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2186,7 +2186,7 @@ exports[`Add Participant > should work with an imported wallet 1`] = `
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Add Participant > should fail if cannot find the address remotely 1`] =
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -388,7 +388,7 @@ exports[`Add Participant > should fail to find 1`] = `
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -767,7 +767,7 @@ exports[`Add Participant > should fail with a duplicate address 1`] = `
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1150,7 +1150,7 @@ exports[`Add Participant > should fail with cold wallet 1`] = `
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1529,7 +1529,7 @@ exports[`Add Participant > should handle exception on find and show address not 
       class="css-1mwq138"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap.orig
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap.orig
@@ -1957,7 +1957,7 @@ exports[`Add Participant > should render custom participants 1`] = `
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2234,7 +2234,7 @@ exports[`Add Participant > should work with an imported wallet 1`] = `
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap.orig
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap.orig
@@ -7,7 +7,7 @@ exports[`Add Participant > should fail if cannot find the address remotely 1`] =
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -395,7 +395,7 @@ exports[`Add Participant > should fail to find 1`] = `
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -783,7 +783,7 @@ exports[`Add Participant > should fail with a duplicate address 1`] = `
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1181,7 +1181,7 @@ exports[`Add Participant > should fail with cold wallet 1`] = `
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1569,7 +1569,7 @@ exports[`Add Participant > should handle exception on find and show address not 
       class="css-1t71j9b"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-5kz4tk"
+        class="flex min-w-0 flex-col css-s0h7ue"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/SecondSignatureRegistrationForm/__snapshots__/SecondSignatureRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureRegistrationForm/__snapshots__/SecondSignatureRegistrationForm.test.tsx.snap
@@ -320,7 +320,7 @@ exports[`SecondSignatureRegistrationForm > should not generate mnemonic if alrea
           </div>
         </div>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div
             data-testid="DetailWrapper"
@@ -417,7 +417,7 @@ exports[`SecondSignatureRegistrationForm > should not generate mnemonic if alrea
         </fieldset>
         <div>
           <fieldset
-            class="-mt-3 sm:mt-0 css-1bcidjh"
+            class="-mt-3 sm:mt-0 css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -621,7 +621,7 @@ exports[`SecondSignatureRegistrationForm > should render generation step 1`] = `
           </div>
         </div>
         <fieldset
-          class="flex min-w-0 flex-col css-1bcidjh"
+          class="flex min-w-0 flex-col css-ea0il3"
         >
           <div
             data-testid="DetailWrapper"
@@ -718,7 +718,7 @@ exports[`SecondSignatureRegistrationForm > should render generation step 1`] = `
         </fieldset>
         <div>
           <fieldset
-            class="-mt-3 sm:mt-0 css-1bcidjh"
+            class="-mt-3 sm:mt-0 css-ea0il3"
           >
             <label
               class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/__snapshots__/TransactionExportForm.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/__snapshots__/TransactionExportForm.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`TransactionExportForm > should render fiat column if wallets network is
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -252,7 +252,7 @@ exports[`TransactionExportForm > should render fiat column if wallets network is
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -699,7 +699,7 @@ exports[`TransactionExportForm > should render in lg 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -835,7 +835,7 @@ exports[`TransactionExportForm > should render in lg 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -1236,7 +1236,7 @@ exports[`TransactionExportForm > should render in md 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -1372,7 +1372,7 @@ exports[`TransactionExportForm > should render in md 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -1773,7 +1773,7 @@ exports[`TransactionExportForm > should render in sm 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -1909,7 +1909,7 @@ exports[`TransactionExportForm > should render in sm 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -2310,7 +2310,7 @@ exports[`TransactionExportForm > should render in xl 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -2446,7 +2446,7 @@ exports[`TransactionExportForm > should render in xl 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -2846,7 +2846,7 @@ exports[`TransactionExportForm > should render in xs 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"
@@ -2982,7 +2982,7 @@ exports[`TransactionExportForm > should render in xs 1`] = `
               data-testid="list-divided-item__value"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div
                   aria-expanded="false"

--- a/src/domains/transaction/components/TransactionExportModal/__snapshots__/TransactionExportModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionExportModal/__snapshots__/TransactionExportModal.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`TransactionExportModal > should render 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -331,7 +331,7 @@ exports[`TransactionExportModal > should render 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -822,7 +822,7 @@ exports[`TransactionExportModal > should render error status 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -961,7 +961,7 @@ exports[`TransactionExportModal > should render error status 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -1452,7 +1452,7 @@ exports[`TransactionExportModal > should render progress status 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -1591,7 +1591,7 @@ exports[`TransactionExportModal > should render progress status 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -2648,7 +2648,7 @@ exports[`TransactionExportModal > should render success status 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -2787,7 +2787,7 @@ exports[`TransactionExportModal > should render success status 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -3278,7 +3278,7 @@ exports[`TransactionExportModal > should render with fiat column 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"
@@ -3417,7 +3417,7 @@ exports[`TransactionExportModal > should render with fiat column 1`] = `
                               data-testid="list-divided-item__value"
                             >
                               <fieldset
-                                class="flex min-w-0 flex-col css-1bcidjh"
+                                class="flex min-w-0 flex-col css-ea0il3"
                               >
                                 <div
                                   aria-expanded="false"

--- a/src/domains/transaction/components/UnlockTokens/blocks/__snapshots__/UnlockTokensAuthentication.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/blocks/__snapshots__/UnlockTokensAuthentication.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`UnlockTokensAuthentication > should render 1`] = `
       </div>
     </div>
     <fieldset
-      class="flex min-w-0 flex-col css-1bcidjh"
+      class="flex min-w-0 flex-col css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -5433,7 +5433,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should show mnemonic a
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-5kz4tk"
+                    class="flex min-w-0 flex-col css-s0h7ue"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -625,7 +625,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should change fee 1`] 
                     class="space-y-3 sm:space-y-4"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <div
                         data-testid="DetailWrapper"
@@ -784,7 +784,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should change fee 1`] 
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1717,7 +1717,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should render 1st step
                     class="space-y-3 sm:space-y-4"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <div
                         data-testid="DetailWrapper"
@@ -1876,7 +1876,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should render 1st step
                       </div>
                     </div>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3727,7 +3727,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should render 3rd step
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3799,7 +3799,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should render 3rd step
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -5361,7 +5361,7 @@ exports[`SendDelegateResignation > Delegate Resignation > should show mnemonic a
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -581,7 +581,7 @@ exports[`SendIpfs > should error if wrong mnemonic 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-5kz4tk"
+                    class="flex min-w-0 flex-col css-s0h7ue"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7229,7 +7229,7 @@ exports[`SendIpfs > should show an error if an invalid IPFS hash is entered 1`] 
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-5kz4tk"
+                      class="flex min-w-0 flex-col css-s0h7ue"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -883,7 +883,7 @@ exports[`SendIpfs > should render form step 1`] = `
       class="space-y-4 pt-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -950,7 +950,7 @@ exports[`SendIpfs > should render form step 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -978,7 +978,7 @@ exports[`SendIpfs > should render form step 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7162,7 +7162,7 @@ exports[`SendIpfs > should show an error if an invalid IPFS hash is entered 1`] 
                     class="space-y-4 pt-4"
                   >
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -7305,7 +7305,7 @@ exports[`SendIpfs > should show an error if an invalid IPFS hash is entered 1`] 
                       </div>
                     </fieldset>
                     <fieldset
-                      class="flex min-w-0 flex-col css-1bcidjh"
+                      class="flex min-w-0 flex-col css-ea0il3"
                     >
                       <label
                         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.SecondSignature.test.tsx.snap
+++ b/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.SecondSignature.test.tsx.snap
@@ -590,7 +590,7 @@ exports[`Second Signature Registration > should register second signature 1`] = 
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
+++ b/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
@@ -1504,7 +1504,7 @@ exports[`Registration > should show mnemonic error 1`] = `
                     </div>
                   </fieldset>
                   <fieldset
-                    class="flex min-w-0 flex-col css-5kz4tk"
+                    class="flex min-w-0 flex-col css-s0h7ue"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
+++ b/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
@@ -1432,7 +1432,7 @@ exports[`Registration > should show mnemonic error 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-1bcidjh"
+                    class="flex min-w-0 flex-col css-ea0il3"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.NetworkSelection.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.NetworkSelection.test.tsx.snap
@@ -633,7 +633,7 @@ exports[`SendTransfer Network Selection > should select cryptoasset 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="mt-8 my-8 css-1bcidjh"
+                    class="mt-8 my-8 css-ea0il3"
                   >
                     <div
                       data-testid="SendTransfer__network-step__select"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2237,7 +2237,7 @@ exports[`SendTransfer > should error if wrong mnemonic 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-5kz4tk"
+                    class="flex min-w-0 flex-col css-s0h7ue"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -2581,7 +2581,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
       class="space-y-4 pt-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2758,7 +2758,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
               class="space-y-4"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div>
                   <div
@@ -2884,7 +2884,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
                 </div>
               </fieldset>
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2966,7 +2966,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
         </div>
       </div>
       <fieldset
-        class="relative css-1bcidjh"
+        class="relative css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3015,7 +3015,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3309,7 +3309,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
       class="space-y-4 pt-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3486,7 +3486,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
               class="space-y-4"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div>
                   <div
@@ -3612,7 +3612,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
                 </div>
               </fieldset>
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3694,7 +3694,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
         </div>
       </div>
       <fieldset
-        class="relative css-1bcidjh"
+        class="relative css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3743,7 +3743,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -4490,7 +4490,7 @@ exports[`SendTransfer > should render network selection without selected wallet 
                     </div>
                   </div>
                   <fieldset
-                    class="mt-8 my-8 css-1bcidjh"
+                    class="mt-8 my-8 css-ea0il3"
                   >
                     <div
                       data-testid="SendTransfer__network-step__select"
@@ -4724,7 +4724,7 @@ exports[`SendTransfer > should render network step with dropdown 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-8 css-1bcidjh"
+      class="mt-8 css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -4915,7 +4915,7 @@ exports[`SendTransfer > should render network step with network cards 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-8 my-8 css-1bcidjh"
+      class="mt-8 my-8 css-ea0il3"
     >
       <div
         data-testid="SendTransfer__network-step__select"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap.orig
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap.orig
@@ -2443,7 +2443,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
       class="space-y-4 pt-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2620,7 +2620,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
               class="space-y-4"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div>
                   <div
@@ -2746,7 +2746,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
                 </div>
               </fieldset>
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2806,7 +2806,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
         </div>
       </div>
       <fieldset
-        class="relative css-1bcidjh"
+        class="relative css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2855,7 +2855,7 @@ exports[`SendTransfer > should render form step (lg) 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3149,7 +3149,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
       class="space-y-4 pt-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3326,7 +3326,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
               class="space-y-4"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <div>
                   <div
@@ -3452,7 +3452,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
                 </div>
               </fieldset>
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3512,7 +3512,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
         </div>
       </div>
       <fieldset
-        class="relative css-1bcidjh"
+        class="relative css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3561,7 +3561,7 @@ exports[`SendTransfer > should render form step (xs) 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -4316,7 +4316,7 @@ exports[`SendTransfer > should render network selection without selected wallet 
                     </div>
                   </div>
                   <fieldset
-                    class="mt-8 my-8 css-1bcidjh"
+                    class="mt-8 my-8 css-ea0il3"
                   >
                     <div
                       data-testid="SendTransfer__network-step__select"
@@ -4550,7 +4550,7 @@ exports[`SendTransfer > should render network step with dropdown 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-8 css-1bcidjh"
+      class="mt-8 css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -4737,7 +4737,7 @@ exports[`SendTransfer > should render network step with network cards 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-8 my-8 css-1bcidjh"
+      class="mt-8 my-8 css-ea0il3"
     >
       <div
         data-testid="SendTransfer__network-step__select"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap.orig
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap.orig
@@ -2099,7 +2099,7 @@ exports[`SendTransfer > should error if wrong mnemonic 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-5kz4tk"
+                    class="flex min-w-0 flex-col css-s0h7ue"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -1922,7 +1922,7 @@ exports[`SendVote > should show error if wrong mnemonic 1`] = `
                     </div>
                   </div>
                   <fieldset
-                    class="flex min-w-0 flex-col css-5kz4tk"
+                    class="flex min-w-0 flex-col css-s0h7ue"
                   >
                     <label
                       class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/components/DeleteWallet/DeleteWallet.tsx
+++ b/src/domains/wallet/components/DeleteWallet/DeleteWallet.tsx
@@ -24,7 +24,7 @@ export const DeleteWallet = ({ onClose, onCancel, onDelete, wallet }: DeleteWall
 			onDelete={onDelete}
 		>
 			<FormField name="wallet" className="mt-4">
-				<FormLabel label={t("COMMON.WALLET")} />
+				<FormLabel label={t("COMMON.WALLET")} className="hover:!text-theme-secondary-text" />
 				<SelectAddress
 					wallet={{
 						address: wallet.address(),

--- a/src/domains/wallet/components/DeleteWallet/DeleteWallet.tsx
+++ b/src/domains/wallet/components/DeleteWallet/DeleteWallet.tsx
@@ -34,6 +34,7 @@ export const DeleteWallet = ({ onClose, onCancel, onDelete, wallet }: DeleteWall
 					showUserIcon={false}
 					profile={wallet.profile()}
 					disabled={true}
+					showWalletAvatar={false}
 				/>
 			</FormField>
 		</DeleteResource>

--- a/src/domains/wallet/components/DeleteWallet/DeleteWallet.tsx
+++ b/src/domains/wallet/components/DeleteWallet/DeleteWallet.tsx
@@ -23,8 +23,8 @@ export const DeleteWallet = ({ onClose, onCancel, onDelete, wallet }: DeleteWall
 			onCancel={onCancel}
 			onDelete={onDelete}
 		>
-			<FormField name="wallet" className="mt-4">
-				<FormLabel label={t("COMMON.WALLET")} className="hover:!text-theme-secondary-text" />
+			<FormField name="wallet" className="mt-4" disableHover>
+				<FormLabel label={t("COMMON.WALLET")} />
 				<SelectAddress
 					wallet={{
 						address: wallet.address(),

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`DeleteWallet > should render a modal 1`] = `
                 type="button"
               >
                 <span
-                  class="absolute inset-y-0 left-14 flex items-center border border-transparent right-4 left-14"
+                  class="absolute inset-y-0 left-14 flex items-center border border-transparent right-4 left-4"
                 >
                   <div
                     class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -199,20 +199,6 @@ exports[`DeleteWallet > should render a modal 1`] = `
                   class="css-4lfin5"
                   disabled=""
                 >
-                  <div
-                    class="shrink-0 css-1p5jpah"
-                    data-testid="Avatar"
-                  >
-                    <div
-                      class="inline-flex h-full w-full items-center justify-center overflow-hidden align-middle rounded-full"
-                    >
-                      <img
-                        alt="AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"
-                        src="data:image/svg+xml;utf8,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" class="picasso" width="100" height="100" viewBox="0 0 100 100"><style>.picasso circle{mix-blend-mode:soft-light;}</style><rect fill="rgb(156, 39, 176)" width="100" height="100"/><circle r="40" cx="10" cy="40" fill="rgb(0, 150, 136)"/><circle r="45" cx="70" cy="60" fill="rgb(33, 150, 243)"/><circle r="60" cx="0" cy="70" fill="rgb(3, 169, 244)"/></svg>"
-                        title="AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX"
-                      />
-                    </div>
-                  </div>
                   <div
                     class="relative flex h-full flex-1 invisible"
                   >

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`DeleteWallet > should render a modal 1`] = `
               </div>
             </div>
             <fieldset
-              class="mt-4 css-ea0il3"
+              class="mt-4 css-svx9dt"
             >
               <label
                 class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`DeleteWallet > should render a modal 1`] = `
               </div>
             </div>
             <fieldset
-              class="mt-4 css-1bcidjh"
+              class="mt-4 css-ea0il3"
             >
               <label
                 class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/components/EncryptPasswordStep/__snapshots__/EncryptPasswordStep.test.tsx.snap
+++ b/src/domains/wallet/components/EncryptPasswordStep/__snapshots__/EncryptPasswordStep.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`EncryptPasswordStep > should trigger password confirmation validation w
       class="space-y-4 pt-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -388,7 +388,7 @@ exports[`EncryptPasswordStep > should trigger password confirmation validation w
         </div>
       </div>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/components/NetworkStep/__snapshots__/NetworkStep.test.tsx.snap
+++ b/src/domains/wallet/components/NetworkStep/__snapshots__/NetworkStep.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`SelectNetworkStep > should render 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-4 css-1bcidjh"
+      class="mt-4 css-ea0il3"
     >
       <div
         data-testid="SelectNetwork"
@@ -244,7 +244,7 @@ exports[`SelectNetworkStep > should render with test networks 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-4 css-1bcidjh"
+      class="mt-4 css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -489,7 +489,7 @@ exports[`SelectNetworkStep > should render without test networks 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-4 css-1bcidjh"
+      class="mt-4 css-ea0il3"
     >
       <div
         data-testid="SelectNetwork"

--- a/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFundsForm.test.tsx.snap
+++ b/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFundsForm.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ReceiveFundsForm > should emit amount onChange event 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -47,7 +47,7 @@ exports[`ReceiveFundsForm > should emit amount onChange event 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -108,7 +108,7 @@ exports[`ReceiveFundsForm > should emit memo onChange event 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -146,7 +146,7 @@ exports[`ReceiveFundsForm > should emit memo onChange event 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -207,7 +207,7 @@ exports[`ReceiveFundsForm > should not show memo if is not supported by network 
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -258,7 +258,7 @@ exports[`ReceiveFundsForm > should render 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -296,7 +296,7 @@ exports[`ReceiveFundsForm > should render 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`UpdateWalletName > should render 1`] = `
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-1bcidjh"
+                class="flex min-w-0 flex-col css-ea0il3"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -217,7 +217,7 @@ exports[`UpdateWalletName > should show an error message for duplicate name 1`] 
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-5kz4tk"
+                class="flex min-w-0 flex-col css-s0h7ue"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -406,7 +406,7 @@ exports[`UpdateWalletName > should show an error message for duplicate name 2`] 
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-5kz4tk"
+                class="flex min-w-0 flex-col css-s0h7ue"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -595,7 +595,7 @@ exports[`UpdateWalletName > should show an error message for duplicate name 3`] 
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-5kz4tk"
+                class="flex min-w-0 flex-col css-s0h7ue"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -784,7 +784,7 @@ exports[`UpdateWalletName > should show an error message for duplicate name 4`] 
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-5kz4tk"
+                class="flex min-w-0 flex-col css-s0h7ue"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -973,7 +973,7 @@ exports[`UpdateWalletName > should show error message when name consists only of
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-5kz4tk"
+                class="flex min-w-0 flex-col css-s0h7ue"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1162,7 +1162,7 @@ exports[`UpdateWalletName > should show error message when name exceeds 42 chara
               data-testid="Form"
             >
               <fieldset
-                class="flex min-w-0 flex-col css-5kz4tk"
+                class="flex min-w-0 flex-col css-s0h7ue"
               >
                 <label
                   class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -716,7 +716,7 @@ exports[`CreateWallet > should create a wallet 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-4 my-4 css-1bcidjh"
+                      class="mt-4 my-4 css-ea0il3"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -2459,7 +2459,7 @@ exports[`CreateWallet > should create a wallet with encryption 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-4 my-4 css-1bcidjh"
+                      class="mt-4 my-4 css-ea0il3"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -3349,7 +3349,7 @@ exports[`CreateWallet > should remove pending wallet if not submitted 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-4 my-4 css-1bcidjh"
+                      class="mt-4 my-4 css-ea0il3"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -4235,7 +4235,7 @@ exports[`CreateWallet > should show an error message for duplicate name 1`] = `
                       </div>
                     </div>
                     <fieldset
-                      class="mt-4 my-4 css-1bcidjh"
+                      class="mt-4 my-4 css-ea0il3"
                     >
                       <div
                         data-testid="SelectNetwork"
@@ -5175,7 +5175,7 @@ exports[`CreateWallet > should show an error message if wallet generation failed
                       </div>
                     </div>
                     <fieldset
-                      class="mt-4 my-4 css-1bcidjh"
+                      class="mt-4 my-4 css-ea0il3"
                     >
                       <div
                         data-testid="SelectNetwork"

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`LedgerTabs > should render connection step 1`] = `
             </div>
           </div>
           <fieldset
-            class="mt-4 my-4 css-1bcidjh"
+            class="mt-4 my-4 css-ea0il3"
           >
             <div
               data-testid="SelectNetwork"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.WIF.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.WIF.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`ImportWallet WIF > should import with invalid wif 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -233,7 +233,7 @@ exports[`ImportWallet WIF > should import with invalid wif 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -447,7 +447,7 @@ exports[`ImportWallet WIF > should import with valid wif 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -584,7 +584,7 @@ exports[`ImportWallet WIF > should import with valid wif 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`ImportWallet > import with private key > when is not valid 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -233,7 +233,7 @@ exports[`ImportWallet > import with private key > when is not valid 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -447,7 +447,7 @@ exports[`ImportWallet > import with private key > when is valid 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -584,7 +584,7 @@ exports[`ImportWallet > import with private key > when is valid 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -798,7 +798,7 @@ exports[`ImportWallet > import with wif > with invalid wif 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -935,7 +935,7 @@ exports[`ImportWallet > import with wif > with invalid wif 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1149,7 +1149,7 @@ exports[`ImportWallet > import with wif > with valid wif 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1286,7 +1286,7 @@ exports[`ImportWallet > import with wif > with valid wif 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1500,7 +1500,7 @@ exports[`ImportWallet > should import with encryped wif 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1637,7 +1637,7 @@ exports[`ImportWallet > should import with encryped wif 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -1668,7 +1668,7 @@ exports[`ImportWallet > should import with encryped wif 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2701,7 +2701,7 @@ exports[`ImportWallet > should render method step 1`] = `
       class="mt-4 space-y-4"
     >
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -2838,7 +2838,7 @@ exports[`ImportWallet > should render method step 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="flex min-w-0 flex-col css-1bcidjh"
+        class="flex min-w-0 flex-col css-ea0il3"
       >
         <label
           class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"
@@ -3152,7 +3152,7 @@ exports[`ImportWallet > should render network step 1`] = `
       </div>
     </div>
     <fieldset
-      class="mt-4 css-1bcidjh"
+      class="mt-4 css-ea0il3"
     >
       <label
         class="FormLabel mb-2 flex text-sm font-semibold leading-[17px] text-theme-secondary-text transition-colors duration-100"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[delete wallet modal] don't change Wallet title colour on hover](https://app.clickup.com/t/86duzmv26)

## Summary

- `FormField` component has been refactored and now supports the `disableHover` prop.
- The hover effect for the "Delete Wallet" modal has been disabled.


<img width="650" alt="image" src="https://github.com/user-attachments/assets/8a71087c-69de-4dbb-9396-99a307009f28">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
