### PR TITLE
fix: truncation on confirmation step

### DIFF
--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -82,7 +82,7 @@ const Modal = ({
 
 	return (
 		<div
-			className={`overflow-overlay fixed inset-0 z-50 flex w-full ${overflowYClass} bg-theme-secondary-900-rgba bg-opacity-60 dark:bg-black-rgba dark:bg-opacity-80 md:py-20 custom-scroll`}
+			className={`overflow-overlay fixed inset-0 z-50 flex w-full ${overflowYClass} bg-theme-secondary-900-rgba bg-opacity-60 dark:bg-black-rgba dark:bg-opacity-80 md:py-20`}
 			onClick={handleClickOverlay}
 			data-testid="Modal__overlay"
 			{...attributes}

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -82,7 +82,7 @@ const Modal = ({
 
 	return (
 		<div
-			className={`overflow-overlay fixed inset-0 z-50 flex w-full ${overflowYClass} bg-theme-secondary-900-rgba bg-opacity-60 dark:bg-black-rgba dark:bg-opacity-80 md:py-20`}
+			className={`overflow-overlay fixed inset-0 z-50 flex w-full ${overflowYClass} bg-theme-secondary-900-rgba bg-opacity-60 dark:bg-black-rgba dark:bg-opacity-80 md:py-20 custom-scroll`}
 			onClick={handleClickOverlay}
 			data-testid="Modal__overlay"
 			{...attributes}

--- a/src/domains/exchange/components/ExchangeForm/ConfirmationStep.tsx
+++ b/src/domains/exchange/components/ExchangeForm/ConfirmationStep.tsx
@@ -27,7 +27,7 @@ const ExplorerLink = ({ value, explorerMask }: ExplorerLinkProperties) => {
 
 	if (explorerMask) {
 		return (
-			<span data-testid="ExplorerLink" ref={reference} className="overflow-hidden">
+			<span data-testid="ExplorerLink" ref={reference} className="overflow-hidden w-full">
 				<Link to={explorerUrl(value, explorerMask)} isExternal>
 					<TruncateMiddleDynamic
 						value={value}

--- a/src/domains/exchange/components/ExchangeForm/ConfirmationStep.tsx
+++ b/src/domains/exchange/components/ExchangeForm/ConfirmationStep.tsx
@@ -27,7 +27,7 @@ const ExplorerLink = ({ value, explorerMask }: ExplorerLinkProperties) => {
 
 	if (explorerMask) {
 		return (
-			<span data-testid="ExplorerLink" ref={reference} className="overflow-hidden w-full">
+			<span data-testid="ExplorerLink" ref={reference} className="w-full overflow-hidden">
 				<Link to={explorerUrl(value, explorerMask)} isExternal>
 					<TruncateMiddleDynamic
 						value={value}

--- a/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ConfirmationStep > should render 1`] = `
                 class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
               >
                 <span
-                  class="overflow-hidden"
+                  class="overflow-hidden w-full"
                   data-testid="ExplorerLink"
                 >
                   <a
@@ -184,7 +184,7 @@ exports[`ConfirmationStep > should render 1`] = `
                 class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
               >
                 <span
-                  class="overflow-hidden"
+                  class="overflow-hidden w-full"
                   data-testid="ExplorerLink"
                 >
                   <a
@@ -1133,7 +1133,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden"
+                          class="overflow-hidden w-full"
                           data-testid="ExplorerLink"
                         >
                           <a
@@ -1232,7 +1232,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden"
+                          class="overflow-hidden w-full"
                           data-testid="ExplorerLink"
                         >
                           <a
@@ -1383,7 +1383,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden"
+                          class="overflow-hidden w-full"
                           data-testid="ExplorerLink"
                         >
                           <a
@@ -1482,7 +1482,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden"
+                          class="overflow-hidden w-full"
                           data-testid="ExplorerLink"
                         >
                           <a

--- a/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ConfirmationStep > should render 1`] = `
                 class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
               >
                 <span
-                  class="overflow-hidden w-full"
+                  class="w-full overflow-hidden"
                   data-testid="ExplorerLink"
                 >
                   <a
@@ -184,7 +184,7 @@ exports[`ConfirmationStep > should render 1`] = `
                 class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
               >
                 <span
-                  class="overflow-hidden w-full"
+                  class="w-full overflow-hidden"
                   data-testid="ExplorerLink"
                 >
                   <a
@@ -1133,7 +1133,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden w-full"
+                          class="w-full overflow-hidden"
                           data-testid="ExplorerLink"
                         >
                           <a
@@ -1232,7 +1232,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden w-full"
+                          class="w-full overflow-hidden"
                           data-testid="ExplorerLink"
                         >
                           <a
@@ -1383,7 +1383,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden w-full"
+                          class="w-full overflow-hidden"
                           data-testid="ExplorerLink"
                         >
                           <a
@@ -1482,7 +1482,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         class="flex items-center space-x-2 whitespace-nowrap text-lg font-semibold"
                       >
                         <span
-                          class="overflow-hidden w-full"
+                          class="w-full overflow-hidden"
                           data-testid="ExplorerLink"
                         >
                           <a


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[exchange] weird truncation on completed page](https://app.clickup.com/t/86duvrzmh)

## Summary

- The width for the explorer link container has been fixed in the exchange completed view.

<img width="632" alt="image" src="https://github.com/user-attachments/assets/8404a3c3-689a-40e0-b862-de41c0e68105">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
