### PR TITLE
fix: exchange table row hover styles

### DIFF
--- a/src/domains/exchange/components/ExchangeTransactionsTable/ExchangeTransactionsRow.tsx
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/ExchangeTransactionsRow.tsx
@@ -170,7 +170,7 @@ export const ExchangeTransactionsRow = ({
 				<ExchangeTransactionProvider slug={exchangeTransaction.provider()} />
 			</TableCell>
 
-			<TableCell className="lg:hidden" innerClassName="items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0">
+			<TableCell className="lg:hidden" innerClassName="items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0">
 				<ExchangeTransactionRowAmount type="sent" data={exchangeTransaction.input()} />
 				<ExchangeTransactionRowAmount
 					type="received"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/ExchangeTransactionsRow.tsx
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/ExchangeTransactionsRow.tsx
@@ -170,7 +170,10 @@ export const ExchangeTransactionsRow = ({
 				<ExchangeTransactionProvider slug={exchangeTransaction.provider()} />
 			</TableCell>
 
-			<TableCell className="lg:hidden" innerClassName="items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0">
+			<TableCell
+				className="lg:hidden"
+				innerClassName="items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
+			>
 				<ExchangeTransactionRowAmount type="sent" data={exchangeTransaction.input()} />
 				<ExchangeTransactionRowAmount
 					type="received"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -666,7 +666,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -965,7 +965,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -1576,7 +1576,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -1875,7 +1875,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -2174,7 +2174,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -2785,7 +2785,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -3084,7 +3084,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -3383,7 +3383,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -3994,7 +3994,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -4293,7 +4293,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -4592,7 +4592,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -5203,7 +5203,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -5502,7 +5502,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -5801,7 +5801,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                 class="lg:hidden"
               >
                 <div
-                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+                  class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
                     class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRow.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRow.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -315,7 +315,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -554,7 +554,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -793,7 +793,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -1101,7 +1101,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -1345,7 +1345,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"
@@ -1589,7 +1589,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
           class="lg:hidden"
         >
           <div
-            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2 xl:my-0"
+            class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
               class="flex h-full items-center justify-center rounded px-1.5 css-xqt0aw"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[exchange] fix table row hover style](https://app.clickup.com/t/86dv571am)

## Summary

- The background hover styles for the exchange transactions table has been updated in tablet view to prevent it from breaking.

<img width="733" alt="image" src="https://github.com/user-attachments/assets/6aa16915-5754-4371-815c-c1f58cc2f7ac">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
