### PR TITLE
fix: restore filter dropdown shadow

### DIFF
--- a/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
+++ b/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
@@ -1,12 +1,12 @@
-import { Contracts } from "@ardenthq/sdk-profiles";
-import React, { memo } from "react";
-import { useTranslation } from "react-i18next";
-
 import { Dropdown, DropdownOption, DropdownOptionGroup } from "@/app/components/Dropdown";
+import React, { memo } from "react";
+
 import { Button } from "@/app/components/Button";
 import { Checkbox } from "@/app/components/Checkbox";
-import { useTransactionTypeFilters } from "./use-transaction-type-filters";
+import { Contracts } from "@ardenthq/sdk-profiles";
 import classNames from "classnames";
+import { useTransactionTypeFilters } from "./use-transaction-type-filters";
+import { useTranslation } from "react-i18next";
 
 interface FilterTransactionsProperties extends JSX.IntrinsicAttributes {
 	className?: string;
@@ -133,7 +133,7 @@ export const FilterTransactions = memo(
 			<div className={className} data-testid="FilterTransactions" {...properties}>
 				<Dropdown
 					placement="bottom-end"
-					wrapperClass="sm:max-w-56 overflow-hidden"
+					wrapperClass="sm:max-w-56"
 					options={options}
 					disableToggle={isDisabled}
 					closeOnSelect={false}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dv5gp62

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
