### PR TITLE
refactor: label hover style

### DIFF
--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`AmountLabel > should render with hint 1`] = `
 exports[`AmountLabel > should render zero 1`] = `
 <DocumentFragment>
   <div
-    class="flex h-full items-center justify-center rounded px-1.5 css-1vn5kd9"
+    class="flex h-full items-center justify-center rounded px-1.5 css-1sycv4s"
     color="secondary"
     data-testid="AmountLabel__wrapper"
   >

--- a/src/app/components/Label/Label.styles.tsx
+++ b/src/app/components/Label/Label.styles.tsx
@@ -38,7 +38,7 @@ const getColor = (color?: ColorType, variant?: string) => {
 			tw`text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:text-theme-secondary-500 dark:bg-transparent dark:border-theme-secondary-800`,
 		primary: () => tw`text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500`,
 		secondary: () =>
-			tw`text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent`,
+			tw`text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent`,
 		success: () => tw`text-theme-success-600 border-theme-success-200 dark:border-theme-success-600`,
 		"success-bg": () =>
 			tw`bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500`,

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -1542,7 +1542,7 @@ exports[`Dashboard > should render 1`] = `
                     >
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                         >
                           <div
                             class="flex flex-col gap-1 font-semibold"
@@ -1586,7 +1586,7 @@ exports[`Dashboard > should render 1`] = `
                         data-testid="TransactionRow__timestamp"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                         >
                           <span
                             data-testid="TimeAgo"
@@ -1597,10 +1597,10 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                         >
                           <div
-                            class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                            class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                             color="secondary"
                             data-testid="TransactionRow__type"
                           >
@@ -1610,7 +1610,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                         >
                           <div
                             class="flex flex-row gap-2"
@@ -1652,7 +1652,7 @@ exports[`Dashboard > should render 1`] = `
                         class="hidden lg:table-cell"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <div
                             class="flex flex-col items-end gap-1"
@@ -1689,7 +1689,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <span
                             class="whitespace-nowrap"
@@ -1706,7 +1706,7 @@ exports[`Dashboard > should render 1`] = `
                     >
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                         >
                           <div
                             class="flex flex-col gap-1 font-semibold"
@@ -1750,7 +1750,7 @@ exports[`Dashboard > should render 1`] = `
                         data-testid="TransactionRow__timestamp"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                         >
                           <span
                             data-testid="TimeAgo"
@@ -1761,10 +1761,10 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                         >
                           <div
-                            class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                            class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                             color="secondary"
                             data-testid="TransactionRow__type"
                           >
@@ -1774,7 +1774,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                         >
                           <div
                             class="flex flex-row gap-2"
@@ -1816,7 +1816,7 @@ exports[`Dashboard > should render 1`] = `
                         class="hidden lg:table-cell"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <div
                             class="flex flex-col items-end gap-1"
@@ -1853,7 +1853,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <span
                             class="whitespace-nowrap"
@@ -1870,7 +1870,7 @@ exports[`Dashboard > should render 1`] = `
                     >
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                         >
                           <div
                             class="flex flex-col gap-1 font-semibold"
@@ -1914,7 +1914,7 @@ exports[`Dashboard > should render 1`] = `
                         data-testid="TransactionRow__timestamp"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                         >
                           <span
                             data-testid="TimeAgo"
@@ -1925,10 +1925,10 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                         >
                           <div
-                            class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                            class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                             color="secondary"
                             data-testid="TransactionRow__type"
                           >
@@ -1938,7 +1938,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                         >
                           <div
                             class="flex flex-row gap-2"
@@ -1980,7 +1980,7 @@ exports[`Dashboard > should render 1`] = `
                         class="hidden lg:table-cell"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <div
                             class="flex flex-col items-end gap-1"
@@ -2017,7 +2017,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <span
                             class="whitespace-nowrap"
@@ -2034,7 +2034,7 @@ exports[`Dashboard > should render 1`] = `
                     >
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                          class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                         >
                           <div
                             class="flex flex-col gap-1 font-semibold"
@@ -2078,7 +2078,7 @@ exports[`Dashboard > should render 1`] = `
                         data-testid="TransactionRow__timestamp"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                         >
                           <span
                             data-testid="TimeAgo"
@@ -2089,10 +2089,10 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                         >
                           <div
-                            class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                            class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                             color="secondary"
                             data-testid="TransactionRow__type"
                           >
@@ -2102,7 +2102,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                          class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                         >
                           <div
                             class="flex flex-row gap-2"
@@ -2144,7 +2144,7 @@ exports[`Dashboard > should render 1`] = `
                         class="hidden lg:table-cell"
                       >
                         <div
-                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <div
                             class="flex flex-col items-end gap-1"
@@ -2181,7 +2181,7 @@ exports[`Dashboard > should render 1`] = `
                       </td>
                       <td>
                         <div
-                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                          class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                         >
                           <span
                             class="whitespace-nowrap"

--- a/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`Signed Transaction Table > should handle the onRowClick function when t
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -1035,7 +1035,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -1759,7 +1759,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -2416,7 +2416,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                   >
                     Unvote
@@ -3035,7 +3035,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                   >
                     Vote
@@ -3703,7 +3703,7 @@ exports[`Signed Transaction Table > should render different status > should show
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -4206,7 +4206,7 @@ exports[`Signed Transaction Table > should render ready to broadcast transaction
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -4681,7 +4681,7 @@ exports[`Signed Transaction Table > should render signed transactions and handle
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -5166,7 +5166,7 @@ exports[`Signed Transaction Table > should show as awaiting confirmations 1`] = 
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                   >
                     Transfer
@@ -5801,7 +5801,7 @@ exports[`Signed Transaction Table > should show the sign button with isCompact =
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >
@@ -6304,7 +6304,7 @@ exports[`Signed Transaction Table > should show the sign button with isCompact =
                   class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-3 min-h-14 xl:min-h-11"
                 >
                   <div
-                    class="rounded px-1 dark:border css-1kocbuc"
+                    class="rounded px-1 dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRowRecipientLabel"
                   >

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -53,7 +53,7 @@ export const TransactionRow = memo(
 			<TableRow onClick={onClick} className={twMerge("relative", className)} {...properties}>
 				<TableCell
 					variant="start"
-					innerClassName="items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+					innerClassName="items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
 				>
 					<div className="flex flex-col gap-1 font-semibold">
 						<Link to={transaction.explorerLink()} showExternalIcon={false} isExternal>
@@ -78,7 +78,7 @@ export const TransactionRow = memo(
 
 				<TableCell
 					className="hidden xl:table-cell"
-					innerClassName="text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+					innerClassName="text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
 					data-testid="TransactionRow__timestamp"
 				>
 					{timeStamp ? (
@@ -88,7 +88,7 @@ export const TransactionRow = memo(
 					)}
 				</TableCell>
 
-				<TableCell innerClassName="items-start my-1 pt-2 min-h-14 xl:min-h-11">
+				<TableCell innerClassName="items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3">
 					<Label
 						color="secondary"
 						size="xs"
@@ -100,13 +100,13 @@ export const TransactionRow = memo(
 					</Label>
 				</TableCell>
 
-				<TableCell innerClassName="space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center">
+				<TableCell innerClassName="space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11">
 					<TransactionRowAddressing transaction={transaction} profile={profile} />
 				</TableCell>
 
 				<TableCell
 					className="hidden lg:table-cell"
-					innerClassName="justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+					innerClassName="justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
 				>
 					<div className="flex flex-col items-end gap-1">
 						<TransactionAmountLabel transaction={transaction} />
@@ -121,7 +121,7 @@ export const TransactionRow = memo(
 
 				<TableCell
 					variant="end"
-					innerClassName="justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+					innerClassName="justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
 				>
 					{isLgAndAbove ? (
 						<Amount value={transaction.convertedTotal()} ticker={exchangeCurrency || ""} />

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
       >
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
           >
             <div
               class="flex flex-col gap-1 font-semibold"
@@ -54,7 +54,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
           data-testid="TransactionRow__timestamp"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
           >
             <span
               data-testid="TimeAgo"
@@ -65,10 +65,10 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
         </td>
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
           >
             <div
-              class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+              class="rounded px-1 py-[3px] dark:border css-a8yjl2"
               color="secondary"
               data-testid="TransactionRow__type"
             >
@@ -78,7 +78,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
         </td>
         <td>
           <div
-            class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+            class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
           >
             <div
               class="flex flex-row gap-2"
@@ -120,7 +120,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
           class="hidden lg:table-cell"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
           >
             <div
               class="flex flex-col items-end gap-1"
@@ -157,7 +157,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
         </td>
         <td>
           <div
-            class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+            class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
           >
             <span
               class="whitespace-nowrap"
@@ -183,7 +183,7 @@ exports[`TransactionRow > should render 1`] = `
       >
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
           >
             <div
               class="flex flex-col gap-1 font-semibold"
@@ -227,7 +227,7 @@ exports[`TransactionRow > should render 1`] = `
           data-testid="TransactionRow__timestamp"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
           >
             <span
               data-testid="TimeAgo"
@@ -238,10 +238,10 @@ exports[`TransactionRow > should render 1`] = `
         </td>
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
           >
             <div
-              class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+              class="rounded px-1 py-[3px] dark:border css-a8yjl2"
               color="secondary"
               data-testid="TransactionRow__type"
             >
@@ -251,7 +251,7 @@ exports[`TransactionRow > should render 1`] = `
         </td>
         <td>
           <div
-            class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+            class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
           >
             <div
               class="flex flex-row gap-2"
@@ -304,7 +304,7 @@ exports[`TransactionRow > should render 1`] = `
           class="hidden lg:table-cell"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
           >
             <div
               class="flex flex-col items-end gap-1"
@@ -341,7 +341,7 @@ exports[`TransactionRow > should render 1`] = `
         </td>
         <td>
           <div
-            class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+            class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
           >
             <span
               class="whitespace-nowrap"
@@ -948,7 +948,7 @@ exports[`TransactionRow > should render with currency 1`] = `
       >
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
           >
             <div
               class="flex flex-col gap-1 font-semibold"
@@ -992,7 +992,7 @@ exports[`TransactionRow > should render with currency 1`] = `
           data-testid="TransactionRow__timestamp"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
           >
             <span
               data-testid="TimeAgo"
@@ -1003,10 +1003,10 @@ exports[`TransactionRow > should render with currency 1`] = `
         </td>
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
           >
             <div
-              class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+              class="rounded px-1 py-[3px] dark:border css-a8yjl2"
               color="secondary"
               data-testid="TransactionRow__type"
             >
@@ -1016,7 +1016,7 @@ exports[`TransactionRow > should render with currency 1`] = `
         </td>
         <td>
           <div
-            class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+            class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
           >
             <div
               class="flex flex-row gap-2"
@@ -1058,7 +1058,7 @@ exports[`TransactionRow > should render with currency 1`] = `
           class="hidden lg:table-cell"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
           >
             <div
               class="flex flex-col items-end gap-1"
@@ -1095,7 +1095,7 @@ exports[`TransactionRow > should render with currency 1`] = `
         </td>
         <td>
           <div
-            class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+            class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
           >
             <span
               class="whitespace-nowrap"

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -6059,7 +6059,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -6103,7 +6103,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -6114,10 +6114,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -6127,7 +6127,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -6169,7 +6169,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6206,7 +6206,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6248,7 +6248,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -6292,7 +6292,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -6303,10 +6303,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -6316,7 +6316,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -6369,7 +6369,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6406,7 +6406,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6448,7 +6448,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -6492,7 +6492,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -6503,10 +6503,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -6516,7 +6516,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -6558,7 +6558,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6595,7 +6595,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6637,7 +6637,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -6681,7 +6681,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -6692,10 +6692,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -6705,7 +6705,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -6747,7 +6747,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6784,7 +6784,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6826,7 +6826,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -6870,7 +6870,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -6881,10 +6881,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -6894,7 +6894,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -6936,7 +6936,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -6973,7 +6973,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7015,7 +7015,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -7059,7 +7059,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -7070,10 +7070,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -7083,7 +7083,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -7125,7 +7125,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7162,7 +7162,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7204,7 +7204,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -7248,7 +7248,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -7259,10 +7259,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -7272,7 +7272,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -7314,7 +7314,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7351,7 +7351,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7393,7 +7393,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -7437,7 +7437,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -7448,10 +7448,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -7461,7 +7461,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -7503,7 +7503,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7540,7 +7540,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7582,7 +7582,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -7626,7 +7626,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -7637,10 +7637,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -7650,7 +7650,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -7692,7 +7692,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7729,7 +7729,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7771,7 +7771,7 @@ exports[`TransactionTable > should render responsive 3`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -7815,7 +7815,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -7826,10 +7826,10 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -7839,7 +7839,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -7892,7 +7892,7 @@ exports[`TransactionTable > should render responsive 3`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -7929,7 +7929,7 @@ exports[`TransactionTable > should render responsive 3`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -8187,7 +8187,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -8231,7 +8231,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -8242,10 +8242,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8255,7 +8255,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -8297,7 +8297,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -8334,7 +8334,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -8351,7 +8351,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -8395,7 +8395,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -8406,10 +8406,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8419,7 +8419,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -8472,7 +8472,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -8509,7 +8509,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -8526,7 +8526,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -8570,7 +8570,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -8581,10 +8581,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8594,7 +8594,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -8636,7 +8636,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -8673,7 +8673,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -8690,7 +8690,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -8734,7 +8734,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -8745,10 +8745,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8758,7 +8758,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -8800,7 +8800,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -8837,7 +8837,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -8854,7 +8854,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -8898,7 +8898,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -8909,10 +8909,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -8922,7 +8922,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -8964,7 +8964,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -9001,7 +9001,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -9018,7 +9018,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -9062,7 +9062,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -9073,10 +9073,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9086,7 +9086,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -9128,7 +9128,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -9165,7 +9165,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -9182,7 +9182,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -9226,7 +9226,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -9237,10 +9237,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9250,7 +9250,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -9292,7 +9292,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -9329,7 +9329,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -9346,7 +9346,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -9390,7 +9390,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -9401,10 +9401,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9414,7 +9414,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -9456,7 +9456,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -9493,7 +9493,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -9510,7 +9510,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -9554,7 +9554,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -9565,10 +9565,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9578,7 +9578,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -9620,7 +9620,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -9657,7 +9657,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -9674,7 +9674,7 @@ exports[`TransactionTable > should render responsive 4`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -9718,7 +9718,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -9729,10 +9729,10 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -9742,7 +9742,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -9795,7 +9795,7 @@ exports[`TransactionTable > should render responsive 4`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -9832,7 +9832,7 @@ exports[`TransactionTable > should render responsive 4`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -10065,7 +10065,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -10109,7 +10109,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -10120,10 +10120,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10133,7 +10133,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -10175,7 +10175,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -10212,7 +10212,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -10229,7 +10229,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -10273,7 +10273,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -10284,10 +10284,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10297,7 +10297,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -10350,7 +10350,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -10387,7 +10387,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -10404,7 +10404,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -10448,7 +10448,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -10459,10 +10459,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10472,7 +10472,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -10514,7 +10514,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -10551,7 +10551,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -10568,7 +10568,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -10612,7 +10612,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -10623,10 +10623,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10636,7 +10636,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -10678,7 +10678,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -10715,7 +10715,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -10732,7 +10732,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -10776,7 +10776,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -10787,10 +10787,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10800,7 +10800,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -10842,7 +10842,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -10879,7 +10879,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -10896,7 +10896,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -10940,7 +10940,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -10951,10 +10951,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -10964,7 +10964,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -11006,7 +11006,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -11043,7 +11043,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -11060,7 +11060,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -11104,7 +11104,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -11115,10 +11115,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11128,7 +11128,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -11170,7 +11170,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -11207,7 +11207,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -11224,7 +11224,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -11268,7 +11268,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -11279,10 +11279,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11292,7 +11292,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -11334,7 +11334,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -11371,7 +11371,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -11388,7 +11388,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -11432,7 +11432,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -11443,10 +11443,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11456,7 +11456,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -11498,7 +11498,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -11535,7 +11535,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"
@@ -11552,7 +11552,7 @@ exports[`TransactionTable > should render responsive 5`] = `
           >
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
               >
                 <div
                   class="flex flex-col gap-1 font-semibold"
@@ -11596,7 +11596,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               data-testid="TransactionRow__timestamp"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
               >
                 <span
                   data-testid="TimeAgo"
@@ -11607,10 +11607,10 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
               >
                 <div
-                  class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                  class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                   color="secondary"
                   data-testid="TransactionRow__type"
                 >
@@ -11620,7 +11620,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
               >
                 <div
                   class="flex flex-row gap-2"
@@ -11673,7 +11673,7 @@ exports[`TransactionTable > should render responsive 5`] = `
               class="hidden lg:table-cell"
             >
               <div
-                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <div
                   class="flex flex-col items-end gap-1"
@@ -11710,7 +11710,7 @@ exports[`TransactionTable > should render responsive 5`] = `
             </td>
             <td>
               <div
-                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
               >
                 <span
                   class="whitespace-nowrap"

--- a/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -472,7 +472,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -516,7 +516,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -527,10 +527,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -540,7 +540,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -570,13 +570,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -607,7 +607,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -624,7 +624,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -668,7 +668,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -679,10 +679,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -692,7 +692,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -722,7 +722,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -759,7 +759,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -776,7 +776,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -820,7 +820,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -831,10 +831,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -844,7 +844,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -874,13 +874,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -911,7 +911,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -928,7 +928,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -972,7 +972,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -983,10 +983,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -996,7 +996,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1026,7 +1026,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -1063,7 +1063,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1080,7 +1080,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -1124,7 +1124,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -1135,10 +1135,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1148,7 +1148,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1178,13 +1178,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -1215,7 +1215,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1232,7 +1232,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -1276,7 +1276,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -1287,10 +1287,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1300,7 +1300,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1330,7 +1330,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -1367,7 +1367,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1384,7 +1384,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -1428,7 +1428,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -1439,10 +1439,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1452,7 +1452,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1482,13 +1482,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -1519,7 +1519,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1536,7 +1536,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -1580,7 +1580,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -1591,10 +1591,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1604,7 +1604,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1634,7 +1634,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -1671,7 +1671,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1688,7 +1688,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -1732,7 +1732,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -1743,10 +1743,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1756,7 +1756,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1781,7 +1781,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -1818,7 +1818,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1835,7 +1835,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -1879,7 +1879,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -1890,10 +1890,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -1903,7 +1903,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -1928,13 +1928,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -1965,7 +1965,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -1982,7 +1982,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2026,7 +2026,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2037,10 +2037,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2050,7 +2050,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -2075,7 +2075,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -2112,7 +2112,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -2129,7 +2129,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2173,7 +2173,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2184,10 +2184,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2197,7 +2197,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -2222,13 +2222,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -2259,7 +2259,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -2276,7 +2276,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2320,7 +2320,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2331,10 +2331,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2344,7 +2344,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -2386,7 +2386,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -2423,7 +2423,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -2440,7 +2440,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2484,7 +2484,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2495,10 +2495,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2508,7 +2508,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -2550,7 +2550,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -2587,7 +2587,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -2604,7 +2604,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2648,7 +2648,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2659,10 +2659,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2672,7 +2672,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -2714,7 +2714,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -2751,7 +2751,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -2768,7 +2768,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2812,7 +2812,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2823,10 +2823,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -2836,7 +2836,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -2878,7 +2878,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -2915,7 +2915,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -2932,7 +2932,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -2976,7 +2976,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -2987,10 +2987,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3000,7 +3000,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -3042,7 +3042,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -3079,7 +3079,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -3096,7 +3096,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -3140,7 +3140,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -3151,10 +3151,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3164,7 +3164,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -3206,7 +3206,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -3243,7 +3243,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -3260,7 +3260,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -3304,7 +3304,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -3315,10 +3315,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3328,7 +3328,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -3370,7 +3370,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -3407,7 +3407,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -3424,7 +3424,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -3468,7 +3468,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -3479,10 +3479,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3492,7 +3492,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -3534,7 +3534,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -3571,7 +3571,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -3588,7 +3588,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -3632,7 +3632,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -3643,10 +3643,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3656,7 +3656,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -3698,7 +3698,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -3735,7 +3735,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -3752,7 +3752,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -3796,7 +3796,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -3807,10 +3807,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3820,7 +3820,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -3862,7 +3862,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -3899,7 +3899,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -3916,7 +3916,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -3960,7 +3960,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -3971,10 +3971,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -3984,7 +3984,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -4026,7 +4026,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -4063,7 +4063,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -4080,7 +4080,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -4124,7 +4124,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -4135,10 +4135,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4148,7 +4148,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -4190,7 +4190,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -4227,7 +4227,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -4244,7 +4244,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -4288,7 +4288,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -4299,10 +4299,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4312,7 +4312,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -4354,7 +4354,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -4391,7 +4391,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -4408,7 +4408,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -4452,7 +4452,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -4463,10 +4463,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4476,7 +4476,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -4518,7 +4518,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -4555,7 +4555,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -4572,7 +4572,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -4616,7 +4616,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -4627,10 +4627,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4640,7 +4640,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -4682,7 +4682,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -4719,7 +4719,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -4736,7 +4736,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -4780,7 +4780,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -4791,10 +4791,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4804,7 +4804,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -4846,7 +4846,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -4883,7 +4883,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -4900,7 +4900,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -4944,7 +4944,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -4955,10 +4955,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -4968,7 +4968,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5010,7 +5010,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -5047,7 +5047,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -5064,7 +5064,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -5108,7 +5108,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -5119,10 +5119,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5132,7 +5132,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5174,7 +5174,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -5211,7 +5211,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -5228,7 +5228,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -5272,7 +5272,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -5283,10 +5283,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5296,7 +5296,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5338,7 +5338,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -5375,7 +5375,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -5392,7 +5392,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -5436,7 +5436,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -5447,10 +5447,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5460,7 +5460,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5502,7 +5502,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -5539,7 +5539,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -5556,7 +5556,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -5600,7 +5600,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -5611,10 +5611,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5624,7 +5624,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5666,7 +5666,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -5703,7 +5703,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -5720,7 +5720,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -5764,7 +5764,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -5775,10 +5775,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5788,7 +5788,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5830,7 +5830,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -5867,7 +5867,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -5884,7 +5884,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -5928,7 +5928,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -5939,10 +5939,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -5952,7 +5952,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -5994,7 +5994,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -6031,7 +6031,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -6048,7 +6048,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -6092,7 +6092,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -6103,10 +6103,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6116,7 +6116,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -6158,7 +6158,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -6195,7 +6195,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -6212,7 +6212,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -6256,7 +6256,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -6267,10 +6267,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6280,7 +6280,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -6322,7 +6322,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -6359,7 +6359,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -6376,7 +6376,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -6420,7 +6420,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -6431,10 +6431,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6444,7 +6444,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -6486,7 +6486,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -6523,7 +6523,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -6540,7 +6540,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -6584,7 +6584,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -6595,10 +6595,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6608,7 +6608,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -6650,7 +6650,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -6687,7 +6687,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -6704,7 +6704,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -6748,7 +6748,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -6759,10 +6759,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6772,7 +6772,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -6814,7 +6814,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -6851,7 +6851,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -6868,7 +6868,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -6912,7 +6912,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -6923,10 +6923,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -6936,7 +6936,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -6978,7 +6978,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -7015,7 +7015,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -7032,7 +7032,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -7076,7 +7076,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -7087,10 +7087,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7100,7 +7100,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -7142,7 +7142,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -7179,7 +7179,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -7196,7 +7196,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -7240,7 +7240,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -7251,10 +7251,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7264,7 +7264,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -7306,7 +7306,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -7343,7 +7343,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -7360,7 +7360,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -7404,7 +7404,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -7415,10 +7415,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7428,7 +7428,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -7470,7 +7470,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -7507,7 +7507,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -7524,7 +7524,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -7568,7 +7568,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -7579,10 +7579,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7592,7 +7592,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -7634,13 +7634,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -7671,7 +7671,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -7688,7 +7688,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -7732,7 +7732,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -7743,10 +7743,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7756,7 +7756,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -7798,13 +7798,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -7835,7 +7835,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -7852,7 +7852,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -7896,7 +7896,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -7907,10 +7907,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -7920,7 +7920,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -7962,13 +7962,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -7999,7 +7999,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -8016,7 +8016,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -8060,7 +8060,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -8071,10 +8071,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8084,7 +8084,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -8126,13 +8126,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -8163,7 +8163,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -8180,7 +8180,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -8224,7 +8224,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -8235,10 +8235,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8248,7 +8248,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -8290,7 +8290,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -8327,7 +8327,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -8344,7 +8344,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -8388,7 +8388,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -8399,10 +8399,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8412,7 +8412,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -8454,7 +8454,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -8491,7 +8491,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -8508,7 +8508,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -8552,7 +8552,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -8563,10 +8563,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8576,7 +8576,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -8618,7 +8618,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -8655,7 +8655,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -8672,7 +8672,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -8716,7 +8716,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -8727,10 +8727,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8740,7 +8740,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -8782,7 +8782,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -8819,7 +8819,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -8836,7 +8836,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -8880,7 +8880,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -8891,10 +8891,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -8904,7 +8904,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -8950,13 +8950,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -8987,7 +8987,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -9004,7 +9004,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -9048,7 +9048,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -9059,10 +9059,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9072,7 +9072,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -9118,13 +9118,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -9155,7 +9155,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -9172,7 +9172,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -9216,7 +9216,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -9227,10 +9227,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9240,7 +9240,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -9286,13 +9286,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -9323,7 +9323,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -9340,7 +9340,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -9384,7 +9384,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -9395,10 +9395,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9408,7 +9408,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -9454,13 +9454,13 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -9491,7 +9491,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -9508,7 +9508,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -9552,7 +9552,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -9563,10 +9563,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9576,7 +9576,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -9618,7 +9618,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -9655,7 +9655,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -9672,7 +9672,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -9716,7 +9716,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -9727,10 +9727,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9740,7 +9740,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -9782,7 +9782,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -9819,7 +9819,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -9836,7 +9836,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -9880,7 +9880,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -9891,10 +9891,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -9904,7 +9904,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -9946,7 +9946,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -9983,7 +9983,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -10000,7 +10000,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -10044,7 +10044,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -10055,10 +10055,10 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -10068,7 +10068,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -10110,7 +10110,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -10147,7 +10147,7 @@ exports[`Transactions > should fetch more transactions 1`] = `
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -10653,7 +10653,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -10697,7 +10697,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -10708,10 +10708,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -10721,7 +10721,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -10751,13 +10751,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -10788,7 +10788,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -10805,7 +10805,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -10849,7 +10849,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -10860,10 +10860,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -10873,7 +10873,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -10903,7 +10903,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -10940,7 +10940,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -10957,7 +10957,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11001,7 +11001,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11012,10 +11012,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11025,7 +11025,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11055,13 +11055,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -11092,7 +11092,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -11109,7 +11109,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11153,7 +11153,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11164,10 +11164,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11177,7 +11177,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11207,7 +11207,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -11244,7 +11244,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -11261,7 +11261,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11305,7 +11305,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11316,10 +11316,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11329,7 +11329,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11354,7 +11354,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -11391,7 +11391,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -11408,7 +11408,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11452,7 +11452,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11463,10 +11463,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11476,7 +11476,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11501,13 +11501,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -11538,7 +11538,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -11555,7 +11555,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11599,7 +11599,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11610,10 +11610,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11623,7 +11623,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11665,7 +11665,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -11702,7 +11702,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -11719,7 +11719,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11763,7 +11763,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11774,10 +11774,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11787,7 +11787,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11829,7 +11829,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -11866,7 +11866,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -11883,7 +11883,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -11927,7 +11927,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -11938,10 +11938,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -11951,7 +11951,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -11993,7 +11993,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -12030,7 +12030,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -12047,7 +12047,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -12091,7 +12091,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -12102,10 +12102,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12115,7 +12115,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -12157,7 +12157,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -12194,7 +12194,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -12211,7 +12211,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -12255,7 +12255,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -12266,10 +12266,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12279,7 +12279,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -12321,7 +12321,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -12358,7 +12358,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -12375,7 +12375,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -12419,7 +12419,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -12430,10 +12430,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12443,7 +12443,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -12485,7 +12485,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -12522,7 +12522,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -12539,7 +12539,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -12583,7 +12583,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -12594,10 +12594,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12607,7 +12607,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -12649,7 +12649,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -12686,7 +12686,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -12703,7 +12703,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -12747,7 +12747,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -12758,10 +12758,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12771,7 +12771,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -12813,7 +12813,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -12850,7 +12850,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -12867,7 +12867,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -12911,7 +12911,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -12922,10 +12922,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -12935,7 +12935,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -12977,7 +12977,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13014,7 +13014,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -13031,7 +13031,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -13075,7 +13075,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -13086,10 +13086,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13099,7 +13099,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -13141,7 +13141,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13178,7 +13178,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -13195,7 +13195,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -13239,7 +13239,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -13250,10 +13250,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13263,7 +13263,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -13305,7 +13305,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13342,7 +13342,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -13359,7 +13359,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -13403,7 +13403,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -13414,10 +13414,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13427,7 +13427,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -13469,7 +13469,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13506,7 +13506,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -13523,7 +13523,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -13567,7 +13567,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -13578,10 +13578,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13591,7 +13591,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -13633,7 +13633,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13670,7 +13670,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -13687,7 +13687,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -13731,7 +13731,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -13742,10 +13742,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13755,7 +13755,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -13797,7 +13797,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13834,7 +13834,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -13851,7 +13851,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -13895,7 +13895,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -13906,10 +13906,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -13919,7 +13919,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -13961,7 +13961,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -13998,7 +13998,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -14015,7 +14015,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -14059,7 +14059,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -14070,10 +14070,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14083,7 +14083,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -14125,7 +14125,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -14162,7 +14162,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -14179,7 +14179,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -14223,7 +14223,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -14234,10 +14234,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14247,7 +14247,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -14289,13 +14289,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -14326,7 +14326,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -14343,7 +14343,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -14387,7 +14387,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -14398,10 +14398,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14411,7 +14411,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -14453,13 +14453,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -14490,7 +14490,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -14507,7 +14507,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -14551,7 +14551,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -14562,10 +14562,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14575,7 +14575,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -14617,7 +14617,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -14654,7 +14654,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -14671,7 +14671,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -14715,7 +14715,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -14726,10 +14726,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14739,7 +14739,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -14781,7 +14781,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -14818,7 +14818,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -14835,7 +14835,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -14879,7 +14879,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -14890,10 +14890,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -14903,7 +14903,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -14949,13 +14949,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -14986,7 +14986,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -15003,7 +15003,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -15047,7 +15047,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -15058,10 +15058,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -15071,7 +15071,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -15117,13 +15117,13 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -15154,7 +15154,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -15171,7 +15171,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -15215,7 +15215,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -15226,10 +15226,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -15239,7 +15239,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -15281,7 +15281,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -15318,7 +15318,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -15335,7 +15335,7 @@ exports[`Transactions > should hide view more button when there are no next page
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -15379,7 +15379,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -15390,10 +15390,10 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -15403,7 +15403,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -15445,7 +15445,7 @@ exports[`Transactions > should hide view more button when there are no next page
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -15482,7 +15482,7 @@ exports[`Transactions > should hide view more button when there are no next page
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -15988,7 +15988,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16032,7 +16032,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16043,10 +16043,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16056,7 +16056,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -16086,13 +16086,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -16123,7 +16123,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -16140,7 +16140,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16184,7 +16184,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16195,10 +16195,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16208,7 +16208,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -16238,7 +16238,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -16275,7 +16275,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -16292,7 +16292,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16336,7 +16336,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16347,10 +16347,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16360,7 +16360,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -16390,13 +16390,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -16427,7 +16427,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -16444,7 +16444,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16488,7 +16488,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16499,10 +16499,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16512,7 +16512,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -16542,7 +16542,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -16579,7 +16579,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -16596,7 +16596,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16640,7 +16640,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16651,10 +16651,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16664,7 +16664,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -16689,7 +16689,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -16726,7 +16726,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -16743,7 +16743,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16787,7 +16787,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16798,10 +16798,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16811,7 +16811,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -16836,13 +16836,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -16873,7 +16873,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -16890,7 +16890,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -16934,7 +16934,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -16945,10 +16945,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -16958,7 +16958,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17000,7 +17000,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -17037,7 +17037,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -17054,7 +17054,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -17098,7 +17098,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -17109,10 +17109,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17122,7 +17122,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17164,7 +17164,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -17201,7 +17201,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -17218,7 +17218,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -17262,7 +17262,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -17273,10 +17273,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17286,7 +17286,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17328,7 +17328,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -17365,7 +17365,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -17382,7 +17382,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -17426,7 +17426,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -17437,10 +17437,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17450,7 +17450,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17492,7 +17492,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -17529,7 +17529,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -17546,7 +17546,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -17590,7 +17590,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -17601,10 +17601,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17614,7 +17614,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17656,7 +17656,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -17693,7 +17693,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -17710,7 +17710,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -17754,7 +17754,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -17765,10 +17765,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17778,7 +17778,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17820,7 +17820,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -17857,7 +17857,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -17874,7 +17874,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -17918,7 +17918,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -17929,10 +17929,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -17942,7 +17942,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -17984,7 +17984,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -18021,7 +18021,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -18038,7 +18038,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -18082,7 +18082,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -18093,10 +18093,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18106,7 +18106,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -18148,7 +18148,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -18185,7 +18185,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -18202,7 +18202,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -18246,7 +18246,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -18257,10 +18257,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18270,7 +18270,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -18312,7 +18312,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -18349,7 +18349,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -18366,7 +18366,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -18410,7 +18410,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -18421,10 +18421,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18434,7 +18434,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -18476,7 +18476,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -18513,7 +18513,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -18530,7 +18530,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -18574,7 +18574,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -18585,10 +18585,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18598,7 +18598,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -18640,7 +18640,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -18677,7 +18677,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -18694,7 +18694,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -18738,7 +18738,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -18749,10 +18749,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18762,7 +18762,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -18804,7 +18804,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -18841,7 +18841,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -18858,7 +18858,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -18902,7 +18902,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -18913,10 +18913,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -18926,7 +18926,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -18968,7 +18968,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -19005,7 +19005,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -19022,7 +19022,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -19066,7 +19066,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -19077,10 +19077,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19090,7 +19090,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -19132,7 +19132,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -19169,7 +19169,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -19186,7 +19186,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -19230,7 +19230,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -19241,10 +19241,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19254,7 +19254,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -19296,7 +19296,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -19333,7 +19333,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -19350,7 +19350,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -19394,7 +19394,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -19405,10 +19405,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19418,7 +19418,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -19460,7 +19460,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -19497,7 +19497,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -19514,7 +19514,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -19558,7 +19558,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -19569,10 +19569,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19582,7 +19582,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -19624,13 +19624,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -19661,7 +19661,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -19678,7 +19678,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -19722,7 +19722,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -19733,10 +19733,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19746,7 +19746,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -19788,13 +19788,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -19825,7 +19825,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -19842,7 +19842,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -19886,7 +19886,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -19897,10 +19897,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -19910,7 +19910,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -19952,7 +19952,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -19989,7 +19989,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -20006,7 +20006,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -20050,7 +20050,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -20061,10 +20061,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20074,7 +20074,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -20116,7 +20116,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -20153,7 +20153,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -20170,7 +20170,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -20214,7 +20214,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -20225,10 +20225,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20238,7 +20238,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -20284,13 +20284,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -20321,7 +20321,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -20338,7 +20338,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -20382,7 +20382,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -20393,10 +20393,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20406,7 +20406,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -20452,13 +20452,13 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
                   >
                     <div
-                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1vn5kd9"
+                      class="flex items-center justify-center px-1.5 h-[21px] rounded dark:border css-1sycv4s"
                       color="secondary"
                       data-testid="AmountLabel__wrapper"
                     >
@@ -20489,7 +20489,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -20506,7 +20506,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -20550,7 +20550,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -20561,10 +20561,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20574,7 +20574,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -20616,7 +20616,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -20653,7 +20653,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"
@@ -20670,7 +20670,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
             >
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:py-1.5"
+                  class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start py-1 my-1 pr-0 lg:pr-3 min-h-14 xl:min-h-11 xl:max-h-11 xl:pt-2.5"
                 >
                   <div
                     class="flex flex-col gap-1 font-semibold"
@@ -20714,7 +20714,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 data-testid="TransactionRow__timestamp"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-2"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3"
                 >
                   <span
                     data-testid="TimeAgo"
@@ -20725,10 +20725,10 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-start my-1 pt-2 min-h-14 xl:min-h-11 xl:pt-3"
                 >
                   <div
-                    class="rounded px-1 py-[3px] dark:border css-1kocbuc"
+                    class="rounded px-1 py-[3px] dark:border css-a8yjl2"
                     color="secondary"
                     data-testid="TransactionRow__type"
                   >
@@ -20738,7 +20738,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-0 xl:min-h-11 xl:items-center"
+                  class="flex transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-4 items-start min-h-14 my-1 pt-2 px-0 lg:px-3 xl:pt-3 xl:min-h-11"
                 >
                   <div
                     class="flex flex-row gap-2"
@@ -20780,7 +20780,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
                 class="hidden lg:table-cell"
               >
                 <div
-                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 transition-colors duration-100 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <div
                     class="flex flex-col items-end gap-1"
@@ -20817,7 +20817,7 @@ exports[`Transactions > should open detail modal on transaction row click 1`] = 
               </td>
               <td>
                 <div
-                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0"
+                  class="flex px-3 my-1 transition-colors duration-100 pr-3 mr-3 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end items-start text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3"
                 >
                   <span
                     class="whitespace-nowrap"

--- a/src/domains/transaction/components/UnlockTokens/blocks/UnlockTokensSelect/__snapshots__/UnlockTokensSelect.test.tsx.snap
+++ b/src/domains/transaction/components/UnlockTokens/blocks/UnlockTokensSelect/__snapshots__/UnlockTokensSelect.test.tsx.snap
@@ -513,7 +513,7 @@ exports[`UnlockTokensSelect > should render 1`] = `
           Total Amount
         </p>
         <div
-          class="flex h-full items-center justify-center rounded px-1.5 css-1vn5kd9"
+          class="flex h-full items-center justify-center rounded px-1.5 css-1sycv4s"
           color="secondary"
           data-testid="AmountLabel__wrapper"
         >
@@ -539,7 +539,7 @@ exports[`UnlockTokensSelect > should render 1`] = `
           Transaction Fee
         </p>
         <div
-          class="flex h-full items-center justify-center rounded px-1.5 css-1vn5kd9"
+          class="flex h-full items-center justify-center rounded px-1.5 css-1sycv4s"
           color="secondary"
           data-testid="AmountLabel__wrapper"
         >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction tables] grey labels should be darker on hover](https://app.clickup.com/t/86dv4r2j7)

## Summary

- Hover style for labels has been refactored in both dark and light mode.
- Padding for row in transaction table has also been fixed.

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/4e02c825-f600-4ad1-b492-cc718f313805">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
