### PR TITLE
refactor: update three dots icon size

### DIFF
--- a/src/app/components/Card/Card.tsx
+++ b/src/app/components/Card/Card.tsx
@@ -41,7 +41,7 @@ export const Card = ({ variant, children, addonIcons, actions, onClick, onSelect
 								<Icon
 									name="EllipsisVertical"
 									className="cursor-pointer p-1 text-theme-primary-300 transition-colors duration-200 hover:text-theme-primary-400 dark:text-theme-secondary-600 dark:hover:text-theme-secondary-200"
-									size="lg"
+									size="md"
 								/>
 							</div>
 						}

--- a/src/app/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/app/components/Card/__snapshots__/Card.test.tsx.snap
@@ -56,9 +56,9 @@ exports[`Card > should render with custom options 1`] = `
             class="flex w-4 justify-center overflow-hidden"
           >
             <div
-              class="cursor-pointer p-1 text-theme-primary-300 transition-colors duration-200 hover:text-theme-primary-400 dark:text-theme-secondary-600 dark:hover:text-theme-secondary-200 css-1i4b0eq"
-              height="20"
-              width="20"
+              class="cursor-pointer p-1 text-theme-primary-300 transition-colors duration-200 hover:text-theme-primary-400 dark:text-theme-secondary-600 dark:hover:text-theme-secondary-200 css-v0ob3f"
+              height="16"
+              width="16"
             >
               <svg
                 id="ellipsis-vertical"

--- a/src/app/components/PageSkeleton/__snapshots__/PageSkeleton.test.tsx.snap
+++ b/src/app/components/PageSkeleton/__snapshots__/PageSkeleton.test.tsx.snap
@@ -484,7 +484,7 @@ exports[`PageSkeleton > should render without profile 1`] = `
                             class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
                           />
                           <div
-                            class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+                            class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
                             height="16"
                             width="16"
                           >
@@ -525,7 +525,7 @@ exports[`PageSkeleton > should render without profile 1`] = `
                             class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
                           />
                           <div
-                            class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+                            class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
                             height="16"
                             width="16"
                           >

--- a/src/app/components/WalletListItem/WalletListItemSkeleton.tsx
+++ b/src/app/components/WalletListItem/WalletListItemSkeleton.tsx
@@ -50,9 +50,9 @@ export const WalletListItemSkeleton: React.VFC = () => {
 						variant="transparent"
 						size="icon"
 						disabled={true}
-						className="-mr-1.5 text-theme-primary-300 hover:text-theme-primary-600"
+						className="-mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
 					>
-						<Icon name="EllipsisVertical" size="lg" />
+						<Icon name="EllipsisVertical" size="md" />
 					</Button>
 				</div>
 			</TableCell>

--- a/src/app/components/WalletListItem/__snapshots__/WalletListItemSkeleton.test.tsx.snap
+++ b/src/app/components/WalletListItem/__snapshots__/WalletListItemSkeleton.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`WalletListItemSkeleton > should render wallet list skeleton when isComp
               data-testid="WalletHeader__more-button"
             >
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-primary-300 hover:text-theme-primary-600"
+                class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-gray-700 -mr-1.5 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                 disabled=""
                 type="button"
               >
@@ -151,9 +151,9 @@ exports[`WalletListItemSkeleton > should render wallet list skeleton when isComp
                   class="flex items-center space-x-2"
                 >
                   <div
-                    class="css-1i4b0eq"
-                    height="20"
-                    width="20"
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
                   >
                     <svg
                       id="ellipsis-vertical"
@@ -342,7 +342,7 @@ exports[`WalletListItemSkeleton > should render wallet list skeleton when isComp
               data-testid="WalletHeader__more-button"
             >
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-primary-300 hover:text-theme-primary-600"
+                class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-gray-700 -mr-1.5 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                 disabled=""
                 type="button"
               >
@@ -350,9 +350,9 @@ exports[`WalletListItemSkeleton > should render wallet list skeleton when isComp
                   class="flex items-center space-x-2"
                 >
                   <div
-                    class="css-1i4b0eq"
-                    height="20"
-                    width="20"
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
                   >
                     <svg
                       id="ellipsis-vertical"

--- a/src/domains/contact/components/ContactListMobile/ContactListItemMobile.tsx
+++ b/src/domains/contact/components/ContactListMobile/ContactListItemMobile.tsx
@@ -58,7 +58,7 @@ export const ContactListItemMobile: React.VFC<Properties> = ({
 						<Dropdown
 							toggleContent={
 								<button type="button" className="flex text-theme-secondary-700">
-									<Icon name="EllipsisVerticalFilled" size="lg" />
+									<Icon name="EllipsisVerticalFilled" size="md" />
 								</button>
 							}
 							options={options}

--- a/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListItemMobile.test.tsx.snap
+++ b/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListItemMobile.test.tsx.snap
@@ -33,9 +33,9 @@ exports[`ContactListItemMobile > should render 1`] = `
                 type="button"
               >
                 <div
-                  class="css-1i4b0eq"
-                  height="20"
-                  width="20"
+                  class="css-v0ob3f"
+                  height="16"
+                  width="16"
                 >
                   <svg
                     fill="none"
@@ -144,9 +144,9 @@ exports[`ContactListItemMobile > should render addresses 1`] = `
                 type="button"
               >
                 <div
-                  class="css-1i4b0eq"
-                  height="20"
-                  width="20"
+                  class="css-v0ob3f"
+                  height="16"
+                  width="16"
                 >
                   <svg
                     fill="none"

--- a/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListMobile.test.tsx.snap
+++ b/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListMobile.test.tsx.snap
@@ -37,9 +37,9 @@ exports[`ContactListMobile > should render 1`] = `
                   type="button"
                 >
                   <div
-                    class="css-1i4b0eq"
-                    height="20"
-                    width="20"
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
                   >
                     <svg
                       fill="none"

--- a/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
+++ b/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
@@ -2298,9 +2298,9 @@ exports[`Contacts > should render responsive with contacts 1`] = `
                       type="button"
                     >
                       <div
-                        class="css-1i4b0eq"
-                        height="20"
-                        width="20"
+                        class="css-v0ob3f"
+                        height="16"
+                        width="16"
                       >
                         <svg
                           fill="none"
@@ -2404,9 +2404,9 @@ exports[`Contacts > should render responsive with contacts 1`] = `
                       type="button"
                     >
                       <div
-                        class="css-1i4b0eq"
-                        height="20"
-                        width="20"
+                        class="css-v0ob3f"
+                        height="16"
+                        width="16"
                       >
                         <svg
                           fill="none"

--- a/src/domains/profile/components/ProfileRow/ProfileRow.tsx
+++ b/src/domains/profile/components/ProfileRow/ProfileRow.tsx
@@ -79,7 +79,7 @@ export const ProfileRowSkeleton = () => (
 		<div className="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800" />
 		<Icon
 			name="EllipsisVerticalFilled"
-			className="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800"
+			className="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200"
 			size="md"
 		/>
 	</div>

--- a/src/domains/profile/components/ProfileRow/__snapshots__/ProfileRow.test.tsx.snap
+++ b/src/domains/profile/components/ProfileRow/__snapshots__/ProfileRow.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ProfileSliderSkeleton > should render 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -55,7 +55,7 @@ exports[`ProfileSliderSkeleton > should render 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -96,7 +96,7 @@ exports[`ProfileSliderSkeleton > should render 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -137,7 +137,7 @@ exports[`ProfileSliderSkeleton > should render 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -178,7 +178,7 @@ exports[`ProfileSliderSkeleton > should render 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -230,7 +230,7 @@ exports[`ProfileSliderSkeleton > should render with dots 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -271,7 +271,7 @@ exports[`ProfileSliderSkeleton > should render with dots 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -312,7 +312,7 @@ exports[`ProfileSliderSkeleton > should render with dots 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -353,7 +353,7 @@ exports[`ProfileSliderSkeleton > should render with dots 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -394,7 +394,7 @@ exports[`ProfileSliderSkeleton > should render with dots 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -474,7 +474,7 @@ exports[`ProfileSliderSkeleton > should render with length 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >
@@ -515,7 +515,7 @@ exports[`ProfileSliderSkeleton > should render with length 1`] = `
           class="h-10 w-10 bg-theme-secondary-100 dark:bg-theme-secondary-800"
         />
         <div
-          class="mr-1.5 pr-1.5 text-theme-secondary-200 dark:text-theme-secondary-800 css-v0ob3f"
+          class="mr-1.5 pr-1.5 text-theme-secondary-700 transition-colors duration-200 group-hover:text-theme-navy-700 dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200 css-v0ob3f"
           height="16"
           width="16"
         >

--- a/src/domains/setting/pages/Networks/blocks/CustomNetworksList.tsx
+++ b/src/domains/setting/pages/Networks/blocks/CustomNetworksList.tsx
@@ -89,7 +89,7 @@ const CustomNetworksListNetwork: React.VFC<{
 							<Icon
 								name="EllipsisVertical"
 								className="cursor-pointer p-1 text-theme-primary-300 transition-colors duration-200 hover:text-theme-primary-400 dark:text-theme-secondary-600 dark:hover:text-theme-secondary-200"
-								size="lg"
+								size="md"
 							/>
 						</div>
 					}

--- a/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
+++ b/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
@@ -2915,9 +2915,9 @@ exports[`Servers Settings > with servers > should ping the servers in an interva
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -3209,9 +3209,9 @@ exports[`Servers Settings > with servers > should ping the servers in an interva
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -3476,9 +3476,9 @@ exports[`Servers Settings > with servers > should ping the servers in an interva
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -5106,9 +5106,9 @@ exports[`Servers Settings > with servers > should render custom servers 1`] = `
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -5372,9 +5372,9 @@ exports[`Servers Settings > with servers > should render custom servers 1`] = `
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -5611,9 +5611,9 @@ exports[`Servers Settings > with servers > should render custom servers 1`] = `
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -9059,9 +9059,9 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -9353,9 +9353,9 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -9620,9 +9620,9 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -15324,9 +15324,9 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -15615,9 +15615,9 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"
@@ -15879,9 +15879,9 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                               class="flex items-center space-x-2"
                                             >
                                               <div
-                                                class="css-1i4b0eq"
-                                                height="20"
-                                                width="20"
+                                                class="css-v0ob3f"
+                                                height="16"
+                                                width="16"
                                               >
                                                 <svg
                                                   id="ellipsis-vertical"

--- a/src/domains/setting/pages/Servers/blocks/CustomPeers.tsx
+++ b/src/domains/setting/pages/Servers/blocks/CustomPeers.tsx
@@ -164,7 +164,7 @@ const PeerRow = ({
 								size="icon"
 								className="text-theme-primary-300 hover:text-theme-primary-600"
 							>
-								<Icon name="EllipsisVertical" size="lg" />
+								<Icon name="EllipsisVertical" size="md" />
 							</Button>
 						}
 						onSelect={onSelectOption}

--- a/src/domains/wallet/components/WalletsList/__snapshots__/WalletsList.test.tsx.snap
+++ b/src/domains/wallet/components/WalletsList/__snapshots__/WalletsList.test.tsx.snap
@@ -2423,7 +2423,7 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                     data-testid="WalletHeader__more-button"
                   >
                     <button
-                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-primary-300 hover:text-theme-primary-600"
+                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                       disabled=""
                       type="button"
                     >
@@ -2431,9 +2431,9 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                         class="flex items-center space-x-2"
                       >
                         <div
-                          class="css-1i4b0eq"
-                          height="20"
-                          width="20"
+                          class="css-v0ob3f"
+                          height="16"
+                          width="16"
                         >
                           <svg
                             id="ellipsis-vertical"
@@ -2611,7 +2611,7 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                     data-testid="WalletHeader__more-button"
                   >
                     <button
-                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-primary-300 hover:text-theme-primary-600"
+                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                       disabled=""
                       type="button"
                     >
@@ -2619,9 +2619,9 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                         class="flex items-center space-x-2"
                       >
                         <div
-                          class="css-1i4b0eq"
-                          height="20"
-                          width="20"
+                          class="css-v0ob3f"
+                          height="16"
+                          width="16"
                         >
                           <svg
                             id="ellipsis-vertical"
@@ -2799,7 +2799,7 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                     data-testid="WalletHeader__more-button"
                   >
                     <button
-                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-primary-300 hover:text-theme-primary-600"
+                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                       disabled=""
                       type="button"
                     >
@@ -2807,9 +2807,9 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                         class="flex items-center space-x-2"
                       >
                         <div
-                          class="css-1i4b0eq"
-                          height="20"
-                          width="20"
+                          class="css-v0ob3f"
+                          height="16"
+                          width="16"
                         >
                           <svg
                             id="ellipsis-vertical"

--- a/src/domains/wallet/components/WalletsList/__snapshots__/WalletsList.test.tsx.snap
+++ b/src/domains/wallet/components/WalletsList/__snapshots__/WalletsList.test.tsx.snap
@@ -2423,7 +2423,7 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                     data-testid="WalletHeader__more-button"
                   >
                     <button
-                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-gray-700 -mr-1.5 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                       disabled=""
                       type="button"
                     >
@@ -2611,7 +2611,7 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                     data-testid="WalletHeader__more-button"
                   >
                     <button
-                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-gray-700 -mr-1.5 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                       disabled=""
                       type="button"
                     >
@@ -2799,7 +2799,7 @@ exports[`WalletsList > should render empty skeleton block 1`] = `
                     data-testid="WalletHeader__more-button"
                   >
                     <button
-                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-1.5 text-theme-gray-700 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                      class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-gray-700 -mr-1.5 hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
                       disabled=""
                       type="button"
                     >

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.tsx
@@ -46,9 +46,9 @@ export const WalletHeader: React.VFC<WalletHeaderProperties> = ({
 								<Button
 									variant="transparent"
 									size="icon"
-									className="bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+									className="bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
 								>
-									<Icon name="EllipsisVertical" size="lg" />
+									<Icon name="EllipsisVerticalFilled" size="md" />
 								</Button>
 							}
 							onSelect={handleSelectOption}

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
@@ -300,48 +300,43 @@ exports[`WalletHeader > should handle locked balance 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -678,48 +673,43 @@ exports[`WalletHeader > should handle locked balance when is ledger 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -949,48 +939,43 @@ exports[`WalletHeader > should render 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -1226,48 +1211,43 @@ exports[`WalletHeader > should render amount for wallet in live network 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -1523,48 +1503,43 @@ exports[`WalletHeader > should render with incompatible ledger wallet 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -1826,48 +1801,43 @@ exports[`WalletHeader > should show currency delta (-5%) 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -2129,48 +2099,43 @@ exports[`WalletHeader > should show currency delta (5%) 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -2461,48 +2426,43 @@ exports[`WalletHeader > should show modifiers 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>
@@ -2702,48 +2662,43 @@ exports[`WalletHeader > should use empty string in clipboard copy if publickey i
           data-testid="dropdown__toggle"
         >
           <button
-            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
             type="button"
           >
             <div
               class="flex items-center space-x-2"
             >
               <div
-                class="css-1i4b0eq"
-                height="20"
-                width="20"
+                class="css-v0ob3f"
+                height="16"
+                width="16"
               >
                 <svg
-                  id="ellipsis-vertical"
+                  fill="none"
                   viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
                   xmlns="http://www.w3.org/2000/svg"
-                  y="0"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  >
-                    <circle
-                      cx="10"
-                      cy="16.994"
-                      r="2.006"
-                    />
-                    <circle
-                      cx="10"
-                      cy="3"
-                      r="2"
-                    />
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="2"
-                    />
-                  </g>
+                  <circle
+                    cx="10.002"
+                    cy="2.99609"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 2.99609)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="9.99805"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 9.99805)"
+                  />
+                  <circle
+                    cx="10.002"
+                    cy="17"
+                    fill="currentColor"
+                    r="2"
+                    transform="rotate(90 10.002 17)"
+                  />
                 </svg>
               </div>
             </div>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`WalletHeader > should handle locked balance 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -673,7 +673,7 @@ exports[`WalletHeader > should handle locked balance when is ledger 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -939,7 +939,7 @@ exports[`WalletHeader > should render 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -1211,7 +1211,7 @@ exports[`WalletHeader > should render amount for wallet in live network 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -1503,7 +1503,7 @@ exports[`WalletHeader > should render with incompatible ledger wallet 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -1801,7 +1801,7 @@ exports[`WalletHeader > should show currency delta (-5%) 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -2099,7 +2099,7 @@ exports[`WalletHeader > should show currency delta (5%) 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -2426,7 +2426,7 @@ exports[`WalletHeader > should show modifiers 1`] = `
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div
@@ -2662,7 +2662,7 @@ exports[`WalletHeader > should use empty string in clipboard copy if publickey i
           data-testid="dropdown__toggle"
         >
           <button
-            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white p-[14px]"
+            class="relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none bg-theme-secondary-800 p-[14px] text-theme-secondary-200 hover:bg-theme-primary-500 hover:text-white"
             type="button"
           >
             <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[wallet details] 3 dot menu icon size](https://app.clickup.com/t/86dv43wy4)

## Summary

- The 3 dots icon size has been updated for the wallet header. The icon has also been updated and now has the dots filled.
- Other implementations for the icon have also been updated in:
  - Custom peer cards (in settings)
  - Custon network icons (in settings)
  - Skeleton loaders (for the wallet header and profile cards)

<img width="605" alt="image" src="https://github.com/user-attachments/assets/63e87e91-d073-4c28-940b-0a09c5115d60">

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
