### PR TITLE
fix: prevent success step to change tab

### DIFF
--- a/src/domains/exchange/components/ExchangeForm/ExchangeForm.tsx
+++ b/src/domains/exchange/components/ExchangeForm/ExchangeForm.tsx
@@ -297,12 +297,12 @@ const ExchangeForm = ({
 	useEffect(() => {
 		let timeout: NodeJS.Timeout;
 
-		if (isFinished) {
+		if (isFinished && activeTab !== Step.ConfirmationStep) {
 			timeout = delay(handleNext, 5000);
 		}
 
 		return () => clearTimeout(timeout);
-	}, [handleNext, isFinished]);
+	}, [handleNext, isFinished, activeTab]);
 
 	const showFormButtons = useMemo(
 		() => activeTab < Step.StatusStep || activeTab === Step.ConfirmationStep,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[exchange] exchange completed page disappears](https://app.clickup.com/t/86duvt63y)

## Summary

- `useEffect` hook used to update the step has been fixed so it can't update after being on the success step.

<!-- What changes are being made? -->

https://github.com/user-attachments/assets/f3784fb8-d7fc-41fc-afe4-d8f1665389df


<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
