### PR TITLE
fix: transaction sender modal truncation

### DIFF
--- a/src/app/components/WalletListItem/WalletListItem.blocks.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.blocks.tsx
@@ -405,7 +405,7 @@ export const ReceiverItemMobile: React.FC<ReceiverItemMobileProperties> = ({
 			onClick={onClick}
 		>
 			<div className="flex flex-col gap-2 pl-2 pt-2">
-				<span className="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200">
+				<span className="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full">
 					{name}
 				</span>
 				<span className="text-xs font-semibold text-theme-secondary-700 dark:text-theme-secondary-500">

--- a/src/app/components/WalletListItem/WalletListItem.blocks.tsx
+++ b/src/app/components/WalletListItem/WalletListItem.blocks.tsx
@@ -405,7 +405,7 @@ export const ReceiverItemMobile: React.FC<ReceiverItemMobileProperties> = ({
 			onClick={onClick}
 		>
 			<div className="flex flex-col gap-2 pl-2 pt-2">
-				<span className="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full">
+				<span className="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128">
 					{name}
 				</span>
 				<span className="text-xs font-semibold text-theme-secondary-700 dark:text-theme-secondary-500">

--- a/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
+++ b/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
@@ -70,7 +70,12 @@ const SearchWalletListItem = ({
 
 	return (
 		<TableRow className="relative">
-			<TableCell variant="start" innerClassName="space-x-4 my-0.5" className="w-full max-w-28" isSelected={isSelected}>
+			<TableCell
+				variant="start"
+				innerClassName="space-x-4 my-0.5"
+				className="w-full max-w-28"
+				isSelected={isSelected}
+			>
 				<Address
 					walletName={alias}
 					address={wallet.address()}

--- a/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
+++ b/src/domains/wallet/components/SearchWallet/SearchWallet.tsx
@@ -70,7 +70,7 @@ const SearchWalletListItem = ({
 
 	return (
 		<TableRow className="relative">
-			<TableCell variant="start" innerClassName="space-x-4 my-0.5" className="w-full" isSelected={isSelected}>
+			<TableCell variant="start" innerClassName="space-x-4 my-0.5" className="w-full max-w-28" isSelected={isSelected}>
 				<Address
 					walletName={alias}
 					address={wallet.address()}

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -1456,7 +1456,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 1`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 Sample Wallet
                               </span>
@@ -1508,7 +1508,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 1`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 ARK Wallet 2
                               </span>
@@ -1771,7 +1771,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 2`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 Sample Wallet
                               </span>
@@ -1823,7 +1823,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 2`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 ARK Wallet 2
                               </span>
@@ -2086,7 +2086,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive with se
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 Sample Wallet
                               </span>
@@ -2138,7 +2138,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive with se
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 ARK Wallet 2
                               </span>
@@ -5034,7 +5034,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 1`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 Sample Wallet
                               </span>
@@ -5086,7 +5086,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 1`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 ARK Wallet 2
                               </span>
@@ -5349,7 +5349,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 2`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 Sample Wallet
                               </span>
@@ -5401,7 +5401,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 2`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 ARK Wallet 2
                               </span>
@@ -5664,7 +5664,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive with sel
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 Sample Wallet
                               </span>
@@ -5716,7 +5716,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive with sel
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
+                                class="w-full max-w-48 truncate text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 xs:max-w-80 sm:max-w-128"
                               >
                                 ARK Wallet 2
                               </span>

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`SearchWallet uses fiat value = false > should render 1`] = `
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -342,7 +342,7 @@ exports[`SearchWallet uses fiat value = false > should render 1`] = `
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -692,7 +692,7 @@ exports[`SearchWallet uses fiat value = false > should render compact on md scre
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -757,7 +757,7 @@ exports[`SearchWallet uses fiat value = false > should render compact on md scre
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -1107,7 +1107,7 @@ exports[`SearchWallet uses fiat value = false > should render compact with selec
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-3 ml-3 bg-theme-success-100 rounded-l dark:bg-transparent dark:border-y-2 dark:border-l-2 dark:border-theme-success-600 space-x-4 my-0.5"
@@ -1170,7 +1170,7 @@ exports[`SearchWallet uses fiat value = false > should render compact with selec
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -1456,7 +1456,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 1`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 Sample Wallet
                               </span>
@@ -1508,7 +1508,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 1`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 ARK Wallet 2
                               </span>
@@ -1771,7 +1771,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 2`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 Sample Wallet
                               </span>
@@ -1823,7 +1823,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive item 2`
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 ARK Wallet 2
                               </span>
@@ -2086,7 +2086,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive with se
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 Sample Wallet
                               </span>
@@ -2138,7 +2138,7 @@ exports[`SearchWallet uses fiat value = false > should render responsive with se
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 ARK Wallet 2
                               </span>
@@ -2465,7 +2465,7 @@ exports[`SearchWallet uses fiat value = false > should render with incompatible 
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -2805,7 +2805,7 @@ exports[`SearchWallet uses fiat value = false > should render with selected addr
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-3 ml-3 bg-theme-success-100 rounded-l dark:bg-transparent dark:border-y-2 dark:border-l-2 dark:border-theme-success-600 space-x-4 my-0.5"
@@ -2868,7 +2868,7 @@ exports[`SearchWallet uses fiat value = false > should render with selected addr
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -3218,7 +3218,7 @@ exports[`SearchWallet uses fiat value = false > should render with the default e
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -3283,7 +3283,7 @@ exports[`SearchWallet uses fiat value = false > should render with the default e
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -3679,7 +3679,7 @@ exports[`SearchWallet uses fiat value = true > should render 1`] = `
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -3758,7 +3758,7 @@ exports[`SearchWallet uses fiat value = true > should render 1`] = `
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -4168,7 +4168,7 @@ exports[`SearchWallet uses fiat value = true > should render compact on md scree
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -4247,7 +4247,7 @@ exports[`SearchWallet uses fiat value = true > should render compact on md scree
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -4657,7 +4657,7 @@ exports[`SearchWallet uses fiat value = true > should render compact with select
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-3 ml-3 bg-theme-success-100 rounded-l dark:bg-transparent dark:border-y-2 dark:border-l-2 dark:border-theme-success-600 space-x-4 my-0.5"
@@ -4734,7 +4734,7 @@ exports[`SearchWallet uses fiat value = true > should render compact with select
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -5034,7 +5034,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 1`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 Sample Wallet
                               </span>
@@ -5086,7 +5086,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 1`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 ARK Wallet 2
                               </span>
@@ -5349,7 +5349,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 2`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 Sample Wallet
                               </span>
@@ -5401,7 +5401,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive item 2`]
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 ARK Wallet 2
                               </span>
@@ -5664,7 +5664,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive with sel
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 Sample Wallet
                               </span>
@@ -5716,7 +5716,7 @@ exports[`SearchWallet uses fiat value = true > should render responsive with sel
                               class="flex flex-col gap-2 pl-2 pt-2"
                             >
                               <span
-                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200 truncate max-w-48 xs:max-w-80 sm:max-w-128 w-full"
                               >
                                 ARK Wallet 2
                               </span>
@@ -6089,7 +6089,7 @@ exports[`SearchWallet uses fiat value = true > should render with incompatible l
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -6489,7 +6489,7 @@ exports[`SearchWallet uses fiat value = true > should render with selected addre
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-3 ml-3 bg-theme-success-100 rounded-l dark:bg-transparent dark:border-y-2 dark:border-l-2 dark:border-theme-success-600 space-x-4 my-0.5"
@@ -6566,7 +6566,7 @@ exports[`SearchWallet uses fiat value = true > should render with selected addre
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -6976,7 +6976,7 @@ exports[`SearchWallet uses fiat value = true > should render with the default ex
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"
@@ -7055,7 +7055,7 @@ exports[`SearchWallet uses fiat value = true > should render with the default ex
                         data-testid="TableRow"
                       >
                         <td
-                          class="w-full"
+                          class="w-full max-w-28"
                         >
                           <div
                             class="flex px-3 items-center transition-colors duration-100 min-h-11 pl-6 rounded-l space-x-4 my-0.5"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transfer] handle truncation in select sender](https://app.clickup.com/t/86dv1uc0a)

## Summary

- Truncation has been added for the wallet name.
- Max width has been set for the wallet name in desktop view.

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/70759711-bfed-4f19-98c4-1e83c83841e5">

<img width="422" alt="image" src="https://github.com/user-attachments/assets/dfb4e45d-47b7-4488-8de2-a8b8e4b70ede">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
