### PR TITLE
refactor: set accordions opened by default

### DIFF
--- a/src/app/components/Accordion/Accordion.test.tsx
+++ b/src/app/components/Accordion/Accordion.test.tsx
@@ -115,7 +115,7 @@ describe("Button", () => {
 		const { container } = render(<Accordion />);
 
 		expect(screen.getByTestId("AccordionHeader")).toBeInTheDocument();
-		expect(screen.queryByTestId("AccordionContent")).toBeInTheDocument();
+		expect(screen.getByTestId("AccordionContent")).toBeInTheDocument();
 		expect(screen.getByTestId("Accordion__toggle")).toBeInTheDocument();
 
 		await userEvent.click(screen.getByTestId("AccordionHeader"));

--- a/src/app/components/Accordion/Accordion.test.tsx
+++ b/src/app/components/Accordion/Accordion.test.tsx
@@ -115,12 +115,12 @@ describe("Button", () => {
 		const { container } = render(<Accordion />);
 
 		expect(screen.getByTestId("AccordionHeader")).toBeInTheDocument();
-		expect(screen.queryByTestId("AccordionContent")).not.toBeInTheDocument();
+		expect(screen.queryByTestId("AccordionContent")).toBeInTheDocument();
 		expect(screen.getByTestId("Accordion__toggle")).toBeInTheDocument();
 
 		await userEvent.click(screen.getByTestId("AccordionHeader"));
 
-		expect(screen.getByTestId("AccordionContent")).toBeInTheDocument();
+		expect(screen.queryByTestId("AccordionContent")).not.toBeInTheDocument();
 
 		expect(container).toMatchSnapshot();
 	});

--- a/src/app/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/app/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`Button > should toggle the accordion on click 1`] = `
     class="css-fvpuky"
   >
     <div
-      class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
+      class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
       data-testid="AccordionHeader"
     >
       <div
@@ -310,14 +310,14 @@ exports[`Button > should toggle the accordion on click 1`] = `
         Header
       </div>
       <div
-        class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
+        class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
       >
         <div
           class="css-tz6w2"
           data-testid="Accordion__toggle"
         >
           <div
-            class="transition-transform rotate-180 css-15txs7d"
+            class="transition-transform css-15txs7d"
             height="10"
             width="10"
           >
@@ -341,12 +341,6 @@ exports[`Button > should toggle the accordion on click 1`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
-      data-testid="AccordionContent"
-    >
-      Content
     </div>
   </div>
 </div>

--- a/src/app/hooks/use-accordion.ts
+++ b/src/app/hooks/use-accordion.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from "react";
 
 export const useAccordion = () => {
-	const [isExpanded, setIsExpanded] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(true);
 
 	const handleHeaderClick = useCallback(
 		(event: React.MouseEvent) => {

--- a/src/domains/contact/components/ContactListMobile/ContactListItemMobile.test.tsx
+++ b/src/domains/contact/components/ContactListMobile/ContactListItemMobile.test.tsx
@@ -61,8 +61,6 @@ describe("ContactListItemMobile", () => {
 			/>,
 		);
 
-		await userEvent.click(screen.getByTestId("AccordionHeader"));
-
 		await waitFor(() => {
 			expect(screen.getByTestId("ContactListItemMobile__addresses")).toBeInTheDocument();
 		});
@@ -83,8 +81,6 @@ describe("ContactListItemMobile", () => {
 				onAction={vi.fn()}
 			/>,
 		);
-
-		await userEvent.click(screen.getByTestId("AccordionHeader"));
 
 		await waitFor(() => {
 			expect(screen.getByTestId("ContactListItemMobile__addresses")).toBeInTheDocument();
@@ -112,8 +108,6 @@ describe("ContactListItemMobile", () => {
 				onAction={vi.fn()}
 			/>,
 		);
-
-		await userEvent.click(screen.getByTestId("AccordionHeader"));
 
 		await waitFor(() => {
 			expect(screen.getByTestId("ContactListItemMobile__addresses")).toBeInTheDocument();

--- a/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListItemMobile.test.tsx.snap
+++ b/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListItemMobile.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ContactListItemMobile > should render 1`] = `
     class="css-fvpuky"
   >
     <div
-      class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+      class="select-none cursor-pointer md:h-20 py-6 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 pb-3 pt-4"
       data-testid="AccordionHeader"
     >
       <div
@@ -75,14 +75,14 @@ exports[`ContactListItemMobile > should render 1`] = `
         </div>
       </div>
       <div
-        class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+        class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
       >
         <div
           class="css-tz6w2"
           data-testid="Accordion__toggle"
         >
           <div
-            class="transition-transform css-15txs7d"
+            class="transition-transform rotate-180 css-15txs7d"
             height="10"
             width="10"
           >
@@ -103,6 +103,113 @@ exports[`ContactListItemMobile > should render 1`] = `
                 stroke-width="2"
               />
             </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="md:px-4 md:pb-0 md:pt-6 px-6 pb-4"
+      data-testid="AccordionContent"
+    >
+      <div
+        class="w-full space-y-3"
+        data-testid="ContactListItemMobile__addresses"
+      >
+        <div
+          class="flex h-18 items-center justify-between overflow-hidden rounded-xl dark:border-2 dark:border-theme-secondary-800"
+        >
+          <div
+            class="flex h-full flex-1 flex-col justify-center overflow-hidden px-6 dark:bg-theme-secondary-900 bg-theme-secondary-100"
+          >
+            <div
+              class="mb-2 text-xs font-semibold leading-[15px] text-theme-secondary-700 dark:text-theme-secondary-700"
+            >
+              ARK Devnet
+            </div>
+            <div
+              class="flex items-center overflow-hidden"
+            >
+              <div
+                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+              >
+                <span
+                  class="no-ligatures min-w-0 overflow-hidden text-theme-text font-semibold text-base"
+                  data-testid="Address__address"
+                >
+                  D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib
+                </span>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                    height="16"
+                    width="16"
+                  >
+                    <svg
+                      id="copy"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                        />
+                        <path
+                          d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="flex h-full"
+          >
+            <button
+              class="flex h-full items-center justify-center bg-theme-primary-100 px-3 dark:bg-theme-secondary-900 text-theme-secondary-500 dark:text-theme-secondary-800"
+              data-testid="ContactListItemMobileAddress__send-button"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="css-1i4b0eq"
+                height="20"
+                width="20"
+              >
+                <svg
+                  id="double-arrow-right"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
+                >
+                  <path
+                    d="M1 7.744h9.013V3.832c0-.4.2-.4.5-.2 2.103 1.504 7.31 5.014 8.111 5.616.501.3.501 1.103 0 1.504-.8.602-6.008 4.212-8.11 5.616-.401.2-.501.2-.501-.2v-3.71H1"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </div>
+            </button>
           </div>
         </div>
       </div>

--- a/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListMobile.test.tsx.snap
+++ b/src/domains/contact/components/ContactListMobile/__snapshots__/ContactListMobile.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ContactListMobile > should render 1`] = `
       class="css-fvpuky"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 py-6 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 pb-3 pt-4"
         data-testid="AccordionHeader"
       >
         <div
@@ -79,14 +79,14 @@ exports[`ContactListMobile > should render 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -107,6 +107,111 @@ exports[`ContactListMobile > should render 1`] = `
                   stroke-width="2"
                 />
               </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="md:px-4 md:pb-0 md:pt-6 px-6 pb-4"
+        data-testid="AccordionContent"
+      >
+        <div
+          class="w-full space-y-3"
+          data-testid="ContactListItemMobile__addresses"
+        >
+          <div
+            class="flex h-18 items-center justify-between overflow-hidden rounded-xl dark:border-2 dark:border-theme-secondary-800"
+          >
+            <div
+              class="flex h-full flex-1 flex-col justify-center overflow-hidden px-6 dark:bg-theme-secondary-900 bg-theme-secondary-100"
+            >
+              <div
+                class="mb-2 text-xs font-semibold leading-[15px] text-theme-secondary-700 dark:text-theme-secondary-700"
+              />
+              <div
+                class="flex items-center overflow-hidden"
+              >
+                <div
+                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                >
+                  <span
+                    class="no-ligatures min-w-0 overflow-hidden text-theme-text font-semibold text-base"
+                    data-testid="Address__address"
+                  >
+                    D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib
+                  </span>
+                  <button
+                    class="ring-focus relative focus:outline-none"
+                    data-ring-focus-margin="-m-1"
+                    data-testid="clipboard-icon__wrapper"
+                    type="button"
+                  >
+                    <div
+                      class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                      height="16"
+                      width="16"
+                    >
+                      <svg
+                        id="copy"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="flex h-full"
+            >
+              <button
+                class="flex h-full items-center justify-center bg-theme-primary-100 px-3 dark:bg-theme-secondary-900 text-theme-secondary-500 dark:text-theme-secondary-800"
+                data-testid="ContactListItemMobileAddress__send-button"
+                disabled=""
+                type="button"
+              >
+                <div
+                  class="css-1i4b0eq"
+                  height="20"
+                  width="20"
+                >
+                  <svg
+                    id="double-arrow-right"
+                    viewBox="0 0 20 20"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M1 7.744h9.013V3.832c0-.4.2-.4.5-.2 2.103 1.504 7.31 5.014 8.111 5.616.501.3.501 1.103 0 1.504-.8.602-6.008 4.212-8.11 5.616-.401.2-.501.2-.501-.2v-3.71H1"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </button>
             </div>
           </div>
         </div>

--- a/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
+++ b/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
@@ -2271,7 +2271,7 @@ exports[`Contacts > should render responsive with contacts 1`] = `
           class="css-fvpuky"
         >
           <div
-            class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+            class="select-none cursor-pointer md:h-20 py-6 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 pb-3 pt-4"
             data-testid="AccordionHeader"
           >
             <div
@@ -2340,14 +2340,14 @@ exports[`Contacts > should render responsive with contacts 1`] = `
               </div>
             </div>
             <div
-              class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+              class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
             >
               <div
                 class="css-tz6w2"
                 data-testid="Accordion__toggle"
               >
                 <div
-                  class="transition-transform css-15txs7d"
+                  class="transition-transform rotate-180 css-15txs7d"
                   height="10"
                   width="10"
                 >
@@ -2372,12 +2372,118 @@ exports[`Contacts > should render responsive with contacts 1`] = `
               </div>
             </div>
           </div>
+          <div
+            class="md:px-4 md:pb-0 md:pt-6 px-6 pb-4"
+            data-testid="AccordionContent"
+          >
+            <div
+              class="w-full space-y-3"
+              data-testid="ContactListItemMobile__addresses"
+            >
+              <div
+                class="flex h-18 items-center justify-between overflow-hidden rounded-xl dark:border-2 dark:border-theme-secondary-800"
+              >
+                <div
+                  class="flex h-full flex-1 flex-col justify-center overflow-hidden px-6 dark:bg-theme-secondary-900 bg-theme-primary-100"
+                >
+                  <div
+                    class="mb-2 text-xs font-semibold leading-[15px] text-theme-secondary-700 dark:text-theme-secondary-700"
+                  >
+                    ARK Devnet
+                  </div>
+                  <div
+                    class="flex items-center overflow-hidden"
+                  >
+                    <div
+                      class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                    >
+                      <span
+                        class="no-ligatures min-w-0 overflow-hidden text-theme-text font-semibold text-base"
+                        data-testid="Address__address"
+                      >
+                        D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib
+                      </span>
+                      <button
+                        class="ring-focus relative focus:outline-none"
+                        data-ring-focus-margin="-m-1"
+                        data-testid="clipboard-icon__wrapper"
+                        type="button"
+                      >
+                        <div
+                          class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                          height="16"
+                          width="16"
+                        >
+                          <svg
+                            id="copy"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="flex h-full"
+                >
+                  <button
+                    class="flex h-full items-center justify-center bg-theme-primary-100 px-3 dark:bg-theme-secondary-900 text-theme-navy-600 hover:bg-theme-primary-700 hover:text-white dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-800 dark:hover:text-theme-secondary-200"
+                    data-testid="ContactListItemMobileAddress__send-button"
+                    type="button"
+                  >
+                    <div
+                      class="css-1i4b0eq"
+                      height="20"
+                      width="20"
+                    >
+                      <svg
+                        id="double-arrow-right"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <path
+                          d="M1 7.744h9.013V3.832c0-.4.2-.4.5-.2 2.103 1.504 7.31 5.014 8.111 5.616.501.3.501 1.103 0 1.504-.8.602-6.008 4.212-8.11 5.616-.401.2-.501.2-.501-.2v-3.71H1"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div
           class="css-fvpuky"
         >
           <div
-            class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+            class="select-none cursor-pointer md:h-20 py-6 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 pb-3 pt-4"
             data-testid="AccordionHeader"
           >
             <div
@@ -2446,14 +2552,14 @@ exports[`Contacts > should render responsive with contacts 1`] = `
               </div>
             </div>
             <div
-              class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+              class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
             >
               <div
                 class="css-tz6w2"
                 data-testid="Accordion__toggle"
               >
                 <div
-                  class="transition-transform css-15txs7d"
+                  class="transition-transform rotate-180 css-15txs7d"
                   height="10"
                   width="10"
                 >
@@ -2474,6 +2580,304 @@ exports[`Contacts > should render responsive with contacts 1`] = `
                       stroke-width="2"
                     />
                   </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="md:px-4 md:pb-0 md:pt-6 px-6 pb-4"
+            data-testid="AccordionContent"
+          >
+            <div
+              class="w-full space-y-3"
+              data-testid="ContactListItemMobile__addresses"
+            >
+              <div
+                class="flex h-18 items-center justify-between overflow-hidden rounded-xl dark:border-2 dark:border-theme-secondary-800"
+              >
+                <div
+                  class="flex h-full flex-1 flex-col justify-center overflow-hidden px-6 dark:bg-theme-secondary-900 bg-theme-primary-100"
+                >
+                  <div
+                    class="mb-2 text-xs font-semibold leading-[15px] text-theme-secondary-700 dark:text-theme-secondary-700"
+                  >
+                    ARK Devnet
+                  </div>
+                  <div
+                    class="flex items-center overflow-hidden"
+                  >
+                    <div
+                      class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                    >
+                      <span
+                        class="no-ligatures min-w-0 overflow-hidden text-theme-text font-semibold text-base"
+                        data-testid="Address__address"
+                      >
+                        DFJ5Z51F1euNNdRUQJKQVdG4h495LZkc6T
+                      </span>
+                      <button
+                        class="ring-focus relative focus:outline-none"
+                        data-ring-focus-margin="-m-1"
+                        data-testid="clipboard-icon__wrapper"
+                        type="button"
+                      >
+                        <div
+                          class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                          height="16"
+                          width="16"
+                        >
+                          <svg
+                            id="copy"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="flex h-full"
+                >
+                  <button
+                    class="flex h-full items-center justify-center bg-theme-primary-100 px-3 dark:bg-theme-secondary-900 text-theme-navy-600 hover:bg-theme-primary-700 hover:text-white dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-800 dark:hover:text-theme-secondary-200"
+                    data-testid="ContactListItemMobileAddress__send-button"
+                    type="button"
+                  >
+                    <div
+                      class="css-1i4b0eq"
+                      height="20"
+                      width="20"
+                    >
+                      <svg
+                        id="double-arrow-right"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <path
+                          d="M1 7.744h9.013V3.832c0-.4.2-.4.5-.2 2.103 1.504 7.31 5.014 8.111 5.616.501.3.501 1.103 0 1.504-.8.602-6.008 4.212-8.11 5.616-.401.2-.501.2-.501-.2v-3.71H1"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="flex h-18 items-center justify-between overflow-hidden rounded-xl dark:border-2 dark:border-theme-secondary-800"
+              >
+                <div
+                  class="flex h-full flex-1 flex-col justify-center overflow-hidden px-6 dark:bg-theme-secondary-900 bg-theme-primary-100"
+                >
+                  <div
+                    class="mb-2 text-xs font-semibold leading-[15px] text-theme-secondary-700 dark:text-theme-secondary-700"
+                  >
+                    ARK Devnet
+                  </div>
+                  <div
+                    class="flex items-center overflow-hidden"
+                  >
+                    <div
+                      class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                    >
+                      <span
+                        class="no-ligatures min-w-0 overflow-hidden text-theme-text font-semibold text-base"
+                        data-testid="Address__address"
+                      >
+                        D9YiyRYMBS2ofzqkufjrkB9nHofWgJLM7f
+                      </span>
+                      <button
+                        class="ring-focus relative focus:outline-none"
+                        data-ring-focus-margin="-m-1"
+                        data-testid="clipboard-icon__wrapper"
+                        type="button"
+                      >
+                        <div
+                          class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                          height="16"
+                          width="16"
+                        >
+                          <svg
+                            id="copy"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="flex h-full"
+                >
+                  <button
+                    class="flex h-full items-center justify-center bg-theme-primary-100 px-3 dark:bg-theme-secondary-900 text-theme-navy-600 hover:bg-theme-primary-700 hover:text-white dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-800 dark:hover:text-theme-secondary-200"
+                    data-testid="ContactListItemMobileAddress__send-button"
+                    type="button"
+                  >
+                    <div
+                      class="css-1i4b0eq"
+                      height="20"
+                      width="20"
+                    >
+                      <svg
+                        id="double-arrow-right"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <path
+                          d="M1 7.744h9.013V3.832c0-.4.2-.4.5-.2 2.103 1.504 7.31 5.014 8.111 5.616.501.3.501 1.103 0 1.504-.8.602-6.008 4.212-8.11 5.616-.401.2-.501.2-.501-.2v-3.71H1"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="flex h-18 items-center justify-between overflow-hidden rounded-xl dark:border-2 dark:border-theme-secondary-800"
+              >
+                <div
+                  class="flex h-full flex-1 flex-col justify-center overflow-hidden px-6 dark:bg-theme-secondary-900 bg-theme-primary-100"
+                >
+                  <div
+                    class="mb-2 text-xs font-semibold leading-[15px] text-theme-secondary-700 dark:text-theme-secondary-700"
+                  >
+                    ARK Devnet
+                  </div>
+                  <div
+                    class="flex items-center overflow-hidden"
+                  >
+                    <div
+                      class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                    >
+                      <span
+                        class="no-ligatures min-w-0 overflow-hidden text-theme-text font-semibold text-base"
+                        data-testid="Address__address"
+                      >
+                        DKrACQw7ytoU2gjppy3qKeE2dQhZjfXYqu
+                      </span>
+                      <button
+                        class="ring-focus relative focus:outline-none"
+                        data-ring-focus-margin="-m-1"
+                        data-testid="clipboard-icon__wrapper"
+                        type="button"
+                      >
+                        <div
+                          class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                          height="16"
+                          width="16"
+                        >
+                          <svg
+                            id="copy"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="flex h-full"
+                >
+                  <button
+                    class="flex h-full items-center justify-center bg-theme-primary-100 px-3 dark:bg-theme-secondary-900 text-theme-navy-600 hover:bg-theme-primary-700 hover:text-white dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-800 dark:hover:text-theme-secondary-200"
+                    data-testid="ContactListItemMobileAddress__send-button"
+                    type="button"
+                  >
+                    <div
+                      class="css-1i4b0eq"
+                      height="20"
+                      width="20"
+                    >
+                      <svg
+                        id="double-arrow-right"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <path
+                          d="M1 7.744h9.013V3.832c0-.4.2-.4.5-.2 2.103 1.504 7.31 5.014 8.111 5.616.501.3.501 1.103 0 1.504-.8.602-6.008 4.212-8.11 5.616-.401.2-.501.2-.501-.2v-3.71H1"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/domains/dashboard/pages/Dashboard/Dashboard.WalletActions.test.tsx
+++ b/src/domains/dashboard/pages/Dashboard/Dashboard.WalletActions.test.tsx
@@ -79,7 +79,7 @@ describe("Dashboard", () => {
 			},
 		);
 
-		await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(9));
+		await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(12));
 
 		await userEvent.click(screen.getByText(dashboardTranslations.WALLET_CONTROLS.IMPORT_LEDGER));
 
@@ -101,7 +101,7 @@ describe("Dashboard", () => {
 			},
 		);
 
-		await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(9));
+		await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(12));
 
 		await userEvent.click(screen.getByText("Create"));
 
@@ -119,7 +119,7 @@ describe("Dashboard", () => {
 			},
 		);
 
-		await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(9));
+		await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(12));
 
 		await userEvent.click(screen.getByText("Import"));
 

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -907,18 +907,18 @@ exports[`Dashboard > should render 1`] = `
           data-testid="NetworkWalletsGroupList"
         >
           <div
-            class="md:!mb-3 css-13o3tsw"
+            class="md:!mb-3 css-fvpuky"
             data-testid="WalletsGroup"
           >
             <div
-              class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+              class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
               data-testid="WalletsGroupHeader"
             >
               <div
                 class="flex flex-grow flex-row items-center"
               >
                 <div
-                  class="css-ziskls"
+                  class="css-1u7yknf"
                 >
                   <div
                     aria-label="ARK"
@@ -1045,14 +1045,14 @@ exports[`Dashboard > should render 1`] = `
                 </div>
               </div>
               <div
-                class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
               >
                 <div
                   class="css-tz6w2"
                   data-testid="Accordion__toggle"
                 >
                   <div
-                    class="transition-transform css-15txs7d"
+                    class="transition-transform rotate-180 css-15txs7d"
                     height="10"
                     width="10"
                   >
@@ -1077,20 +1077,601 @@ exports[`Dashboard > should render 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="px-6 pb-4 md:p-0"
+              data-testid="WalletsList"
+            >
+              <div
+                data-testid="WalletTable"
+              >
+                <div
+                  class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+                  role="table"
+                >
+                  <table
+                    cellpadding="0"
+                    class="w-full table-auto"
+                  >
+                    <thead>
+                      <tr
+                        role="row"
+                      >
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                          colspan="1"
+                          data-testid="table__th--0"
+                          role="columnheader"
+                        >
+                          <div
+                            class="flex flex-inline align-top"
+                          >
+                            <div
+                              class=""
+                            >
+                              <div
+                                class="py-0.5 pr-3"
+                              >
+                                <button
+                                  class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                                  data-testid="WalletIcon__Starred__header"
+                                  type="button"
+                                >
+                                  <div
+                                    class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                                    height="18"
+                                    width="18"
+                                  >
+                                    <svg
+                                      id="star-filled"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      stroke-width="2"
+                                      viewBox="0 0 20 20"
+                                      x="0"
+                                      xml:space="preserve"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      y="0"
+                                    >
+                                      <path
+                                        d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                          colspan="1"
+                          data-testid="table__th--1"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top -ml-3"
+                          >
+                            <div
+                              class=""
+                            >
+                              Name
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                          colspan="1"
+                          data-testid="table__th--2"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top -ml-3"
+                          >
+                            <div
+                              class=""
+                            >
+                              Address
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                          colspan="1"
+                          data-testid="table__th--3"
+                          role="columnheader"
+                        >
+                          <div
+                            class="flex flex-inline align-top justify-center"
+                          >
+                            <div
+                              class=""
+                            >
+                              Info
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                          colspan="1"
+                          data-testid="table__th--4"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                          >
+                            <div
+                              class=""
+                            >
+                              Balance
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                          colspan="1"
+                          data-testid="table__th--5"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top justify-end flex-row-reverse"
+                          >
+                            <div
+                              class=""
+                            >
+                              Currency
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                          colspan="1"
+                          data-testid="table__th--6"
+                          role="columnheader"
+                        >
+                          <div
+                            class="flex flex-inline align-top hidden"
+                          >
+                            <div
+                              class=""
+                            >
+                              Actions
+                            </div>
+                          </div>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      role="rowgroup"
+                    >
+                      <tr
+                        class="group relative css-1tl8buz"
+                        data-testid="TableRow"
+                      >
+                        <td
+                          data-testid="TableCell_Starred"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                          >
+                            <div
+                              class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                            >
+                              <div
+                                class="flex shrink-0 items-center justify-center"
+                                data-testid="WalletIcon__Starred"
+                              >
+                                <div
+                                  class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                                  height="18"
+                                  width="18"
+                                >
+                                  <svg
+                                    id="star-filled"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <path
+                                      d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class="hidden lg:table-cell"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                          >
+                            <div
+                              class="w-24 flex-1 overflow-hidden"
+                            >
+                              <div
+                                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                              >
+                                <span
+                                  class="font-semibold text-base text-sm leading-[17px]"
+                                  data-testid="Address__alias"
+                                >
+                                  <span
+                                    class="no-ligatures css-9nx3be"
+                                    data-testid="TruncateEnd"
+                                  >
+                                    arkx
+                                  </span>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          data-testid="TableCell_Wallet"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                          >
+                            <div
+                              class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                            >
+                              <div
+                                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                              >
+                                <span
+                                  class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                                  data-testid="Address__alias"
+                                >
+                                  <span
+                                    class="no-ligatures css-9nx3be"
+                                    data-testid="TruncateEnd"
+                                  >
+                                    arkx
+                                  </span>
+                                </span>
+                                <span
+                                  class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                                  data-testid="Address__address"
+                                >
+                                  AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                                </span>
+                                <button
+                                  class="ring-focus relative focus:outline-none"
+                                  data-ring-focus-margin="-m-1"
+                                  data-testid="clipboard-icon__wrapper"
+                                  type="button"
+                                >
+                                  <div
+                                    class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                                    height="16"
+                                    width="16"
+                                  >
+                                    <svg
+                                      id="copy"
+                                      viewBox="0 0 20 20"
+                                      x="0"
+                                      xml:space="preserve"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      y="0"
+                                    >
+                                      <g
+                                        fill="none"
+                                        stroke="currentColor"
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                      >
+                                        <path
+                                          d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                        />
+                                        <path
+                                          d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                          >
+                            <div
+                              class="inline-flex items-center space-x-1"
+                            >
+                              <div
+                                class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                                data-testid="WalletIcon__SecondSignature"
+                              >
+                                <div
+                                  class="css-1i4b0eq"
+                                  height="20"
+                                  width="20"
+                                >
+                                  <svg
+                                    id="second-signature"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <g
+                                      fill="none"
+                                      stroke="currentColor"
+                                      stroke-linecap="round"
+                                      stroke-width="2"
+                                      transform="translate(482.484 177)"
+                                    >
+                                      <path
+                                        d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
+                                      />
+                                      <circle
+                                        cx="-476.5"
+                                        cy="-170.9"
+                                        r="5"
+                                      />
+                                    </g>
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                          >
+                            <span
+                              class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                              data-testid="Amount"
+                            >
+                              50,114.21127898 ARK
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="hidden lg:table-cell"
+                          data-testid="CurrencyCell"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                          >
+                            <span
+                              class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                              data-testid="Amount"
+                            >
+                              50.11421128 BTC
+                            </span>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                          >
+                            <div>
+                              <button
+                                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                                data-testid="WalletListItem__send-button"
+                                type="button"
+                              >
+                                <div
+                                  class="flex items-center space-x-2"
+                                >
+                                  <div
+                                    class="pr-3"
+                                  >
+                                    Send
+                                  </div>
+                                </div>
+                              </button>
+                            </div>
+                            <div
+                              class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                            />
+                            <div
+                              data-testid="WalletListItem__more-button"
+                            >
+                              <div
+                                aria-expanded="false"
+                                aria-haspopup="dialog"
+                                data-testid="dropdown__toggle"
+                              >
+                                <button
+                                  class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                                  type="button"
+                                >
+                                  <div
+                                    class="flex items-center space-x-2"
+                                  >
+                                    <div
+                                      class="css-v0ob3f"
+                                      height="16"
+                                      width="16"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        viewBox="0 0 20 20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <circle
+                                          cx="10.002"
+                                          cy="2.99609"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 2.99609)"
+                                        />
+                                        <circle
+                                          cx="10.002"
+                                          cy="9.99805"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 9.99805)"
+                                        />
+                                        <circle
+                                          cx="10.002"
+                                          cy="17"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 17)"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
           </div>
           <div
-            class="md:!mb-3 css-13o3tsw"
+            class="md:!mb-3 css-fvpuky"
             data-testid="WalletsGroup"
           >
             <div
-              class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+              class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
               data-testid="WalletsGroupHeader"
             >
               <div
                 class="flex flex-grow flex-row items-center"
               >
                 <div
-                  class="css-ziskls"
+                  class="css-1u7yknf"
                 >
                   <div
                     aria-label="ARK Devnet"
@@ -1279,14 +1860,14 @@ exports[`Dashboard > should render 1`] = `
                 </div>
               </div>
               <div
-                class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
               >
                 <div
                   class="css-tz6w2"
                   data-testid="Accordion__toggle"
                 >
                   <div
-                    class="transition-transform css-15txs7d"
+                    class="transition-transform rotate-180 css-15txs7d"
                     height="10"
                     width="10"
                   >
@@ -1308,6 +1889,895 @@ exports[`Dashboard > should render 1`] = `
                       />
                     </svg>
                   </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="px-6 pb-4 md:p-0"
+              data-testid="WalletsList"
+            >
+              <div
+                data-testid="WalletTable"
+              >
+                <div
+                  class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+                  role="table"
+                >
+                  <table
+                    cellpadding="0"
+                    class="w-full table-auto"
+                  >
+                    <thead>
+                      <tr
+                        role="row"
+                      >
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                          colspan="1"
+                          data-testid="table__th--0"
+                          role="columnheader"
+                        >
+                          <div
+                            class="flex flex-inline align-top"
+                          >
+                            <div
+                              class=""
+                            >
+                              <div
+                                class="py-0.5 pr-3"
+                              >
+                                <button
+                                  class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                                  data-testid="WalletIcon__Starred__header"
+                                  type="button"
+                                >
+                                  <div
+                                    class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                                    height="18"
+                                    width="18"
+                                  >
+                                    <svg
+                                      id="star-filled"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      stroke-width="2"
+                                      viewBox="0 0 20 20"
+                                      x="0"
+                                      xml:space="preserve"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      y="0"
+                                    >
+                                      <path
+                                        d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                      />
+                                    </svg>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                          colspan="1"
+                          data-testid="table__th--1"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top -ml-3"
+                          >
+                            <div
+                              class=""
+                            >
+                              Name
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                          colspan="1"
+                          data-testid="table__th--2"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top -ml-3"
+                          >
+                            <div
+                              class=""
+                            >
+                              Address
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                          colspan="1"
+                          data-testid="table__th--3"
+                          role="columnheader"
+                        >
+                          <div
+                            class="flex flex-inline align-top justify-center"
+                          >
+                            <div
+                              class=""
+                            >
+                              Info
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                          colspan="1"
+                          data-testid="table__th--4"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                          >
+                            <div
+                              class=""
+                            >
+                              Balance
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                          colspan="1"
+                          data-testid="table__th--5"
+                          role="columnheader"
+                          style="cursor: pointer;"
+                          title="Toggle SortBy"
+                        >
+                          <div
+                            class="flex flex-inline align-top justify-end flex-row-reverse"
+                          >
+                            <div
+                              class=""
+                            >
+                              Currency
+                            </div>
+                            <div
+                              class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                            >
+                              <div
+                                class="transition-transform rotate-180 css-15txs7d"
+                                height="10"
+                                role="img"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </th>
+                        <th
+                          class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                          colspan="1"
+                          data-testid="table__th--6"
+                          role="columnheader"
+                        >
+                          <div
+                            class="flex flex-inline align-top hidden"
+                          >
+                            <div
+                              class=""
+                            >
+                              Actions
+                            </div>
+                          </div>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody
+                      role="rowgroup"
+                    >
+                      <tr
+                        class="group relative css-1tl8buz"
+                        data-testid="TableRow"
+                      >
+                        <td
+                          data-testid="TableCell_Starred"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                          >
+                            <div
+                              class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                            >
+                              <div
+                                class="flex shrink-0 items-center justify-center"
+                                data-testid="WalletIcon__Starred"
+                              >
+                                <div
+                                  class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                                  height="18"
+                                  width="18"
+                                >
+                                  <svg
+                                    id="star-filled"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <path
+                                      d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class="hidden lg:table-cell"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                          >
+                            <div
+                              class="w-24 flex-1 overflow-hidden"
+                            >
+                              <div
+                                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                              >
+                                <span
+                                  class="font-semibold text-base text-sm leading-[17px]"
+                                  data-testid="Address__alias"
+                                >
+                                  <span
+                                    class="no-ligatures css-9nx3be"
+                                    data-testid="TruncateEnd"
+                                  >
+                                    ARK Wallet 1
+                                  </span>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          data-testid="TableCell_Wallet"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                          >
+                            <div
+                              class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                            >
+                              <div
+                                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                              >
+                                <span
+                                  class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                                  data-testid="Address__alias"
+                                >
+                                  <span
+                                    class="no-ligatures css-9nx3be"
+                                    data-testid="TruncateEnd"
+                                  >
+                                    ARK Wallet 1
+                                  </span>
+                                </span>
+                                <span
+                                  class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                                  data-testid="Address__address"
+                                >
+                                  D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                                </span>
+                                <button
+                                  class="ring-focus relative focus:outline-none"
+                                  data-ring-focus-margin="-m-1"
+                                  data-testid="clipboard-icon__wrapper"
+                                  type="button"
+                                >
+                                  <div
+                                    class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                                    height="16"
+                                    width="16"
+                                  >
+                                    <svg
+                                      id="copy"
+                                      viewBox="0 0 20 20"
+                                      x="0"
+                                      xml:space="preserve"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      y="0"
+                                    >
+                                      <g
+                                        fill="none"
+                                        stroke="currentColor"
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                      >
+                                        <path
+                                          d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                        />
+                                        <path
+                                          d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                          >
+                            <div
+                              class="inline-flex items-center space-x-1"
+                            >
+                              <div
+                                class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                                data-testid="WalletIcon__TestNetwork"
+                              >
+                                <div
+                                  class="css-1i4b0eq"
+                                  height="20"
+                                  width="20"
+                                >
+                                  <svg
+                                    id="code"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <path
+                                      d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      stroke-width="2"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                          >
+                            <span
+                              class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                              data-testid="Amount"
+                            >
+                              33.75089801 DARK
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="hidden lg:table-cell"
+                          data-testid="CurrencyCell"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                          >
+                            <span
+                              class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                            >
+                              N/A
+                            </span>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                          >
+                            <div>
+                              <button
+                                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                                data-testid="WalletListItem__send-button"
+                                type="button"
+                              >
+                                <div
+                                  class="flex items-center space-x-2"
+                                >
+                                  <div
+                                    class="pr-3"
+                                  >
+                                    Send
+                                  </div>
+                                </div>
+                              </button>
+                            </div>
+                            <div
+                              class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                            />
+                            <div
+                              data-testid="WalletListItem__more-button"
+                            >
+                              <div
+                                aria-expanded="false"
+                                aria-haspopup="dialog"
+                                data-testid="dropdown__toggle"
+                              >
+                                <button
+                                  class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                                  type="button"
+                                >
+                                  <div
+                                    class="flex items-center space-x-2"
+                                  >
+                                    <div
+                                      class="css-v0ob3f"
+                                      height="16"
+                                      width="16"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        viewBox="0 0 20 20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <circle
+                                          cx="10.002"
+                                          cy="2.99609"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 2.99609)"
+                                        />
+                                        <circle
+                                          cx="10.002"
+                                          cy="9.99805"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 9.99805)"
+                                        />
+                                        <circle
+                                          cx="10.002"
+                                          cy="17"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 17)"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr
+                        class="group relative css-1tl8buz"
+                        data-testid="TableRow"
+                      >
+                        <td
+                          data-testid="TableCell_Starred"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                          >
+                            <div
+                              class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                            >
+                              <div
+                                class="flex shrink-0 items-center justify-center"
+                                data-testid="WalletIcon__Starred"
+                              >
+                                <div
+                                  class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                                  height="18"
+                                  width="18"
+                                >
+                                  <svg
+                                    id="star-filled"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <path
+                                      d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          class="hidden lg:table-cell"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                          >
+                            <div
+                              class="w-24 flex-1 overflow-hidden"
+                            >
+                              <div
+                                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                              >
+                                <span
+                                  class="font-semibold text-base text-sm leading-[17px]"
+                                  data-testid="Address__alias"
+                                >
+                                  <span
+                                    class="no-ligatures css-9nx3be"
+                                    data-testid="TruncateEnd"
+                                  >
+                                    ARK Wallet 2
+                                  </span>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td
+                          data-testid="TableCell_Wallet"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                          >
+                            <div
+                              class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                            >
+                              <div
+                                class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                              >
+                                <span
+                                  class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                                  data-testid="Address__alias"
+                                >
+                                  <span
+                                    class="no-ligatures css-9nx3be"
+                                    data-testid="TruncateEnd"
+                                  >
+                                    ARK Wallet 2
+                                  </span>
+                                </span>
+                                <span
+                                  class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                                  data-testid="Address__address"
+                                >
+                                  D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb
+                                </span>
+                                <button
+                                  class="ring-focus relative focus:outline-none"
+                                  data-ring-focus-margin="-m-1"
+                                  data-testid="clipboard-icon__wrapper"
+                                  type="button"
+                                >
+                                  <div
+                                    class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                                    height="16"
+                                    width="16"
+                                  >
+                                    <svg
+                                      id="copy"
+                                      viewBox="0 0 20 20"
+                                      x="0"
+                                      xml:space="preserve"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      y="0"
+                                    >
+                                      <g
+                                        fill="none"
+                                        stroke="currentColor"
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                      >
+                                        <path
+                                          d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                        />
+                                        <path
+                                          d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                        />
+                                      </g>
+                                    </svg>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                          >
+                            <div
+                              class="inline-flex items-center space-x-1"
+                            >
+                              <div
+                                class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                                data-testid="WalletIcon__SecondSignature"
+                              >
+                                <div
+                                  class="css-1i4b0eq"
+                                  height="20"
+                                  width="20"
+                                >
+                                  <svg
+                                    id="second-signature"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <g
+                                      fill="none"
+                                      stroke="currentColor"
+                                      stroke-linecap="round"
+                                      stroke-width="2"
+                                      transform="translate(482.484 177)"
+                                    >
+                                      <path
+                                        d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
+                                      />
+                                      <circle
+                                        cx="-476.5"
+                                        cy="-170.9"
+                                        r="5"
+                                      />
+                                    </g>
+                                  </svg>
+                                </div>
+                              </div>
+                              <div
+                                class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                                data-testid="WalletIcon__TestNetwork"
+                              >
+                                <div
+                                  class="css-1i4b0eq"
+                                  height="20"
+                                  width="20"
+                                >
+                                  <svg
+                                    id="code"
+                                    viewBox="0 0 20 20"
+                                    x="0"
+                                    xml:space="preserve"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                                  >
+                                    <path
+                                      d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      stroke-width="2"
+                                    />
+                                  </svg>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                          >
+                            <span
+                              class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                              data-testid="Amount"
+                            >
+                              57.68 DARK
+                            </span>
+                          </div>
+                        </td>
+                        <td
+                          class="hidden lg:table-cell"
+                          data-testid="CurrencyCell"
+                        >
+                          <div
+                            class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                          >
+                            <span
+                              class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                            >
+                              N/A
+                            </span>
+                          </div>
+                        </td>
+                        <td>
+                          <div
+                            class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                          >
+                            <div>
+                              <button
+                                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                                data-testid="WalletListItem__send-button"
+                                type="button"
+                              >
+                                <div
+                                  class="flex items-center space-x-2"
+                                >
+                                  <div
+                                    class="pr-3"
+                                  >
+                                    Send
+                                  </div>
+                                </div>
+                              </button>
+                            </div>
+                            <div
+                              class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                            />
+                            <div
+                              data-testid="WalletListItem__more-button"
+                            >
+                              <div
+                                aria-expanded="false"
+                                aria-haspopup="dialog"
+                                data-testid="dropdown__toggle"
+                              >
+                                <button
+                                  class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                                  type="button"
+                                >
+                                  <div
+                                    class="flex items-center space-x-2"
+                                  >
+                                    <div
+                                      class="css-v0ob3f"
+                                      height="16"
+                                      width="16"
+                                    >
+                                      <svg
+                                        fill="none"
+                                        viewBox="0 0 20 20"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                      >
+                                        <circle
+                                          cx="10.002"
+                                          cy="2.99609"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 2.99609)"
+                                        />
+                                        <circle
+                                          cx="10.002"
+                                          cy="9.99805"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 9.99805)"
+                                        />
+                                        <circle
+                                          cx="10.002"
+                                          cy="17"
+                                          fill="currentColor"
+                                          r="2"
+                                          transform="rotate(90 10.002 17)"
+                                        />
+                                      </svg>
+                                    </div>
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
               </div>
             </div>

--- a/src/domains/setting/pages/Servers/Servers.test.tsx
+++ b/src/domains/setting/pages/Servers/Servers.test.tsx
@@ -899,7 +899,7 @@ describe("Servers Settings", () => {
 
 			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[0]);
 
-			expect(screen.getByTestId("CustomPeers-network-item--mobile--expanded")).toBeInTheDocument();
+			expect(screen.queryAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument();
 		});
 
 		it("can expand a custom servers accordion in xs for peer", async () => {
@@ -918,7 +918,7 @@ describe("Servers Settings", () => {
 			// index 2 is a peer network
 			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[2]);
 
-			expect(screen.getByTestId("CustomPeers-network-item--mobile--expanded")).toBeInTheDocument();
+			expect(screen.queryAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument();
 		});
 
 		it("can check servers accordion in mobile", async () => {
@@ -962,7 +962,7 @@ describe("Servers Settings", () => {
 
 			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[0]);
 
-			await userEvent.click(screen.getByTestId("CustomPeers-network-item--mobile--edit"));
+			await userEvent.click(screen.queryAllByTestId("CustomPeers-network-item--mobile--edit")[0]);
 
 			expect(screen.getByTestId("ServerFormModal")).toBeInTheDocument();
 		});
@@ -982,7 +982,7 @@ describe("Servers Settings", () => {
 
 			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[0]);
 
-			await userEvent.click(screen.getByTestId("CustomPeers-network-item--mobile--delete"));
+			await userEvent.click(screen.queryAllByTestId("CustomPeers-network-item--mobile--delete")[0]);
 
 			await expect(screen.findByTestId(serverDeleteConfirmationTestId)).resolves.toBeVisible();
 		});
@@ -1002,11 +1002,9 @@ describe("Servers Settings", () => {
 
 			const table = screen.getByTestId(customPeerListTestId);
 
-			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[0]);
-
 			await waitFor(() => expect(screen.queryByTestId(peerStatusLoadingTestId)).not.toBeInTheDocument());
 
-			await userEvent.click(screen.getByTestId("CustomPeers-network-item--mobile--refresh"));
+			await userEvent.click(screen.queryAllByTestId("CustomPeers-network-item--mobile--refresh")[0]);
 
 			await waitFor(() => {
 				expect(refreshPersistMock).toHaveBeenCalledOnce();
@@ -1027,17 +1025,17 @@ describe("Servers Settings", () => {
 			);
 
 			// Is loading initially
-			expect(screen.getAllByTestId(peerStatusLoadingTestId)).toHaveLength(3);
+			expect(screen.getAllByTestId(peerStatusLoadingTestId)).toHaveLength(6);
 
 			// After ping it should show ok
-			await waitFor(() => expect(screen.getAllByTestId(peerStatusOkTestId)).toHaveLength(3));
+			await waitFor(() => expect(screen.getAllByTestId(peerStatusOkTestId)).toHaveLength(6));
 
 			await userEvent.click(screen.getAllByTestId(peerStatusOkTestId)[0]);
 
 			await waitFor(() =>
-				expect(screen.queryByTestId("CustomPeers-network-item--mobile--expanded")).not.toBeInTheDocument(),
+				expect(screen.queryAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument(),
 			);
-		});
+		}); 
 
 		it("should show status ok after ping the servers", async () => {
 			const { asFragment } = render(
@@ -1091,10 +1089,10 @@ describe("Servers Settings", () => {
 			);
 
 			// Is loading initially
-			expect(screen.getAllByTestId(peerStatusLoadingTestId)).toHaveLength(3);
+			expect(screen.getAllByTestId(peerStatusLoadingTestId)).toHaveLength(6);
 
 			// After ping it should show ok
-			await waitFor(() => expect(screen.getAllByTestId(peerStatusOkTestId)).toHaveLength(3));
+			await waitFor(() => expect(screen.getAllByTestId(peerStatusOkTestId)).toHaveLength(6));
 
 			expect(asFragment()).toMatchSnapshot();
 		});
@@ -1115,7 +1113,7 @@ describe("Servers Settings", () => {
 			);
 
 			// After ping it should show ok
-			await waitFor(() => expect(screen.getAllByTestId(peerStatusOkTestId)).toHaveLength(4));
+			await waitFor(() => expect(screen.getAllByTestId(peerStatusOkTestId)).toHaveLength(5));
 
 			expect(asFragment()).toMatchSnapshot();
 		});
@@ -1410,10 +1408,10 @@ describe("Servers Settings", () => {
 			);
 
 			// Is loading initially
-			expect(screen.getAllByTestId(peerStatusLoadingTestId)).toHaveLength(3);
+			expect(screen.getAllByTestId(peerStatusLoadingTestId)).toHaveLength(6);
 
 			// After ping it should show error
-			await waitFor(() => expect(screen.getAllByTestId(peerStatusErrorTestId)).toHaveLength(3));
+			await waitFor(() => expect(screen.getAllByTestId(peerStatusErrorTestId)).toHaveLength(6));
 
 			expect(asFragment()).toMatchSnapshot();
 		});
@@ -1434,7 +1432,7 @@ describe("Servers Settings", () => {
 			);
 
 			// After ping it should show error
-			await waitFor(() => expect(screen.getAllByTestId(peerStatusErrorTestId)).toHaveLength(4));
+			await waitFor(() => expect(screen.getAllByTestId(peerStatusErrorTestId)).toHaveLength(5));
 
 			expect(asFragment()).toMatchSnapshot();
 		});

--- a/src/domains/setting/pages/Servers/Servers.test.tsx
+++ b/src/domains/setting/pages/Servers/Servers.test.tsx
@@ -899,7 +899,7 @@ describe("Servers Settings", () => {
 
 			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[0]);
 
-			expect(screen.queryAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument();
+			expect(screen.getAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument();
 		});
 
 		it("can expand a custom servers accordion in xs for peer", async () => {
@@ -918,7 +918,7 @@ describe("Servers Settings", () => {
 			// index 2 is a peer network
 			await userEvent.click(within(table).getAllByTestId(networkAccordionIconTestId)[2]);
 
-			expect(screen.queryAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument();
+			expect(screen.getAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument();
 		});
 
 		it("can check servers accordion in mobile", async () => {
@@ -1000,8 +1000,6 @@ describe("Servers Settings", () => {
 				},
 			);
 
-			const table = screen.getByTestId(customPeerListTestId);
-
 			await waitFor(() => expect(screen.queryByTestId(peerStatusLoadingTestId)).not.toBeInTheDocument());
 
 			await userEvent.click(screen.queryAllByTestId("CustomPeers-network-item--mobile--refresh")[0]);
@@ -1033,7 +1031,7 @@ describe("Servers Settings", () => {
 			await userEvent.click(screen.getAllByTestId(peerStatusOkTestId)[0]);
 
 			await waitFor(() =>
-				expect(screen.queryAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument(),
+				expect(screen.getAllByTestId("CustomPeers-network-item--mobile--expanded")[0]).toBeInTheDocument(),
 			);
 		}); 
 

--- a/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
+++ b/src/domains/setting/pages/Servers/__snapshots__/Servers.test.tsx.snap
@@ -6977,11 +6977,11 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -7068,14 +7068,14 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -7100,17 +7100,237 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Peer
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M15.099 16c2.2 0 3.9-1.7 3.9-3.9s-1.7-3.9-3.9-3.9c-.8 0-1.6.2-2.3.7-.6-3.2-3.7-5.4-6.9-4.8-3.2.6-5.4 3.7-4.8 7 .6 2.8 3.1 4.9 6 4.9h8z"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live.arkvault.io/api
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusloading"
+                                            >
+                                              <div
+                                                class="css-v1kihw"
+                                                color="info"
+                                              />
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                             <div
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -7222,14 +7442,14 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -7254,17 +7474,255 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK Devnet
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-test-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusloading"
+                                            >
+                                              <div
+                                                class="css-v1kihw"
+                                                color="info"
+                                              />
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                             <div
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -7351,14 +7809,14 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -7380,6 +7838,244 @@ exports[`Servers Settings > with servers > should render customs servers in xs 1
                                           />
                                         </svg>
                                       </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusloading"
+                                            >
+                                              <div
+                                                class="css-v1kihw"
+                                                color="info"
+                                              />
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
                                     </div>
                                   </div>
                                 </div>
@@ -11040,11 +11736,11 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -11159,14 +11855,14 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -11191,17 +11887,270 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Peer
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M15.099 16c2.2 0 3.9-1.7 3.9-3.9s-1.7-3.9-3.9-3.9c-.8 0-1.6.2-2.3.7-.6-3.2-3.7-5.4-6.9-4.8-3.2.6-5.4 3.7-4.8 7 .6 2.8 3.1 4.9 6 4.9h8z"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live.arkvault.io/api
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is healthy
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusok"
+                                            >
+                                              <div
+                                                class="text-theme-success-600 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  viewBox="0 0 20 20"
+                                                  x="0"
+                                                  xml:space="preserve"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <g
+                                                    fill="none"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                    transform="translate(1054 350.79)"
+                                                  >
+                                                    <circle
+                                                      cx="-1044"
+                                                      cy="-341"
+                                                      r="9"
+                                                      transform="translate(0 .172)"
+                                                    />
+                                                    <path
+                                                      d="M-1040.1-343.8l-4.7 6.3c-.2.3-.5.3-.9.1l-.1-.1-1.3-1.3"
+                                                      stroke-linecap="round"
+                                                      stroke-linejoin="round"
+                                                    />
+                                                  </g>
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                             <div
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -11341,14 +12290,14 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -11373,17 +12322,288 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK Devnet
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-test-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is healthy
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusok"
+                                            >
+                                              <div
+                                                class="text-theme-success-600 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  viewBox="0 0 20 20"
+                                                  x="0"
+                                                  xml:space="preserve"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <g
+                                                    fill="none"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                    transform="translate(1054 350.79)"
+                                                  >
+                                                    <circle
+                                                      cx="-1044"
+                                                      cy="-341"
+                                                      r="9"
+                                                      transform="translate(0 .172)"
+                                                    />
+                                                    <path
+                                                      d="M-1040.1-343.8l-4.7 6.3c-.2.3-.5.3-.9.1l-.1-.1-1.3-1.3"
+                                                      stroke-linecap="round"
+                                                      stroke-linejoin="round"
+                                                    />
+                                                  </g>
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                             <div
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -11498,14 +12718,14 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -11527,6 +12747,277 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                           />
                                         </svg>
                                       </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is healthy
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusok"
+                                            >
+                                              <div
+                                                class="text-theme-success-600 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  viewBox="0 0 20 20"
+                                                  x="0"
+                                                  xml:space="preserve"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <g
+                                                    fill="none"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                    transform="translate(1054 350.79)"
+                                                  >
+                                                    <circle
+                                                      cx="-1044"
+                                                      cy="-341"
+                                                      r="9"
+                                                      transform="translate(0 .172)"
+                                                    />
+                                                    <path
+                                                      d="M-1040.1-343.8l-4.7 6.3c-.2.3-.5.3-.9.1l-.1-.1-1.3-1.3"
+                                                      stroke-linecap="round"
+                                                      stroke-linejoin="round"
+                                                    />
+                                                  </g>
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
                                     </div>
                                   </div>
                                 </div>
@@ -12914,11 +14405,11 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                               class="-mx-8"
                             >
                               <div
-                                class="css-fvpuky"
+                                class="css-13o3tsw"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
+                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -12962,6 +14453,188 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                       >
                                         ARK #1
                                       </div>
+                                    </div>
+                                    <div
+                                      class="ml-5 flex items-center space-x-3"
+                                    >
+                                      <div
+                                        class="flex cursor-pointer justify-center"
+                                      >
+                                        <div
+                                          data-testid="CustomPeersPeer--statusok"
+                                        >
+                                          <div
+                                            class="text-theme-success-600 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-width="2"
+                                                transform="translate(1054 350.79)"
+                                              >
+                                                <circle
+                                                  cx="-1044"
+                                                  cy="-341"
+                                                  r="9"
+                                                  transform="translate(0 .172)"
+                                                />
+                                                <path
+                                                  d="M-1040.1-343.8l-4.7 6.3c-.2.3-.5.3-.9.1l-.1-.1-1.3-1.3"
+                                                  stroke-linecap="round"
+                                                  stroke-linejoin="round"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
+                                        type="vertical"
+                                      />
+                                      <label
+                                        class="css-xklln0"
+                                      >
+                                        <input
+                                          class="css-1r71f0z toggle-input"
+                                          data-testid="CustomPeers-toggle"
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          class="css-d8rk4r toggle-handle"
+                                        >
+                                          <span
+                                            class="css-st84t0"
+                                          />
+                                        </div>
+                                      </label>
+                                      <div
+                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
+                                        type="vertical"
+                                      />
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                  >
+                                    <div
+                                      class="css-tz6w2"
+                                      data-testid="Accordion__toggle"
+                                    >
+                                      <div
+                                        class="transition-transform css-15txs7d"
+                                        height="10"
+                                        width="10"
+                                      >
+                                        <svg
+                                          id="chevron-down-small"
+                                          viewBox="0 0 10 10"
+                                          x="0"
+                                          xml:space="preserve"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                          y="0"
+                                        >
+                                          <path
+                                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                          />
+                                        </svg>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="-mx-8"
+                            >
+                              <div
+                                class="css-fvpuky"
+                                data-testid="CustomPeers-network-item--mobile"
+                              >
+                                <div
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
+                                  data-testid="AccordionHeader"
+                                >
+                                  <div
+                                    class="flex flex-grow flex-row items-center"
+                                  >
+                                    <div
+                                      class="flex w-0 flex-grow items-center space-x-3 text-theme-secondary-700"
+                                    >
+                                      <div
+                                        class="flex shrink-0 items-center"
+                                      >
+                                        <div
+                                          aria-label="ARK Devnet"
+                                          class="inline-flex h-5 w-5 items-center justify-center text-theme-secondary-700 border-theme-secondary-300 dark:border-theme-secondary-700"
+                                          data-testid="NetworkIcon-ARK-ark.devnet"
+                                        >
+                                          <div
+                                            class="css-1i4b0eq"
+                                            data-testid="NetworkIcon__icon"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              id="ark"
+                                              viewBox="0 0 36.3 30.6"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M18.2 10.7L0 30.6 18.2 0l18.1 30.6-18.1-19.9zM10 24.2l2.9-3.2h10.6l2.9 3.2H10zm5-5.4l3.2-3.4 3.2 3.4H15z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="truncate font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                      >
+                                        ARK Devnet Musig #1
+                                      </div>
+                                      <span>
+                                        <div
+                                          class="text-theme-secondary-500 dark:text-theme-secondary-700 css-v0ob3f"
+                                          height="16"
+                                          width="16"
+                                        >
+                                          <svg
+                                            id="code"
+                                            viewBox="0 0 20 20"
+                                            x="0"
+                                            xml:space="preserve"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            y="0"
+                                          >
+                                            <path
+                                              d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                              fill="none"
+                                              stroke="currentColor"
+                                              stroke-linecap="round"
+                                              stroke-linejoin="round"
+                                              stroke-width="2"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </span>
                                     </div>
                                     <div
                                       class="ml-5 flex items-center space-x-3"
@@ -13086,7 +14759,7 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                         <div
                                           class="break-all text-right"
                                         >
-                                          ARK
+                                          ARK Devnet
                                         </div>
                                       </div>
                                     </div>
@@ -13105,7 +14778,7 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                           class="flex items-center space-x-3"
                                         >
                                           <div>
-                                            Peer
+                                            Multisig
                                           </div>
                                           <div
                                             class="text-theme-secondary-700 css-1i4b0eq"
@@ -13114,18 +14787,36 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                           >
                                             <svg
                                               fill="none"
-                                              viewBox="0 0 20 20"
+                                              viewBox="0 0 21 21"
                                               x="0"
                                               xmlns="http://www.w3.org/2000/svg"
                                               y="0"
                                             >
-                                              <path
-                                                d="M15.099 16c2.2 0 3.9-1.7 3.9-3.9s-1.7-3.9-3.9-3.9c-.8 0-1.6.2-2.3.7-.6-3.2-3.7-5.4-6.9-4.8-3.2.6-5.4 3.7-4.8 7 .6 2.8 3.1 4.9 6 4.9h8z"
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
                                                 stroke="currentColor"
                                                 stroke-linecap="round"
                                                 stroke-linejoin="round"
                                                 stroke-width="2"
-                                              />
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
                                             </svg>
                                           </div>
                                         </div>
@@ -13145,7 +14836,7 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                         <div
                                           class="break-all text-right"
                                         >
-                                          https://ark-live.arkvault.io/api
+                                          https://ark-test-musig.arkvault.io
                                         </div>
                                       </div>
                                     </div>
@@ -13324,193 +15015,11 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
-                                  data-testid="AccordionHeader"
-                                >
-                                  <div
-                                    class="flex flex-grow flex-row items-center"
-                                  >
-                                    <div
-                                      class="flex w-0 flex-grow items-center space-x-3 text-theme-secondary-700"
-                                    >
-                                      <div
-                                        class="flex shrink-0 items-center"
-                                      >
-                                        <div
-                                          aria-label="ARK Devnet"
-                                          class="inline-flex h-5 w-5 items-center justify-center text-theme-secondary-700 border-theme-secondary-300 dark:border-theme-secondary-700"
-                                          data-testid="NetworkIcon-ARK-ark.devnet"
-                                        >
-                                          <div
-                                            class="css-1i4b0eq"
-                                            data-testid="NetworkIcon__icon"
-                                            height="20"
-                                            width="20"
-                                          >
-                                            <svg
-                                              id="ark"
-                                              viewBox="0 0 36.3 30.6"
-                                              x="0"
-                                              xml:space="preserve"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                              y="0"
-                                            >
-                                              <path
-                                                d="M18.2 10.7L0 30.6 18.2 0l18.1 30.6-18.1-19.9zM10 24.2l2.9-3.2h10.6l2.9 3.2H10zm5-5.4l3.2-3.4 3.2 3.4H15z"
-                                                fill="currentColor"
-                                              />
-                                            </svg>
-                                          </div>
-                                        </div>
-                                      </div>
-                                      <div
-                                        class="truncate font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
-                                      >
-                                        ARK Devnet Musig #1
-                                      </div>
-                                      <span>
-                                        <div
-                                          class="text-theme-secondary-500 dark:text-theme-secondary-700 css-v0ob3f"
-                                          height="16"
-                                          width="16"
-                                        >
-                                          <svg
-                                            id="code"
-                                            viewBox="0 0 20 20"
-                                            x="0"
-                                            xml:space="preserve"
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            y="0"
-                                          >
-                                            <path
-                                              d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
-                                              fill="none"
-                                              stroke="currentColor"
-                                              stroke-linecap="round"
-                                              stroke-linejoin="round"
-                                              stroke-width="2"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </span>
-                                    </div>
-                                    <div
-                                      class="ml-5 flex items-center space-x-3"
-                                    >
-                                      <div
-                                        class="flex cursor-pointer justify-center"
-                                      >
-                                        <div
-                                          data-testid="CustomPeersPeer--statusok"
-                                        >
-                                          <div
-                                            class="text-theme-success-600 css-1i4b0eq"
-                                            height="20"
-                                            width="20"
-                                          >
-                                            <svg
-                                              viewBox="0 0 20 20"
-                                              x="0"
-                                              xml:space="preserve"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                              y="0"
-                                            >
-                                              <g
-                                                fill="none"
-                                                stroke="currentColor"
-                                                stroke-width="2"
-                                                transform="translate(1054 350.79)"
-                                              >
-                                                <circle
-                                                  cx="-1044"
-                                                  cy="-341"
-                                                  r="9"
-                                                  transform="translate(0 .172)"
-                                                />
-                                                <path
-                                                  d="M-1040.1-343.8l-4.7 6.3c-.2.3-.5.3-.9.1l-.1-.1-1.3-1.3"
-                                                  stroke-linecap="round"
-                                                  stroke-linejoin="round"
-                                                />
-                                              </g>
-                                            </svg>
-                                          </div>
-                                        </div>
-                                      </div>
-                                      <div
-                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
-                                        type="vertical"
-                                      />
-                                      <label
-                                        class="css-xklln0"
-                                      >
-                                        <input
-                                          class="css-1r71f0z toggle-input"
-                                          data-testid="CustomPeers-toggle"
-                                          type="checkbox"
-                                        />
-                                        <div
-                                          class="css-d8rk4r toggle-handle"
-                                        >
-                                          <span
-                                            class="css-st84t0"
-                                          />
-                                        </div>
-                                      </label>
-                                      <div
-                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
-                                        type="vertical"
-                                      />
-                                    </div>
-                                  </div>
-                                  <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
-                                  >
-                                    <div
-                                      class="css-tz6w2"
-                                      data-testid="Accordion__toggle"
-                                    >
-                                      <div
-                                        class="transition-transform css-15txs7d"
-                                        height="10"
-                                        width="10"
-                                      >
-                                        <svg
-                                          id="chevron-down-small"
-                                          viewBox="0 0 10 10"
-                                          x="0"
-                                          xml:space="preserve"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                          y="0"
-                                        >
-                                          <path
-                                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
-                                            fill="none"
-                                            stroke="currentColor"
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            stroke-width="2"
-                                          />
-                                        </svg>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="-mx-8"
-                            >
-                              <div
-                                class="css-13o3tsw"
-                                data-testid="CustomPeers-network-item--mobile"
-                              >
-                                <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -13625,14 +15134,14 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -13654,6 +15163,277 @@ exports[`Servers Settings > with servers > should show status ok after ping the 
                                           />
                                         </svg>
                                       </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is healthy
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statusok"
+                                            >
+                                              <div
+                                                class="text-theme-success-600 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  viewBox="0 0 20 20"
+                                                  x="0"
+                                                  xml:space="preserve"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <g
+                                                    fill="none"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                    transform="translate(1054 350.79)"
+                                                  >
+                                                    <circle
+                                                      cx="-1044"
+                                                      cy="-341"
+                                                      r="9"
+                                                      transform="translate(0 .172)"
+                                                    />
+                                                    <path
+                                                      d="M-1040.1-343.8l-4.7 6.3c-.2.3-.5.3-.9.1l-.1-.1-1.3-1.3"
+                                                      stroke-linecap="round"
+                                                      stroke-linejoin="round"
+                                                    />
+                                                  </g>
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
                                     </div>
                                   </div>
                                 </div>
@@ -17293,11 +19073,11 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -17409,14 +19189,14 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -17441,17 +19221,267 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Peer
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M15.099 16c2.2 0 3.9-1.7 3.9-3.9s-1.7-3.9-3.9-3.9c-.8 0-1.6.2-2.3.7-.6-3.2-3.7-5.4-6.9-4.8-3.2.6-5.4 3.7-4.8 7 .6 2.8 3.1 4.9 6 4.9h8z"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live.arkvault.io/api
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is not resolving
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statuserror"
+                                            >
+                                              <div
+                                                class="text-theme-danger-400 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  fill="none"
+                                                  height="20"
+                                                  width="20"
+                                                  x="0"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <circle
+                                                    cx="10"
+                                                    cy="10"
+                                                    r="9"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                  />
+                                                  <path
+                                                    d="M7.3 12.7l5.4-5.4m0 5.4L7.3 7.3"
+                                                    stroke="currentColor"
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    stroke-width="2"
+                                                  />
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                             <div
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -17588,14 +19618,14 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -17620,17 +19650,285 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK Devnet
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-test-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is not resolving
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statuserror"
+                                            >
+                                              <div
+                                                class="text-theme-danger-400 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  fill="none"
+                                                  height="20"
+                                                  width="20"
+                                                  x="0"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <circle
+                                                    cx="10"
+                                                    cy="10"
+                                                    r="9"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                  />
+                                                  <path
+                                                    d="M7.3 12.7l5.4-5.4m0 5.4L7.3 7.3"
+                                                    stroke="currentColor"
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    stroke-width="2"
+                                                  />
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
+                                    </div>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                             <div
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -17742,14 +20040,14 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -17771,6 +20069,274 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                           />
                                         </svg>
                                       </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is not resolving
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statuserror"
+                                            >
+                                              <div
+                                                class="text-theme-danger-400 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  fill="none"
+                                                  height="20"
+                                                  width="20"
+                                                  x="0"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <circle
+                                                    cx="10"
+                                                    cy="10"
+                                                    r="9"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                  />
+                                                  <path
+                                                    d="M7.3 12.7l5.4-5.4m0 5.4L7.3 7.3"
+                                                    stroke="currentColor"
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    stroke-width="2"
+                                                  />
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
                                     </div>
                                   </div>
                                 </div>
@@ -19152,11 +21718,11 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                               class="-mx-8"
                             >
                               <div
-                                class="css-fvpuky"
+                                class="css-13o3tsw"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
+                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -19200,6 +21766,185 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                       >
                                         ARK #1
                                       </div>
+                                    </div>
+                                    <div
+                                      class="ml-5 flex items-center space-x-3"
+                                    >
+                                      <div
+                                        class="flex cursor-pointer justify-center"
+                                      >
+                                        <div
+                                          data-testid="CustomPeersPeer--statuserror"
+                                        >
+                                          <div
+                                            class="text-theme-danger-400 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              height="20"
+                                              width="20"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <circle
+                                                cx="10"
+                                                cy="10"
+                                                r="9"
+                                                stroke="currentColor"
+                                                stroke-width="2"
+                                              />
+                                              <path
+                                                d="M7.3 12.7l5.4-5.4m0 5.4L7.3 7.3"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
+                                        type="vertical"
+                                      />
+                                      <label
+                                        class="css-xklln0"
+                                      >
+                                        <input
+                                          class="css-1r71f0z toggle-input"
+                                          data-testid="CustomPeers-toggle"
+                                          type="checkbox"
+                                        />
+                                        <div
+                                          class="css-d8rk4r toggle-handle"
+                                        >
+                                          <span
+                                            class="css-st84t0"
+                                          />
+                                        </div>
+                                      </label>
+                                      <div
+                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
+                                        type="vertical"
+                                      />
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                  >
+                                    <div
+                                      class="css-tz6w2"
+                                      data-testid="Accordion__toggle"
+                                    >
+                                      <div
+                                        class="transition-transform css-15txs7d"
+                                        height="10"
+                                        width="10"
+                                      >
+                                        <svg
+                                          id="chevron-down-small"
+                                          viewBox="0 0 10 10"
+                                          x="0"
+                                          xml:space="preserve"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                          y="0"
+                                        >
+                                          <path
+                                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                          />
+                                        </svg>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="-mx-8"
+                            >
+                              <div
+                                class="css-fvpuky"
+                                data-testid="CustomPeers-network-item--mobile"
+                              >
+                                <div
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
+                                  data-testid="AccordionHeader"
+                                >
+                                  <div
+                                    class="flex flex-grow flex-row items-center"
+                                  >
+                                    <div
+                                      class="flex w-0 flex-grow items-center space-x-3 text-theme-secondary-700"
+                                    >
+                                      <div
+                                        class="flex shrink-0 items-center"
+                                      >
+                                        <div
+                                          aria-label="ARK Devnet"
+                                          class="inline-flex h-5 w-5 items-center justify-center text-theme-secondary-700 border-theme-secondary-300 dark:border-theme-secondary-700"
+                                          data-testid="NetworkIcon-ARK-ark.devnet"
+                                        >
+                                          <div
+                                            class="css-1i4b0eq"
+                                            data-testid="NetworkIcon__icon"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              id="ark"
+                                              viewBox="0 0 36.3 30.6"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M18.2 10.7L0 30.6 18.2 0l18.1 30.6-18.1-19.9zM10 24.2l2.9-3.2h10.6l2.9 3.2H10zm5-5.4l3.2-3.4 3.2 3.4H15z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="truncate font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
+                                      >
+                                        ARK Devnet Musig #1
+                                      </div>
+                                      <span>
+                                        <div
+                                          class="text-theme-secondary-500 dark:text-theme-secondary-700 css-v0ob3f"
+                                          height="16"
+                                          width="16"
+                                        >
+                                          <svg
+                                            id="code"
+                                            viewBox="0 0 20 20"
+                                            x="0"
+                                            xml:space="preserve"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            y="0"
+                                          >
+                                            <path
+                                              d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                              fill="none"
+                                              stroke="currentColor"
+                                              stroke-linecap="round"
+                                              stroke-linejoin="round"
+                                              stroke-width="2"
+                                            />
+                                          </svg>
+                                        </div>
+                                      </span>
                                     </div>
                                     <div
                                       class="ml-5 flex items-center space-x-3"
@@ -19321,7 +22066,7 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                         <div
                                           class="break-all text-right"
                                         >
-                                          ARK
+                                          ARK Devnet
                                         </div>
                                       </div>
                                     </div>
@@ -19340,7 +22085,7 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                           class="flex items-center space-x-3"
                                         >
                                           <div>
-                                            Peer
+                                            Multisig
                                           </div>
                                           <div
                                             class="text-theme-secondary-700 css-1i4b0eq"
@@ -19349,18 +22094,36 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                           >
                                             <svg
                                               fill="none"
-                                              viewBox="0 0 20 20"
+                                              viewBox="0 0 21 21"
                                               x="0"
                                               xmlns="http://www.w3.org/2000/svg"
                                               y="0"
                                             >
-                                              <path
-                                                d="M15.099 16c2.2 0 3.9-1.7 3.9-3.9s-1.7-3.9-3.9-3.9c-.8 0-1.6.2-2.3.7-.6-3.2-3.7-5.4-6.9-4.8-3.2.6-5.4 3.7-4.8 7 .6 2.8 3.1 4.9 6 4.9h8z"
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
                                                 stroke="currentColor"
                                                 stroke-linecap="round"
                                                 stroke-linejoin="round"
                                                 stroke-width="2"
-                                              />
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
                                             </svg>
                                           </div>
                                         </div>
@@ -19380,7 +22143,7 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                         <div
                                           class="break-all text-right"
                                         >
-                                          https://ark-live.arkvault.io/api
+                                          https://ark-test-musig.arkvault.io
                                         </div>
                                       </div>
                                     </div>
@@ -19556,190 +22319,11 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                               class="-mx-8"
                             >
                               <div
-                                class="css-13o3tsw"
+                                class="css-fvpuky"
                                 data-testid="CustomPeers-network-item--mobile"
                               >
                                 <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
-                                  data-testid="AccordionHeader"
-                                >
-                                  <div
-                                    class="flex flex-grow flex-row items-center"
-                                  >
-                                    <div
-                                      class="flex w-0 flex-grow items-center space-x-3 text-theme-secondary-700"
-                                    >
-                                      <div
-                                        class="flex shrink-0 items-center"
-                                      >
-                                        <div
-                                          aria-label="ARK Devnet"
-                                          class="inline-flex h-5 w-5 items-center justify-center text-theme-secondary-700 border-theme-secondary-300 dark:border-theme-secondary-700"
-                                          data-testid="NetworkIcon-ARK-ark.devnet"
-                                        >
-                                          <div
-                                            class="css-1i4b0eq"
-                                            data-testid="NetworkIcon__icon"
-                                            height="20"
-                                            width="20"
-                                          >
-                                            <svg
-                                              id="ark"
-                                              viewBox="0 0 36.3 30.6"
-                                              x="0"
-                                              xml:space="preserve"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                              y="0"
-                                            >
-                                              <path
-                                                d="M18.2 10.7L0 30.6 18.2 0l18.1 30.6-18.1-19.9zM10 24.2l2.9-3.2h10.6l2.9 3.2H10zm5-5.4l3.2-3.4 3.2 3.4H15z"
-                                                fill="currentColor"
-                                              />
-                                            </svg>
-                                          </div>
-                                        </div>
-                                      </div>
-                                      <div
-                                        class="truncate font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
-                                      >
-                                        ARK Devnet Musig #1
-                                      </div>
-                                      <span>
-                                        <div
-                                          class="text-theme-secondary-500 dark:text-theme-secondary-700 css-v0ob3f"
-                                          height="16"
-                                          width="16"
-                                        >
-                                          <svg
-                                            id="code"
-                                            viewBox="0 0 20 20"
-                                            x="0"
-                                            xml:space="preserve"
-                                            xmlns="http://www.w3.org/2000/svg"
-                                            y="0"
-                                          >
-                                            <path
-                                              d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
-                                              fill="none"
-                                              stroke="currentColor"
-                                              stroke-linecap="round"
-                                              stroke-linejoin="round"
-                                              stroke-width="2"
-                                            />
-                                          </svg>
-                                        </div>
-                                      </span>
-                                    </div>
-                                    <div
-                                      class="ml-5 flex items-center space-x-3"
-                                    >
-                                      <div
-                                        class="flex cursor-pointer justify-center"
-                                      >
-                                        <div
-                                          data-testid="CustomPeersPeer--statuserror"
-                                        >
-                                          <div
-                                            class="text-theme-danger-400 css-1i4b0eq"
-                                            height="20"
-                                            width="20"
-                                          >
-                                            <svg
-                                              fill="none"
-                                              height="20"
-                                              width="20"
-                                              x="0"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                              y="0"
-                                            >
-                                              <circle
-                                                cx="10"
-                                                cy="10"
-                                                r="9"
-                                                stroke="currentColor"
-                                                stroke-width="2"
-                                              />
-                                              <path
-                                                d="M7.3 12.7l5.4-5.4m0 5.4L7.3 7.3"
-                                                stroke="currentColor"
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                stroke-width="2"
-                                              />
-                                            </svg>
-                                          </div>
-                                        </div>
-                                      </div>
-                                      <div
-                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
-                                        type="vertical"
-                                      />
-                                      <label
-                                        class="css-xklln0"
-                                      >
-                                        <input
-                                          class="css-1r71f0z toggle-input"
-                                          data-testid="CustomPeers-toggle"
-                                          type="checkbox"
-                                        />
-                                        <div
-                                          class="css-d8rk4r toggle-handle"
-                                        >
-                                          <span
-                                            class="css-st84t0"
-                                          />
-                                        </div>
-                                      </label>
-                                      <div
-                                        class="border-theme-secondary-300 dark:border-theme-secondary-800 css-1aie31u"
-                                        type="vertical"
-                                      />
-                                    </div>
-                                  </div>
-                                  <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
-                                  >
-                                    <div
-                                      class="css-tz6w2"
-                                      data-testid="Accordion__toggle"
-                                    >
-                                      <div
-                                        class="transition-transform css-15txs7d"
-                                        height="10"
-                                        width="10"
-                                      >
-                                        <svg
-                                          id="chevron-down-small"
-                                          viewBox="0 0 10 10"
-                                          x="0"
-                                          xml:space="preserve"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                          y="0"
-                                        >
-                                          <path
-                                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
-                                            fill="none"
-                                            stroke="currentColor"
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            stroke-width="2"
-                                          />
-                                        </svg>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="-mx-8"
-                            >
-                              <div
-                                class="css-13o3tsw"
-                                data-testid="CustomPeers-network-item--mobile"
-                              >
-                                <div
-                                  class="select-none cursor-pointer group md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800"
+                                  class="select-none cursor-pointer md:h-20 py-6 px-8 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b"
                                   data-testid="AccordionHeader"
                                 >
                                   <div
@@ -19851,14 +22435,14 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                     </div>
                                   </div>
                                   <div
-                                    class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+                                    class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
                                   >
                                     <div
                                       class="css-tz6w2"
                                       data-testid="Accordion__toggle"
                                     >
                                       <div
-                                        class="transition-transform css-15txs7d"
+                                        class="transition-transform rotate-180 css-15txs7d"
                                         height="10"
                                         width="10"
                                       >
@@ -19880,6 +22464,274 @@ exports[`Servers Settings > with unreachable servers > should show status error 
                                           />
                                         </svg>
                                       </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div
+                                  class="px-8 pb-6 md:px-4 md:pb-0 md:pt-6"
+                                  data-testid="CustomPeers-network-item--mobile--expanded"
+                                >
+                                  <div
+                                    class="flex flex-col"
+                                  >
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Network
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          ARK
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Type
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-3"
+                                        >
+                                          <div>
+                                            Multisig
+                                          </div>
+                                          <div
+                                            class="text-theme-secondary-700 css-1i4b0eq"
+                                            height="20"
+                                            width="20"
+                                          >
+                                            <svg
+                                              fill="none"
+                                              viewBox="0 0 21 21"
+                                              x="0"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_6059_157627)"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M4.389 7.064a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0m0 6.801a.283.283 0 1 0 0 .567.283.283 0 0 0 0-.567v0"
+                                                />
+                                                <path
+                                                  d="M15.155 3.95a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm0 6.8a3.4 3.4 0 1 1 0 6.8h-10.2a3.4 3.4 0 1 1 0-6.8h10.2zm-6.233-3.4h6.233m-6.233 6.798h6.233"
+                                                />
+                                              </g>
+                                              <defs>
+                                                <clippath
+                                                  id="clip0_6059_157627"
+                                                >
+                                                  <path
+                                                    d="M0 0h20v20H0z"
+                                                    fill="#fff"
+                                                    transform="translate(.055 .95)"
+                                                  />
+                                                </clippath>
+                                              </defs>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Address
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="break-all text-right"
+                                        >
+                                          https://ark-live-musig.arkvault.io
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="flex items-start space-x-3 border-t border-dashed border-theme-secondary-300 py-4 dark:border-theme-secondary-800"
+                                    >
+                                      <div
+                                        class="font-semibold text-theme-secondary-500 dark:text-theme-secondary-700"
+                                      >
+                                        Status
+                                      </div>
+                                      <div
+                                        class="flex flex-1 justify-end text-theme-secondary-700 dark:text-theme-secondary-500"
+                                      >
+                                        <div
+                                          class="flex w-0 flex-1 items-center justify-end space-x-3 overflow-hidden"
+                                        >
+                                          <span
+                                            class="truncate"
+                                          >
+                                            Peer is not resolving
+                                          </span>
+                                          <div
+                                            class="flex cursor-pointer justify-center"
+                                          >
+                                            <div
+                                              data-testid="CustomPeersPeer--statuserror"
+                                            >
+                                              <div
+                                                class="text-theme-danger-400 css-1i4b0eq"
+                                                height="20"
+                                                width="20"
+                                              >
+                                                <svg
+                                                  fill="none"
+                                                  height="20"
+                                                  width="20"
+                                                  x="0"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  y="0"
+                                                >
+                                                  <circle
+                                                    cx="10"
+                                                    cy="10"
+                                                    r="9"
+                                                    stroke="currentColor"
+                                                    stroke-width="2"
+                                                  />
+                                                  <path
+                                                    d="M7.3 12.7l5.4-5.4m0 5.4L7.3 7.3"
+                                                    stroke="currentColor"
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    stroke-width="2"
+                                                  />
+                                                </svg>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                    <div
+                                      class="mt-3 flex space-x-3"
+                                    >
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 disabled:cursor-not-allowed bg-theme-danger-100 text-theme-danger-400 dark:bg-theme-danger-400 dark:text-white hover:bg-theme-danger-400 hover:text-white dark:hover:bg-theme-danger-300 focus:ring-theme-danger-300"
+                                        data-testid="CustomPeers-network-item--mobile--delete"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="trash"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <g
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              >
+                                                <path
+                                                  d="M1 3.629h18M11.8 1H8c-.7 0-1.3.607-1.3 1.315h0v1.314H13V2.315C13 1.607 12.5 1 11.8 1h0zM8 14.449v-6.37M11.8 14.449v-6.37M15.7 17.787c-.1.707-.6 1.213-1.3 1.213H5.3c-.7 0-1.2-.506-1.3-1.213L2.9 3.629h14l-1.2 14.158z"
+                                                />
+                                              </g>
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500"
+                                        data-testid="CustomPeers-network-item--mobile--refresh"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="arrow-rotate-left"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M10.01 20c1.407 0 2.81-.296 4.127-.883a9.766 9.766 0 0 0 5.232-5.576C21.29 8.323 18.675 2.538 13.54.645 9.827-.715 5.824.11 3.049 2.793v-.87a1.129 1.129 0 1 0-2.26 0V5.52a1.13 1.13 0 0 0 .282.743 1.123 1.123 0 0 0 .775.382c.027.001.044 0 .08.002h3.587a1.129 1.129 0 1 0 0-2.259H4.65c2.147-2.05 5.237-2.674 8.11-1.622 3.965 1.462 5.98 5.946 4.49 9.995a7.521 7.521 0 0 1-4.033 4.294 7.86 7.86 0 0 1-5.96.191 7.656 7.656 0 0 1-4.31-3.998 1.129 1.129 0 1 0-2.056.938 9.94 9.94 0 0 0 5.588 5.18A10.18 10.18 0 0 0 10.01 20z"
+                                                fill="currentColor"
+                                              />
+                                            </svg>
+                                          </div>
+                                        </div>
+                                      </button>
+                                      <button
+                                        class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 w-full"
+                                        data-testid="CustomPeers-network-item--mobile--edit"
+                                        type="button"
+                                      >
+                                        <div
+                                          class="flex items-center space-x-2"
+                                        >
+                                          <div
+                                            class="css-v0ob3f"
+                                            height="16"
+                                            width="16"
+                                          >
+                                            <svg
+                                              id="pencil"
+                                              viewBox="0 0 20 20"
+                                              x="0"
+                                              xml:space="preserve"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              y="0"
+                                            >
+                                              <path
+                                                d="M5.92 18.297L1 19l.703-4.72L14.054 1.828c1.105-1.104 2.913-1.104 4.118 0 1.104 1.105 1.104 2.913 0 4.118L5.92 18.297z"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                stroke-width="2"
+                                              />
+                                            </svg>
+                                          </div>
+                                          <span>
+                                            Edit
+                                          </span>
+                                        </div>
+                                      </button>
                                     </div>
                                   </div>
                                 </div>

--- a/src/domains/wallet/components/PortfolioHeader/__snapshots__/PortfolioHeader.test.tsx.snap
+++ b/src/domains/wallet/components/PortfolioHeader/__snapshots__/PortfolioHeader.test.tsx.snap
@@ -256,18 +256,18 @@ exports[`Portfolio grouped networks > should apply ledger import 1`] = `
     data-testid="NetworkWalletsGroupList"
   >
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK"
@@ -454,14 +454,14 @@ exports[`Portfolio grouped networks > should apply ledger import 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -486,20 +486,601 @@ exports[`Portfolio grouped networks > should apply ledger import 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              arkx
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              arkx
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__SecondSignature"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="second-signature"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-width="2"
+                                transform="translate(482.484 177)"
+                              >
+                                <path
+                                  d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
+                                />
+                                <circle
+                                  cx="-476.5"
+                                  cy="-170.9"
+                                  r="5"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK Devnet"
@@ -726,14 +1307,14 @@ exports[`Portfolio grouped networks > should apply ledger import 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -755,6 +1336,895 @@ exports[`Portfolio grouped networks > should apply ledger import 1`] = `
                 />
               </svg>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__TestNetwork"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="code"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 2
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 2
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__SecondSignature"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="second-signature"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-width="2"
+                                transform="translate(482.484 177)"
+                              >
+                                <path
+                                  d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
+                                />
+                                <circle
+                                  cx="-476.5"
+                                  cy="-170.9"
+                                  r="5"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__TestNetwork"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="code"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        57.68 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
@@ -1019,18 +2489,18 @@ exports[`Portfolio grouped networks > should render list 1`] = `
     data-testid="NetworkWalletsGroupList"
   >
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK"
@@ -1217,14 +2687,14 @@ exports[`Portfolio grouped networks > should render list 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -1249,20 +2719,601 @@ exports[`Portfolio grouped networks > should render list 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              arkx
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              arkx
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__SecondSignature"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="second-signature"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-width="2"
+                                transform="translate(482.484 177)"
+                              >
+                                <path
+                                  d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
+                                />
+                                <circle
+                                  cx="-476.5"
+                                  cy="-170.9"
+                                  r="5"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK Devnet"
@@ -1489,14 +3540,14 @@ exports[`Portfolio grouped networks > should render list 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -1518,6 +3569,895 @@ exports[`Portfolio grouped networks > should render list 1`] = `
                 />
               </svg>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__TestNetwork"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="code"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 2
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 2
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__SecondSignature"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="second-signature"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-width="2"
+                                transform="translate(482.484 177)"
+                              >
+                                <path
+                                  d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
+                                />
+                                <circle
+                                  cx="-476.5"
+                                  cy="-170.9"
+                                  r="5"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
+                          data-testid="WalletIcon__TestNetwork"
+                        >
+                          <div
+                            class="css-1i4b0eq"
+                            height="20"
+                            width="20"
+                          >
+                            <svg
+                              id="code"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M6 6L1 9.98 6 14m8-8l5 3.98L14 14M11 4L9 16"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        57.68 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
@@ -1782,18 +4722,18 @@ exports[`Portfolio grouped networks > should render without testnet wallets 1`] 
     data-testid="NetworkWalletsGroupList"
   >
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK"
@@ -1980,14 +4920,14 @@ exports[`Portfolio grouped networks > should render without testnet wallets 1`] 
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -2009,6 +4949,564 @@ exports[`Portfolio grouped networks > should render without testnet wallets 1`] 
                 />
               </svg>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              arkx
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              arkx
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
@@ -346,8 +346,8 @@ describe("WalletsGroup", () => {
 		const currencyCell = screen.getAllByTestId("CurrencyCell")[0];
 		expect(currencyCell).toBeInTheDocument();
 
-		const { getAllByClassName } = within(currencyCell);
-		const skeletons = getAllByClassName("react-loading-skeleton");
+		// Use querySelectorAll on the currencyCell to find elements with the class name
+		const skeletons = currencyCell.querySelectorAll(".react-loading-skeleton");
 		expect(skeletons.length).toBeGreaterThan(0);
 		expect(skeletons[0]).toBeInTheDocument();
 

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
@@ -342,11 +342,10 @@ describe("WalletsGroup", () => {
 			},
 		);
 
-		// eslint-disable-next-line testing-library/no-node-access
 		const currencyCell = screen.getAllByTestId("CurrencyCell")[0];
 		expect(currencyCell).toBeInTheDocument();
 
-		// Use querySelectorAll on the currencyCell to find elements with the class name
+		// eslint-disable-next-line testing-library/no-node-access
 		const skeletons = currencyCell.querySelectorAll(".react-loading-skeleton");
 		expect(skeletons.length).toBeGreaterThan(0);
 		expect(skeletons[0]).toBeInTheDocument();

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
@@ -120,10 +120,6 @@ describe("WalletsGroup", () => {
 
 		expect(asFragment()).toMatchSnapshot();
 
-		const toggleArkMainnet = screen.getAllByTestId("Accordion__toggle")[0];
-		const toggleArkDevnet = screen.getAllByTestId("Accordion__toggle")[1];
-
-		
 		expect(screen.getAllByText(wallets[2].address())[0]).toBeInTheDocument();
 
 		expect(screen.getAllByTestId("WalletsGroupHeader")[0].classList.contains("md:border-b")).toBeTruthy();
@@ -326,7 +322,7 @@ describe("WalletsGroup", () => {
 		useDisplayWalletsSpy.mockRestore();
 	});
 
-	it("should show skeleton when syncing exchange rates", async () => {
+	it("should show skeleton when syncing exchange rates", () => {
 		const useConfigurationSpy = vi
 			.spyOn(configurationModule, "useConfiguration")
 			.mockReturnValue({ profileIsSyncingExchangeRates: true });
@@ -348,11 +344,12 @@ describe("WalletsGroup", () => {
 
 		// eslint-disable-next-line testing-library/no-node-access
 		const currencyCell = screen.getAllByTestId("CurrencyCell")[0];
-        expect(currencyCell).toBeInTheDocument();
+		expect(currencyCell).toBeInTheDocument();
 
-        const skeletons = currencyCell.querySelectorAll(".react-loading-skeleton");
-        expect(skeletons.length).toBeGreaterThan(0);
-        expect(skeletons[0]).toBeInTheDocument();
+		const { getAllByClassName } = within(currencyCell);
+		const skeletons = getAllByClassName("react-loading-skeleton");
+		expect(skeletons.length).toBeGreaterThan(0);
+		expect(skeletons[0]).toBeInTheDocument();
 
 		expect(asFragment()).toMatchSnapshot();
 

--- a/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
+++ b/src/domains/wallet/components/WalletsGroup/WalletsGroup.test.tsx
@@ -123,17 +123,14 @@ describe("WalletsGroup", () => {
 		const toggleArkMainnet = screen.getAllByTestId("Accordion__toggle")[0];
 		const toggleArkDevnet = screen.getAllByTestId("Accordion__toggle")[1];
 
-		expect(screen.queryByText(wallets[2].address())).not.toBeInTheDocument();
-
-		await userEvent.click(toggleArkMainnet);
+		
+		expect(screen.getAllByText(wallets[2].address())[0]).toBeInTheDocument();
 
 		expect(screen.getAllByTestId("WalletsGroupHeader")[0].classList.contains("md:border-b")).toBeTruthy();
 		expect(screen.queryAllByTestId("WalletsGroupHeader")[1].classList.contains("border-b")).toBeFalsy();
 
-		expect(screen.queryByText(wallets[0].alias()!)).not.toBeInTheDocument();
-		expect(screen.getByText(wallets[2].address())).toBeInTheDocument();
-
-		await userEvent.click(toggleArkDevnet);
+		expect(screen.getAllByText(wallets[0].alias()!)[0]).toBeInTheDocument();
+		expect(screen.getAllByText(wallets[2].address())[0]).toBeInTheDocument();
 
 		expect(screen.getAllByText(wallets[0].alias()!)[0]).toBeInTheDocument();
 
@@ -349,10 +346,13 @@ describe("WalletsGroup", () => {
 			},
 		);
 
-		await userEvent.click(screen.getAllByTestId("Accordion__toggle")[0]);
-
 		// eslint-disable-next-line testing-library/no-node-access
-		expect(screen.getAllByTestId("CurrencyCell")[0].querySelector(".react-loading-skeleton")).toBeInTheDocument();
+		const currencyCell = screen.getAllByTestId("CurrencyCell")[0];
+        expect(currencyCell).toBeInTheDocument();
+
+        const skeletons = currencyCell.querySelectorAll(".react-loading-skeleton");
+        expect(skeletons.length).toBeGreaterThan(0);
+        expect(skeletons[0]).toBeInTheDocument();
 
 		expect(asFragment()).toMatchSnapshot();
 

--- a/src/domains/wallet/components/WalletsGroup/__snapshots__/WalletsGroup.test.tsx.snap
+++ b/src/domains/wallet/components/WalletsGroup/__snapshots__/WalletsGroup.test.tsx.snap
@@ -256,18 +256,18 @@ exports[`WalletsGroup > should handle list wallet click 1`] = `
     data-testid="NetworkWalletsGroupList"
   >
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK"
@@ -454,14 +454,14 @@ exports[`WalletsGroup > should handle list wallet click 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -486,20 +486,578 @@ exports[`WalletsGroup > should handle list wallet click 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              AAA
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              AAA
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK Devnet"
@@ -726,14 +1284,14 @@ exports[`WalletsGroup > should handle list wallet click 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -756,6 +1314,3245 @@ exports[`WalletsGroup > should handle list wallet click 1`] = `
               </svg>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              AAA
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              AAA
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          class="flex w-full flex-col gap-4 border-theme-secondary-300 pt-4 dark:border-theme-secondary-800 sm:flex-row sm:justify-between md:border-t md:px-6 md:pb-4"
+        >
+          <div
+            class="flex items-center justify-center gap-2 text-sm font-semibold leading-5 text-theme-secondary-700 dark:text-theme-secondary-200 sm:justify-start"
+          >
+            <span>
+              Show
+            </span>
+            <div
+              class="relative"
+              data-testid="SelectDropdown"
+            >
+              <div
+                class="sr-only css-14zfvme"
+              >
+                <div
+                  class="relative flex h-full flex-1"
+                >
+                  <input
+                    autocomplete="off"
+                    class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                    data-testid="select-list__input"
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value="10"
+                  />
+                </div>
+              </div>
+              <div
+                class="w-full"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-owns="downshift-0-menu"
+                  role="combobox"
+                >
+                  <div>
+                    <label
+                      for="downshift-0-input"
+                      id="downshift-0-label"
+                    />
+                    <div
+                      class="invisible fixed w-auto whitespace-nowrap"
+                    >
+                      10…
+                    </div>
+                    <div
+                      class="!h-8 !w-[78px] !px-3 css-14zfvme"
+                    >
+                      <div
+                        class="relative flex h-full flex-1"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="downshift-0-menu"
+                          aria-labelledby="downshift-0-label"
+                          autocomplete="off"
+                          class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                          data-testid="SelectDropdown__input"
+                          id="downshift-0-input"
+                          placeholder="Select option"
+                          readonly=""
+                          type="text"
+                          value="10"
+                        />
+                        <span
+                          class="pointer-events-none absolute inset-y-0 flex w-full items-center text-sm font-normal opacity-50 sm:text-base"
+                          data-testid="Input__suggestion"
+                        >
+                          <span
+                            class="truncate"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                        data-testid="Input__addon-end"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="flex items-center"
+                          >
+                            <div
+                              class="flex items-center justify-center"
+                              data-testid="SelectDropdown__caret"
+                            >
+                              <div
+                                class="absolute inset-0 block cursor-pointer md:hidden"
+                              />
+                              <div
+                                class="transition-transform text-theme-secondary-500 css-15txs7d"
+                                height="10"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="downshift-0-label"
+                    id="downshift-0-menu"
+                    role="listbox"
+                  />
+                </div>
+              </div>
+            </div>
+            <span>
+              Records
+            </span>
+          </div>
+          <nav
+            class="relative w-full sm:w-auto css-4ybc2s"
+            data-testid="Pagination"
+          >
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 px-4 py-1.5"
+              data-testid="Pagination__first"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  First
+                </span>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 h-8 w-8 p-2.5"
+              data-testid="Pagination__previous"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-left-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M6.938 9l-3.8-3.8c-.1-.1-.1-.3 0-.4l3.8-3.8"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <div
+              class="flex rounded bg-theme-primary-100 dark:bg-theme-secondary-800"
+            >
+              <button
+                class="group css-eti7fq"
+                data-testid="PaginationSearchButton"
+                type="button"
+              >
+                <span
+                  class="group-hover:invisible"
+                >
+                  <span
+                    class="font-semibold"
+                  >
+                    Page 1 of 2
+                  </span>
+                </span>
+                <span
+                  class="invisible absolute bottom-0 left-0 right-0 top-0 flex items-center justify-center group-hover:visible"
+                  data-testid="PaginationSearchButton__search"
+                >
+                  <div
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
+                  >
+                    <svg
+                      id="magnifying-glass"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M12.1 16.4c4.1-1.7 6-6.5 4.3-10.5C14.7 1.8 9.9 0 5.9 1.6s-6 6.5-4.3 10.5h0c1.8 4.1 6.4 6 10.5 4.3h0zM14.7 14.7L19 19"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </span>
+              </button>
+            </div>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 h-8 w-8 p-2.5"
+              data-testid="Pagination__next"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-right-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M3.063 1l3.8 3.8c.1.1.1.3 0 .4L3.063 9"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 px-4 py-1.5"
+              data-testid="Pagination__last"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  Last
+                </span>
+              </div>
+            </button>
+          </nav>
         </div>
       </div>
     </div>
@@ -935,18 +4732,18 @@ exports[`WalletsGroup > should render GroupNetworkTotal with amounts 1`] = `
 exports[`WalletsGroup > should render group with different widths 1`] = `
 <DocumentFragment>
   <div
-    class="md:!mb-3 css-13o3tsw"
+    class="md:!mb-3 css-fvpuky"
     data-testid="WalletsGroup"
   >
     <div
-      class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+      class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
       data-testid="WalletsGroupHeader"
     >
       <div
         class="flex flex-grow flex-row items-center"
       >
         <div
-          class="css-ziskls"
+          class="css-1u7yknf"
         >
           <div
             aria-label="ARK"
@@ -1133,14 +4930,14 @@ exports[`WalletsGroup > should render group with different widths 1`] = `
         </div>
       </div>
       <div
-        class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+        class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
       >
         <div
           class="css-tz6w2"
           data-testid="Accordion__toggle"
         >
           <div
-            class="transition-transform css-15txs7d"
+            class="transition-transform rotate-180 css-15txs7d"
             height="10"
             width="10"
           >
@@ -1162,6 +4959,829 @@ exports[`WalletsGroup > should render group with different widths 1`] = `
               />
             </svg>
           </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-6 pb-4 md:p-0"
+      data-testid="WalletsList"
+    >
+      <div
+        data-testid="WalletTable"
+      >
+        <div
+          class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+          role="table"
+        >
+          <table
+            cellpadding="0"
+            class="w-full table-auto"
+          >
+            <thead>
+              <tr
+                role="row"
+              >
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                  colspan="1"
+                  data-testid="table__th--0"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top"
+                  >
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="py-0.5 pr-3"
+                      >
+                        <button
+                          class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                          data-testid="WalletIcon__Starred__header"
+                          type="button"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                  colspan="1"
+                  data-testid="table__th--1"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top -ml-3"
+                  >
+                    <div
+                      class=""
+                    >
+                      Name
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                  colspan="1"
+                  data-testid="table__th--2"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top -ml-3"
+                  >
+                    <div
+                      class=""
+                    >
+                      Address
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                  colspan="1"
+                  data-testid="table__th--3"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-center"
+                  >
+                    <div
+                      class=""
+                    >
+                      Info
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                  colspan="1"
+                  data-testid="table__th--4"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                  >
+                    <div
+                      class=""
+                    >
+                      Balance
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                  colspan="1"
+                  data-testid="table__th--5"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-end flex-row-reverse"
+                  >
+                    <div
+                      class=""
+                    >
+                      Currency
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                  colspan="1"
+                  data-testid="table__th--6"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top hidden"
+                  >
+                    <div
+                      class=""
+                    >
+                      Actions
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              role="rowgroup"
+            >
+              <tr
+                class="group relative css-1tl8buz"
+                data-testid="TableRow"
+              >
+                <td
+                  data-testid="TableCell_Starred"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                  >
+                    <div
+                      class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                    >
+                      <div
+                        class="flex shrink-0 items-center justify-center"
+                        data-testid="WalletIcon__Starred"
+                      >
+                        <div
+                          class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                          height="18"
+                          width="18"
+                        >
+                          <svg
+                            id="star-filled"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-24 flex-1 overflow-hidden"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-sm leading-[17px]"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  data-testid="TableCell_Wallet"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                      >
+                        <span
+                          class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
+                        </span>
+                        <span
+                          class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                          data-testid="Address__address"
+                        >
+                          D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                        </span>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                            height="16"
+                            width="16"
+                          >
+                            <svg
+                              id="copy"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                  >
+                    <div
+                      class="inline-flex items-center space-x-1"
+                    >
+                      <span
+                        aria-busy="true"
+                        aria-live="polite"
+                        class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton"
+                          style="width: 54px; height: 20px;"
+                        >
+                          ‌
+                        </span>
+                        <br />
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                  >
+                    <span
+                      class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                      data-testid="Amount"
+                    >
+                      33.75089801 DARK
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                  data-testid="CurrencyCell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                  >
+                    <span
+                      class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                    >
+                      N/A
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                  >
+                    <div>
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                        data-testid="WalletListItem__send-button"
+                        type="button"
+                      >
+                        <div
+                          class="flex items-center space-x-2"
+                        >
+                          <div
+                            class="pr-3"
+                          >
+                            Send
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                    />
+                    <div
+                      data-testid="WalletListItem__more-button"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="dialog"
+                        data-testid="dropdown__toggle"
+                      >
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                fill="none"
+                                viewBox="0 0 20 20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="10.002"
+                                  cy="2.99609"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 2.99609)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="9.99805"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 9.99805)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="17"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 17)"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="group relative css-1tl8buz"
+                data-testid="TableRow"
+              >
+                <td
+                  data-testid="TableCell_Starred"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                  >
+                    <div
+                      class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                    >
+                      <div
+                        class="flex shrink-0 items-center justify-center"
+                        data-testid="WalletIcon__Starred"
+                      >
+                        <div
+                          class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                          height="18"
+                          width="18"
+                        >
+                          <svg
+                            id="star-filled"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-24 flex-1 overflow-hidden"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-sm leading-[17px]"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 2
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  data-testid="TableCell_Wallet"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                      >
+                        <span
+                          class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 2
+                          </span>
+                        </span>
+                        <span
+                          class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                          data-testid="Address__address"
+                        >
+                          D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb
+                        </span>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                            height="16"
+                            width="16"
+                          >
+                            <svg
+                              id="copy"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                  >
+                    <div
+                      class="inline-flex items-center space-x-1"
+                    >
+                      <span
+                        aria-busy="true"
+                        aria-live="polite"
+                        class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton"
+                          style="width: 54px; height: 20px;"
+                        >
+                          ‌
+                        </span>
+                        <br />
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                  >
+                    <span
+                      class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                      data-testid="Amount"
+                    >
+                      57.68 DARK
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                  data-testid="CurrencyCell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                  >
+                    <span
+                      class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                    >
+                      N/A
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                  >
+                    <div>
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                        data-testid="WalletListItem__send-button"
+                        type="button"
+                      >
+                        <div
+                          class="flex items-center space-x-2"
+                        >
+                          <div
+                            class="pr-3"
+                          >
+                            Send
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                    />
+                    <div
+                      data-testid="WalletListItem__more-button"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="dialog"
+                        data-testid="dropdown__toggle"
+                      >
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                fill="none"
+                                viewBox="0 0 20 20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="10.002"
+                                  cy="2.99609"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 2.99609)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="9.99805"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 9.99805)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="17"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 17)"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -1172,18 +5792,18 @@ exports[`WalletsGroup > should render group with different widths 1`] = `
 exports[`WalletsGroup > should render group with different widths 2`] = `
 <DocumentFragment>
   <div
-    class="md:!mb-3 css-13o3tsw"
+    class="md:!mb-3 css-fvpuky"
     data-testid="WalletsGroup"
   >
     <div
-      class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+      class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
       data-testid="WalletsGroupHeader"
     >
       <div
         class="flex flex-grow flex-row items-center"
       >
         <div
-          class="css-ziskls"
+          class="css-1u7yknf"
         >
           <div
             aria-label="ARK"
@@ -1370,14 +5990,14 @@ exports[`WalletsGroup > should render group with different widths 2`] = `
         </div>
       </div>
       <div
-        class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+        class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
       >
         <div
           class="css-tz6w2"
           data-testid="Accordion__toggle"
         >
           <div
-            class="transition-transform css-15txs7d"
+            class="transition-transform rotate-180 css-15txs7d"
             height="10"
             width="10"
           >
@@ -1402,6 +6022,829 @@ exports[`WalletsGroup > should render group with different widths 2`] = `
         </div>
       </div>
     </div>
+    <div
+      class="px-6 pb-4 md:p-0"
+      data-testid="WalletsList"
+    >
+      <div
+        data-testid="WalletTable"
+      >
+        <div
+          class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+          role="table"
+        >
+          <table
+            cellpadding="0"
+            class="w-full table-auto"
+          >
+            <thead>
+              <tr
+                role="row"
+              >
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                  colspan="1"
+                  data-testid="table__th--0"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top"
+                  >
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="py-0.5 pr-3"
+                      >
+                        <button
+                          class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                          data-testid="WalletIcon__Starred__header"
+                          type="button"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                  colspan="1"
+                  data-testid="table__th--1"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top -ml-3"
+                  >
+                    <div
+                      class=""
+                    >
+                      Name
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                  colspan="1"
+                  data-testid="table__th--2"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top -ml-3"
+                  >
+                    <div
+                      class=""
+                    >
+                      Address
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                  colspan="1"
+                  data-testid="table__th--3"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-center"
+                  >
+                    <div
+                      class=""
+                    >
+                      Info
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                  colspan="1"
+                  data-testid="table__th--4"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                  >
+                    <div
+                      class=""
+                    >
+                      Balance
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                  colspan="1"
+                  data-testid="table__th--5"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-end flex-row-reverse"
+                  >
+                    <div
+                      class=""
+                    >
+                      Currency
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                  colspan="1"
+                  data-testid="table__th--6"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top hidden"
+                  >
+                    <div
+                      class=""
+                    >
+                      Actions
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              role="rowgroup"
+            >
+              <tr
+                class="group relative css-1tl8buz"
+                data-testid="TableRow"
+              >
+                <td
+                  data-testid="TableCell_Starred"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                  >
+                    <div
+                      class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                    >
+                      <div
+                        class="flex shrink-0 items-center justify-center"
+                        data-testid="WalletIcon__Starred"
+                      >
+                        <div
+                          class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                          height="18"
+                          width="18"
+                        >
+                          <svg
+                            id="star-filled"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-24 flex-1 overflow-hidden"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-sm leading-[17px]"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  data-testid="TableCell_Wallet"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                      >
+                        <span
+                          class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
+                        </span>
+                        <span
+                          class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                          data-testid="Address__address"
+                        >
+                          D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                        </span>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                            height="16"
+                            width="16"
+                          >
+                            <svg
+                              id="copy"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                  >
+                    <div
+                      class="inline-flex items-center space-x-1"
+                    >
+                      <span
+                        aria-busy="true"
+                        aria-live="polite"
+                        class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton"
+                          style="width: 54px; height: 20px;"
+                        >
+                          ‌
+                        </span>
+                        <br />
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                  >
+                    <span
+                      class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                      data-testid="Amount"
+                    >
+                      33.75089801 DARK
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                  data-testid="CurrencyCell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                  >
+                    <span
+                      class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                    >
+                      N/A
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                  >
+                    <div>
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                        data-testid="WalletListItem__send-button"
+                        type="button"
+                      >
+                        <div
+                          class="flex items-center space-x-2"
+                        >
+                          <div
+                            class="pr-3"
+                          >
+                            Send
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                    />
+                    <div
+                      data-testid="WalletListItem__more-button"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="dialog"
+                        data-testid="dropdown__toggle"
+                      >
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                fill="none"
+                                viewBox="0 0 20 20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="10.002"
+                                  cy="2.99609"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 2.99609)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="9.99805"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 9.99805)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="17"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 17)"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="group relative css-1tl8buz"
+                data-testid="TableRow"
+              >
+                <td
+                  data-testid="TableCell_Starred"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                  >
+                    <div
+                      class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                    >
+                      <div
+                        class="flex shrink-0 items-center justify-center"
+                        data-testid="WalletIcon__Starred"
+                      >
+                        <div
+                          class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                          height="18"
+                          width="18"
+                        >
+                          <svg
+                            id="star-filled"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-24 flex-1 overflow-hidden"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-sm leading-[17px]"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 2
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  data-testid="TableCell_Wallet"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                      >
+                        <span
+                          class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 2
+                          </span>
+                        </span>
+                        <span
+                          class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                          data-testid="Address__address"
+                        >
+                          D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb
+                        </span>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                            height="16"
+                            width="16"
+                          >
+                            <svg
+                              id="copy"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                  >
+                    <div
+                      class="inline-flex items-center space-x-1"
+                    >
+                      <span
+                        aria-busy="true"
+                        aria-live="polite"
+                        class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton"
+                          style="width: 54px; height: 20px;"
+                        >
+                          ‌
+                        </span>
+                        <br />
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                  >
+                    <span
+                      class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                      data-testid="Amount"
+                    >
+                      57.68 DARK
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                  data-testid="CurrencyCell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                  >
+                    <span
+                      class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                    >
+                      N/A
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                  >
+                    <div>
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                        data-testid="WalletListItem__send-button"
+                        type="button"
+                      >
+                        <div
+                          class="flex items-center space-x-2"
+                        >
+                          <div
+                            class="pr-3"
+                          >
+                            Send
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                    />
+                    <div
+                      data-testid="WalletListItem__more-button"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="dialog"
+                        data-testid="dropdown__toggle"
+                      >
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                fill="none"
+                                viewBox="0 0 20 20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="10.002"
+                                  cy="2.99609"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 2.99609)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="9.99805"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 9.99805)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="17"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 17)"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 </DocumentFragment>
 `;
@@ -1409,18 +6852,18 @@ exports[`WalletsGroup > should render group with different widths 2`] = `
 exports[`WalletsGroup > should render group with different widths 3`] = `
 <DocumentFragment>
   <div
-    class="md:!mb-3 css-13o3tsw"
+    class="md:!mb-3 css-fvpuky"
     data-testid="WalletsGroup"
   >
     <div
-      class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+      class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
       data-testid="WalletsGroupHeader"
     >
       <div
         class="flex flex-grow flex-row items-center"
       >
         <div
-          class="css-ziskls"
+          class="css-1u7yknf"
         >
           <div
             aria-label="ARK"
@@ -1609,14 +7052,14 @@ exports[`WalletsGroup > should render group with different widths 3`] = `
         </div>
       </div>
       <div
-        class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+        class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
       >
         <div
           class="css-tz6w2"
           data-testid="Accordion__toggle"
         >
           <div
-            class="transition-transform css-15txs7d"
+            class="transition-transform rotate-180 css-15txs7d"
             height="10"
             width="10"
           >
@@ -1638,6 +7081,829 @@ exports[`WalletsGroup > should render group with different widths 3`] = `
               />
             </svg>
           </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-6 pb-4 md:p-0"
+      data-testid="WalletsList"
+    >
+      <div
+        data-testid="WalletTable"
+      >
+        <div
+          class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+          role="table"
+        >
+          <table
+            cellpadding="0"
+            class="w-full table-auto"
+          >
+            <thead>
+              <tr
+                role="row"
+              >
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                  colspan="1"
+                  data-testid="table__th--0"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top"
+                  >
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="py-0.5 pr-3"
+                      >
+                        <button
+                          class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                          data-testid="WalletIcon__Starred__header"
+                          type="button"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                  colspan="1"
+                  data-testid="table__th--1"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top -ml-3"
+                  >
+                    <div
+                      class=""
+                    >
+                      Name
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                  colspan="1"
+                  data-testid="table__th--2"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top -ml-3"
+                  >
+                    <div
+                      class=""
+                    >
+                      Address
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                  colspan="1"
+                  data-testid="table__th--3"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-center"
+                  >
+                    <div
+                      class=""
+                    >
+                      Info
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                  colspan="1"
+                  data-testid="table__th--4"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                  >
+                    <div
+                      class=""
+                    >
+                      Balance
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                  colspan="1"
+                  data-testid="table__th--5"
+                  role="columnheader"
+                  style="cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  <div
+                    class="flex flex-inline align-top justify-end flex-row-reverse"
+                  >
+                    <div
+                      class=""
+                    >
+                      Currency
+                    </div>
+                    <div
+                      class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                    >
+                      <div
+                        class="transition-transform rotate-180 css-15txs7d"
+                        height="10"
+                        role="img"
+                        width="10"
+                      >
+                        <svg
+                          id="chevron-down-small"
+                          viewBox="0 0 10 10"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <path
+                            d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                  colspan="1"
+                  data-testid="table__th--6"
+                  role="columnheader"
+                >
+                  <div
+                    class="flex flex-inline align-top hidden"
+                  >
+                    <div
+                      class=""
+                    >
+                      Actions
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              role="rowgroup"
+            >
+              <tr
+                class="group relative css-1tl8buz"
+                data-testid="TableRow"
+              >
+                <td
+                  data-testid="TableCell_Starred"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                  >
+                    <div
+                      class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                    >
+                      <div
+                        class="flex shrink-0 items-center justify-center"
+                        data-testid="WalletIcon__Starred"
+                      >
+                        <div
+                          class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                          height="18"
+                          width="18"
+                        >
+                          <svg
+                            id="star-filled"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-24 flex-1 overflow-hidden"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-sm leading-[17px]"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  data-testid="TableCell_Wallet"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                      >
+                        <span
+                          class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
+                        </span>
+                        <span
+                          class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                          data-testid="Address__address"
+                        >
+                          D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                        </span>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                            height="16"
+                            width="16"
+                          >
+                            <svg
+                              id="copy"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                  >
+                    <div
+                      class="inline-flex items-center space-x-1"
+                    >
+                      <span
+                        aria-busy="true"
+                        aria-live="polite"
+                        class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton"
+                          style="width: 54px; height: 20px;"
+                        >
+                          ‌
+                        </span>
+                        <br />
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                  >
+                    <span
+                      class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                      data-testid="Amount"
+                    >
+                      33.75089801 DARK
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                  data-testid="CurrencyCell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                  >
+                    <span
+                      class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                    >
+                      N/A
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                  >
+                    <div>
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                        data-testid="WalletListItem__send-button"
+                        type="button"
+                      >
+                        <div
+                          class="flex items-center space-x-2"
+                        >
+                          <div
+                            class="pr-3"
+                          >
+                            Send
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                    />
+                    <div
+                      data-testid="WalletListItem__more-button"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="dialog"
+                        data-testid="dropdown__toggle"
+                      >
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                fill="none"
+                                viewBox="0 0 20 20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="10.002"
+                                  cy="2.99609"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 2.99609)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="9.99805"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 9.99805)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="17"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 17)"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="group relative css-1tl8buz"
+                data-testid="TableRow"
+              >
+                <td
+                  data-testid="TableCell_Starred"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                  >
+                    <div
+                      class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                    >
+                      <div
+                        class="flex shrink-0 items-center justify-center"
+                        data-testid="WalletIcon__Starred"
+                      >
+                        <div
+                          class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                          height="18"
+                          width="18"
+                        >
+                          <svg
+                            id="star-filled"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-24 flex-1 overflow-hidden"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                      >
+                        <span
+                          class="font-semibold text-base text-sm leading-[17px]"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 2
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  data-testid="TableCell_Wallet"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                  >
+                    <div
+                      class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                      >
+                        <span
+                          class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                          data-testid="Address__alias"
+                        >
+                          <span
+                            class="no-ligatures css-9nx3be"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 2
+                          </span>
+                        </span>
+                        <span
+                          class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                          data-testid="Address__address"
+                        >
+                          D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb
+                        </span>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                            height="16"
+                            width="16"
+                          >
+                            <svg
+                              id="copy"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              >
+                                <path
+                                  d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                />
+                                <path
+                                  d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                />
+                              </g>
+                            </svg>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                  >
+                    <div
+                      class="inline-flex items-center space-x-1"
+                    >
+                      <span
+                        aria-busy="true"
+                        aria-live="polite"
+                        class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                      >
+                        <span
+                          class="react-loading-skeleton"
+                          style="width: 54px; height: 20px;"
+                        >
+                          ‌
+                        </span>
+                        <br />
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                  >
+                    <span
+                      class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                      data-testid="Amount"
+                    >
+                      57.68 DARK
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="hidden lg:table-cell"
+                  data-testid="CurrencyCell"
+                >
+                  <div
+                    class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                  >
+                    <span
+                      class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                    >
+                      N/A
+                    </span>
+                  </div>
+                </td>
+                <td>
+                  <div
+                    class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                  >
+                    <div>
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                        data-testid="WalletListItem__send-button"
+                        type="button"
+                      >
+                        <div
+                          class="flex items-center space-x-2"
+                        >
+                          <div
+                            class="pr-3"
+                          >
+                            Send
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                    <div
+                      class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                    />
+                    <div
+                      data-testid="WalletListItem__more-button"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="dialog"
+                        data-testid="dropdown__toggle"
+                      >
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                fill="none"
+                                viewBox="0 0 20 20"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="10.002"
+                                  cy="2.99609"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 2.99609)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="9.99805"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 9.99805)"
+                                />
+                                <circle
+                                  cx="10.002"
+                                  cy="17"
+                                  fill="currentColor"
+                                  r="2"
+                                  transform="rotate(90 10.002 17)"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -1651,18 +7917,18 @@ exports[`WalletsGroup > should render with dark mode = false 1`] = `
     data-testid="NetworkWalletsGroupList"
   >
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK"
@@ -1849,14 +8115,14 @@ exports[`WalletsGroup > should render with dark mode = false 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -1881,20 +8147,555 @@ exports[`WalletsGroup > should render with dark mode = false 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        />
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK Devnet"
@@ -2121,14 +8922,14 @@ exports[`WalletsGroup > should render with dark mode = false 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -2151,6 +8952,3244 @@ exports[`WalletsGroup > should render with dark mode = false 1`] = `
               </svg>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          class="flex w-full flex-col gap-4 border-theme-secondary-300 pt-4 dark:border-theme-secondary-800 sm:flex-row sm:justify-between md:border-t md:px-6 md:pb-4"
+        >
+          <div
+            class="flex items-center justify-center gap-2 text-sm font-semibold leading-5 text-theme-secondary-700 dark:text-theme-secondary-200 sm:justify-start"
+          >
+            <span>
+              Show
+            </span>
+            <div
+              class="relative"
+              data-testid="SelectDropdown"
+            >
+              <div
+                class="sr-only css-14zfvme"
+              >
+                <div
+                  class="relative flex h-full flex-1"
+                >
+                  <input
+                    autocomplete="off"
+                    class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                    data-testid="select-list__input"
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value="10"
+                  />
+                </div>
+              </div>
+              <div
+                class="w-full"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-owns="downshift-12-menu"
+                  role="combobox"
+                >
+                  <div>
+                    <label
+                      for="downshift-12-input"
+                      id="downshift-12-label"
+                    />
+                    <div
+                      class="invisible fixed w-auto whitespace-nowrap"
+                    >
+                      10…
+                    </div>
+                    <div
+                      class="!h-8 !w-[78px] !px-3 css-14zfvme"
+                    >
+                      <div
+                        class="relative flex h-full flex-1"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="downshift-12-menu"
+                          aria-labelledby="downshift-12-label"
+                          autocomplete="off"
+                          class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                          data-testid="SelectDropdown__input"
+                          id="downshift-12-input"
+                          placeholder="Select option"
+                          readonly=""
+                          type="text"
+                          value="10"
+                        />
+                        <span
+                          class="pointer-events-none absolute inset-y-0 flex w-full items-center text-sm font-normal opacity-50 sm:text-base"
+                          data-testid="Input__suggestion"
+                        >
+                          <span
+                            class="truncate"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                        data-testid="Input__addon-end"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="flex items-center"
+                          >
+                            <div
+                              class="flex items-center justify-center"
+                              data-testid="SelectDropdown__caret"
+                            >
+                              <div
+                                class="absolute inset-0 block cursor-pointer md:hidden"
+                              />
+                              <div
+                                class="transition-transform text-theme-secondary-500 css-15txs7d"
+                                height="10"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="downshift-12-label"
+                    id="downshift-12-menu"
+                    role="listbox"
+                  />
+                </div>
+              </div>
+            </div>
+            <span>
+              Records
+            </span>
+          </div>
+          <nav
+            class="relative w-full sm:w-auto css-4ybc2s"
+            data-testid="Pagination"
+          >
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 px-4 py-1.5"
+              data-testid="Pagination__first"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  First
+                </span>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 h-8 w-8 p-2.5"
+              data-testid="Pagination__previous"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-left-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M6.938 9l-3.8-3.8c-.1-.1-.1-.3 0-.4l3.8-3.8"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <div
+              class="flex rounded bg-theme-primary-100 dark:bg-theme-secondary-800"
+            >
+              <button
+                class="group css-eti7fq"
+                data-testid="PaginationSearchButton"
+                type="button"
+              >
+                <span
+                  class="group-hover:invisible"
+                >
+                  <span
+                    class="font-semibold"
+                  >
+                    Page 1 of 2
+                  </span>
+                </span>
+                <span
+                  class="invisible absolute bottom-0 left-0 right-0 top-0 flex items-center justify-center group-hover:visible"
+                  data-testid="PaginationSearchButton__search"
+                >
+                  <div
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
+                  >
+                    <svg
+                      id="magnifying-glass"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M12.1 16.4c4.1-1.7 6-6.5 4.3-10.5C14.7 1.8 9.9 0 5.9 1.6s-6 6.5-4.3 10.5h0c1.8 4.1 6.4 6 10.5 4.3h0zM14.7 14.7L19 19"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </span>
+              </button>
+            </div>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 h-8 w-8 p-2.5"
+              data-testid="Pagination__next"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-right-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M3.063 1l3.8 3.8c.1.1.1.3 0 .4L3.063 9"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 px-4 py-1.5"
+              data-testid="Pagination__last"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  Last
+                </span>
+              </div>
+            </button>
+          </nav>
         </div>
       </div>
     </div>
@@ -2164,18 +12203,18 @@ exports[`WalletsGroup > should render with dark mode = true 1`] = `
     data-testid="NetworkWalletsGroupList"
   >
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 bg-transparent px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 bg-transparent md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-km2hr7"
+            class="css-rm1unj"
           >
             <div
               aria-label="ARK"
@@ -2362,14 +12401,14 @@ exports[`WalletsGroup > should render with dark mode = true 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -2394,20 +12433,555 @@ exports[`WalletsGroup > should render with dark mode = true 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding after:mx-[0.15rem] after:block after:h-[5px] after:rounded-b-lg after:bg-theme-primary-100 after:content-[''] after:dark:bg-theme-secondary-800 css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        />
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            AdVSe37niA3uFUPgCgMUH2tMsHF4LpLoiX
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        50,114.21127898 ARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap text-xs font-semibold text-theme-navy-200 dark:text-white md:text-base md:text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        0 BTC
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 bg-transparent px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 bg-transparent md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-km2hr7"
+            class="css-rm1unj"
           >
             <div
               aria-label="ARK Devnet"
@@ -2634,14 +13208,14 @@ exports[`WalletsGroup > should render with dark mode = true 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -2664,6 +13238,3244 @@ exports[`WalletsGroup > should render with dark mode = true 1`] = `
               </svg>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          class="flex w-full flex-col gap-4 border-theme-secondary-300 pt-4 dark:border-theme-secondary-800 sm:flex-row sm:justify-between md:border-t md:px-6 md:pb-4"
+        >
+          <div
+            class="flex items-center justify-center gap-2 text-sm font-semibold leading-5 text-theme-secondary-700 dark:text-theme-secondary-200 sm:justify-start"
+          >
+            <span>
+              Show
+            </span>
+            <div
+              class="relative"
+              data-testid="SelectDropdown"
+            >
+              <div
+                class="sr-only css-14zfvme"
+              >
+                <div
+                  class="relative flex h-full flex-1"
+                >
+                  <input
+                    autocomplete="off"
+                    class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                    data-testid="select-list__input"
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value="10"
+                  />
+                </div>
+              </div>
+              <div
+                class="w-full"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-owns="downshift-9-menu"
+                  role="combobox"
+                >
+                  <div>
+                    <label
+                      for="downshift-9-input"
+                      id="downshift-9-label"
+                    />
+                    <div
+                      class="invisible fixed w-auto whitespace-nowrap"
+                    >
+                      10…
+                    </div>
+                    <div
+                      class="!h-8 !w-[78px] !px-3 css-14zfvme"
+                    >
+                      <div
+                        class="relative flex h-full flex-1"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="downshift-9-menu"
+                          aria-labelledby="downshift-9-label"
+                          autocomplete="off"
+                          class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                          data-testid="SelectDropdown__input"
+                          id="downshift-9-input"
+                          placeholder="Select option"
+                          readonly=""
+                          type="text"
+                          value="10"
+                        />
+                        <span
+                          class="pointer-events-none absolute inset-y-0 flex w-full items-center text-sm font-normal opacity-50 sm:text-base"
+                          data-testid="Input__suggestion"
+                        >
+                          <span
+                            class="truncate"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                        data-testid="Input__addon-end"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="flex items-center"
+                          >
+                            <div
+                              class="flex items-center justify-center"
+                              data-testid="SelectDropdown__caret"
+                            >
+                              <div
+                                class="absolute inset-0 block cursor-pointer md:hidden"
+                              />
+                              <div
+                                class="transition-transform text-theme-secondary-500 css-15txs7d"
+                                height="10"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="downshift-9-label"
+                    id="downshift-9-menu"
+                    role="listbox"
+                  />
+                </div>
+              </div>
+            </div>
+            <span>
+              Records
+            </span>
+          </div>
+          <nav
+            class="relative w-full sm:w-auto css-4ybc2s"
+            data-testid="Pagination"
+          >
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 px-4 py-1.5"
+              data-testid="Pagination__first"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  First
+                </span>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 h-8 w-8 p-2.5"
+              data-testid="Pagination__previous"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-left-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M6.938 9l-3.8-3.8c-.1-.1-.1-.3 0-.4l3.8-3.8"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <div
+              class="flex rounded bg-theme-primary-100 dark:bg-theme-secondary-800"
+            >
+              <button
+                class="group css-eti7fq"
+                data-testid="PaginationSearchButton"
+                type="button"
+              >
+                <span
+                  class="group-hover:invisible"
+                >
+                  <span
+                    class="font-semibold"
+                  >
+                    Page 1 of 2
+                  </span>
+                </span>
+                <span
+                  class="invisible absolute bottom-0 left-0 right-0 top-0 flex items-center justify-center group-hover:visible"
+                  data-testid="PaginationSearchButton__search"
+                >
+                  <div
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
+                  >
+                    <svg
+                      id="magnifying-glass"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M12.1 16.4c4.1-1.7 6-6.5 4.3-10.5C14.7 1.8 9.9 0 5.9 1.6s-6 6.5-4.3 10.5h0c1.8 4.1 6.4 6 10.5 4.3h0zM14.7 14.7L19 19"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </span>
+              </button>
+            </div>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 h-8 w-8 p-2.5"
+              data-testid="Pagination__next"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-right-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M3.063 1l3.8 3.8c.1.1.1.3 0 .4L3.063 9"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 px-4 py-1.5"
+              data-testid="Pagination__last"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  Last
+                </span>
+              </div>
+            </button>
+          </nav>
         </div>
       </div>
     </div>
@@ -3208,19 +17020,7 @@ exports[`WalletsGroup > should show skeleton when syncing exchange rates 1`] = `
                       >
                         <div
                           class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
-                        >
-                          <span
-                            class="font-semibold text-base text-sm leading-[17px]"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures css-9nx3be"
-                              data-testid="TruncateEnd"
-                            >
-                              New Name
-                            </span>
-                          </span>
-                        </div>
+                        />
                       </div>
                     </div>
                   </td>
@@ -3236,17 +17036,6 @@ exports[`WalletsGroup > should show skeleton when syncing exchange rates 1`] = `
                         <div
                           class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
                         >
-                          <span
-                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures css-9nx3be"
-                              data-testid="TruncateEnd"
-                            >
-                              New Name
-                            </span>
-                          </span>
                           <span
                             class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
                             data-testid="Address__address"
@@ -3300,42 +17089,19 @@ exports[`WalletsGroup > should show skeleton when syncing exchange rates 1`] = `
                       <div
                         class="inline-flex items-center space-x-1"
                       >
-                        <div
-                          class="inline-block p-1 text-theme-secondary-700 dark:text-theme-secondary-600"
-                          data-testid="WalletIcon__SecondSignature"
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
                         >
-                          <div
-                            class="css-1i4b0eq"
-                            height="20"
-                            width="20"
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
                           >
-                            <svg
-                              id="second-signature"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
-                            >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-linecap="round"
-                                stroke-width="2"
-                                transform="translate(482.484 177)"
-                              >
-                                <path
-                                  d="M-473.4-166.7l4.1 3.9-2.2 2.2 2.2 2.1 2.2-2.2 1 1 2.2-2.2-5.4-5.3"
-                                />
-                                <circle
-                                  cx="-476.5"
-                                  cy="-170.9"
-                                  r="5"
-                                />
-                              </g>
-                            </svg>
-                          </div>
-                        </div>
+                            ‌
+                          </span>
+                          <br />
+                        </span>
                       </div>
                     </div>
                   </td>
@@ -3459,18 +17225,18 @@ exports[`WalletsGroup > should show skeleton when syncing exchange rates 1`] = `
       </div>
     </div>
     <div
-      class="md:!mb-3 css-13o3tsw"
+      class="md:!mb-3 css-fvpuky"
       data-testid="WalletsGroup"
     >
       <div
-        class="select-none cursor-pointer group md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 px-6 py-4"
+        class="select-none cursor-pointer md:h-20 md:p-4 flex flex-row items-center border-theme-secondary-300 dark:border-theme-secondary-800 md:border-b px-6 py-4"
         data-testid="WalletsGroupHeader"
       >
         <div
           class="flex flex-grow flex-row items-center"
         >
           <div
-            class="css-ziskls"
+            class="css-1u7yknf"
           >
             <div
               aria-label="ARK Devnet"
@@ -3659,14 +17425,14 @@ exports[`WalletsGroup > should show skeleton when syncing exchange rates 1`] = `
           </div>
         </div>
         <div
-          class="ml-4 flex flex-shrink-0 items-center self-stretch transition-all duration-100 css-o6tyc"
+          class="ml-4 flex flex-shrink-0 items-center self-stretch css-o6tyc"
         >
           <div
             class="css-tz6w2"
             data-testid="Accordion__toggle"
           >
             <div
-              class="transition-transform css-15txs7d"
+              class="transition-transform rotate-180 css-15txs7d"
               height="10"
               width="10"
             >
@@ -3689,6 +17455,3244 @@ exports[`WalletsGroup > should show skeleton when syncing exchange rates 1`] = `
               </svg>
             </div>
           </div>
+        </div>
+      </div>
+      <div
+        class="px-6 pb-4 md:p-0"
+        data-testid="WalletsList"
+      >
+        <div
+          data-testid="WalletTable"
+        >
+          <div
+            class="with-x-padding css-1m6rt2i"
+            role="table"
+          >
+            <table
+              cellpadding="0"
+              class="w-full table-auto"
+            >
+              <thead>
+                <tr
+                  role="row"
+                >
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:pl-4 md:first:pl-6 w-1 min-w-1"
+                    colspan="1"
+                    data-testid="table__th--0"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top"
+                    >
+                      <div
+                        class=""
+                      >
+                        <div
+                          class="py-0.5 pr-3"
+                        >
+                          <button
+                            class="flex shrink-0 cursor-pointer items-center justify-center rounded ring-theme-primary-400 ring-offset-theme-background focus:outline-none focus:ring-2 focus:ring-offset-8"
+                            data-testid="WalletIcon__Starred__header"
+                            type="button"
+                          >
+                            <div
+                              class="transition-all duration-300 ease-in-out fill-theme-warning-400 stroke-theme-warning-400 text-theme-warning-400 css-tuuiwl"
+                              height="18"
+                              width="18"
+                            >
+                              <svg
+                                id="star-filled"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <path
+                                  d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                                />
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border hidden lg:table-cell first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--1"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Name
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl"
+                    colspan="1"
+                    data-testid="table__th--2"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top -ml-3"
+                    >
+                      <div
+                        class=""
+                      >
+                        Address
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity ml-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-36 min-w-36"
+                    colspan="1"
+                    data-testid="table__th--3"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-center"
+                    >
+                      <div
+                        class=""
+                      >
+                        Info
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border first:rounded-tl-xl last:rounded-tr-xl w-40 min-w-40"
+                    colspan="1"
+                    data-testid="table__th--4"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top flex-row-reverse justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Balance
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black hidden lg:table-cell no-border first:rounded-tl-xl last:rounded-tr-xl w-32 min-w-32"
+                    colspan="1"
+                    data-testid="table__th--5"
+                    role="columnheader"
+                    style="cursor: pointer;"
+                    title="Toggle SortBy"
+                  >
+                    <div
+                      class="flex flex-inline align-top justify-end flex-row-reverse"
+                    >
+                      <div
+                        class=""
+                      >
+                        Currency
+                      </div>
+                      <div
+                        class="flex items-center text-theme-secondary-500 dark:text-theme-secondary-700 transition-opacity opacity-0 group-hover:opacity-100 ml-auto mr-2"
+                      >
+                        <div
+                          class="transition-transform rotate-180 css-15txs7d"
+                          height="10"
+                          role="img"
+                          width="10"
+                        >
+                          <svg
+                            id="chevron-down-small"
+                            viewBox="0 0 10 10"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <path
+                              d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </th>
+                  <th
+                    class="group relative text-sm text-left select-none text-theme-secondary-700 border-theme-secondary-300 dark:text-theme-secondary-500 dark:border-theme-secondary-800 m-0 p-3 first:pl-6 last:pr-6 font-semibold bg-theme-secondary-100 dark:bg-black no-border w-1"
+                    colspan="1"
+                    data-testid="table__th--6"
+                    role="columnheader"
+                  >
+                    <div
+                      class="flex flex-inline align-top hidden"
+                    >
+                      <div
+                        class=""
+                      >
+                        Actions
+                      </div>
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                role="rowgroup"
+              >
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr
+                  class="group relative css-1tl8buz"
+                  data-testid="TableRow"
+                >
+                  <td
+                    data-testid="TableCell_Starred"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 rounded-l dark:group-hover:bg-black group-hover:bg-theme-secondary-200 space-x-3 pl-4 ml-2"
+                    >
+                      <div
+                        class="flex h-5 items-center pr-3 dark:border-theme-secondary-800"
+                      >
+                        <div
+                          class="flex shrink-0 items-center justify-center"
+                          data-testid="WalletIcon__Starred"
+                        >
+                          <div
+                            class="transition-all duration-300 ease-in-out fill-transparent stroke-theme-warning-400 hover:fill-theme-warning-200 css-tuuiwl"
+                            height="18"
+                            width="18"
+                          >
+                            <svg
+                              id="star-filled"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
+                            >
+                              <path
+                                d="M10.558 1.411l2.711 5.273 5.12.497c.603.1.804.697.402 1.094l-4.217 4.179 1.607 5.67c.1.498-.402 1.094-1.004.796l-5.221-2.686-5.12 2.587c-.302.198-1.105-.1-.904-.796l1.606-5.77-4.317-3.98c-.3-.397-.401-.994.402-1.094l5.12-.497L9.454 1.41c.301-.597.803-.497 1.104 0h0z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-24 flex-1 overflow-hidden"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                        >
+                          <span
+                            class="font-semibold text-base text-sm leading-[17px]"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    data-testid="TableCell_Wallet"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 -ml-3 space-x-3"
+                    >
+                      <div
+                        class="w-full max-w-64 flex-1 overflow-hidden md:max-w-40 lg:max-w-48 xl:max-w-full"
+                      >
+                        <div
+                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full justify-between"
+                        >
+                          <span
+                            class="font-semibold text-base lg:hidden text-sm text-theme-text group-hover:text-theme-primary-700"
+                            data-testid="Address__alias"
+                          >
+                            <span
+                              class="no-ligatures css-9nx3be"
+                              data-testid="TruncateEnd"
+                            >
+                              ARK Wallet 1
+                            </span>
+                          </span>
+                          <span
+                            class="no-ligatures min-w-0 overflow-hidden text-sm text-theme-secondary-700 dark:text-theme-secondary-500 lg:!ml-0 font-semibold text-base"
+                            data-testid="Address__address"
+                          >
+                            D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
+                          </span>
+                          <button
+                            class="ring-focus relative focus:outline-none"
+                            data-ring-focus-margin="-m-1"
+                            data-testid="clipboard-icon__wrapper"
+                            type="button"
+                          >
+                            <div
+                              class="text-theme-primary-400 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white css-v0ob3f"
+                              height="16"
+                              width="16"
+                            >
+                              <svg
+                                id="copy"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-center text-sm font-bold text-center align-middle"
+                    >
+                      <div
+                        class="inline-flex items-center space-x-1"
+                      >
+                        <span
+                          aria-busy="true"
+                          aria-live="polite"
+                          class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                        >
+                          <span
+                            class="react-loading-skeleton"
+                            style="width: 54px; height: 20px;"
+                          >
+                            ‌
+                          </span>
+                          <br />
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 font-semibold justify-end"
+                    >
+                      <span
+                        class="whitespace-nowrap dark:text-theme-white text-theme-secondary-700 dark:md:text-theme-secondary-500"
+                        data-testid="Amount"
+                      >
+                        33.75089801 DARK
+                      </span>
+                    </div>
+                  </td>
+                  <td
+                    class="hidden lg:table-cell"
+                    data-testid="CurrencyCell"
+                  >
+                    <div
+                      class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end"
+                    >
+                      <span
+                        class="text-xs font-semibold text-theme-navy-200 md:text-base md:text-theme-secondary-500 dark:md:text-theme-secondary-700"
+                      >
+                        N/A
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="flex px-3 my-1 transition-colors duration-100 min-h-11 mr-2 rounded-r dark:group-hover:bg-black group-hover:bg-theme-secondary-200 justify-end text-theme-secondary-text pr-6 items-center"
+                    >
+                      <div>
+                        <button
+                          class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none pr-0 text-sm text-theme-primary-600 hover:text-theme-primary-700 hover:underline dark:hover:text-theme-primary-500"
+                          data-testid="WalletListItem__send-button"
+                          type="button"
+                        >
+                          <div
+                            class="flex items-center space-x-2"
+                          >
+                            <div
+                              class="pr-3"
+                            >
+                              Send
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                      <div
+                        class="h-4 w-px bg-theme-secondary-300 dark:bg-theme-secondary-800"
+                      />
+                      <div
+                        data-testid="WalletListItem__more-button"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="dialog"
+                          data-testid="dropdown__toggle"
+                        >
+                          <button
+                            class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-gray-700 ml-3 h-6 w-6 rounded bg-transparent hover:bg-theme-primary-200 hover:text-theme-primary-700 dark:hover:bg-theme-secondary-800 dark:hover:text-white"
+                            type="button"
+                          >
+                            <div
+                              class="flex items-center space-x-2"
+                            >
+                              <div
+                                class="css-v0ob3f"
+                                height="16"
+                                width="16"
+                              >
+                                <svg
+                                  fill="none"
+                                  viewBox="0 0 20 20"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="10.002"
+                                    cy="2.99609"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 2.99609)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="9.99805"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 9.99805)"
+                                  />
+                                  <circle
+                                    cx="10.002"
+                                    cy="17"
+                                    fill="currentColor"
+                                    r="2"
+                                    transform="rotate(90 10.002 17)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div
+          class="flex w-full flex-col gap-4 border-theme-secondary-300 pt-4 dark:border-theme-secondary-800 sm:flex-row sm:justify-between md:border-t md:px-6 md:pb-4"
+        >
+          <div
+            class="flex items-center justify-center gap-2 text-sm font-semibold leading-5 text-theme-secondary-700 dark:text-theme-secondary-200 sm:justify-start"
+          >
+            <span>
+              Show
+            </span>
+            <div
+              class="relative"
+              data-testid="SelectDropdown"
+            >
+              <div
+                class="sr-only css-14zfvme"
+              >
+                <div
+                  class="relative flex h-full flex-1"
+                >
+                  <input
+                    autocomplete="off"
+                    class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                    data-testid="select-list__input"
+                    readonly=""
+                    tabindex="-1"
+                    type="text"
+                    value="10"
+                  />
+                </div>
+              </div>
+              <div
+                class="w-full"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  aria-owns="downshift-15-menu"
+                  role="combobox"
+                >
+                  <div>
+                    <label
+                      for="downshift-15-input"
+                      id="downshift-15-label"
+                    />
+                    <div
+                      class="invisible fixed w-auto whitespace-nowrap"
+                    >
+                      10…
+                    </div>
+                    <div
+                      class="!h-8 !w-[78px] !px-3 css-14zfvme"
+                    >
+                      <div
+                        class="relative flex h-full flex-1"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="downshift-15-menu"
+                          aria-labelledby="downshift-15-label"
+                          autocomplete="off"
+                          class="no-ligatures w-full border-none !text-sm placeholder:text-theme-secondary-400 dark:placeholder:text-theme-secondary-700 sm:!text-base css-1937ogs"
+                          data-testid="SelectDropdown__input"
+                          id="downshift-15-input"
+                          placeholder="Select option"
+                          readonly=""
+                          type="text"
+                          value="10"
+                        />
+                        <span
+                          class="pointer-events-none absolute inset-y-0 flex w-full items-center text-sm font-normal opacity-50 sm:text-base"
+                          data-testid="Input__suggestion"
+                        >
+                          <span
+                            class="truncate"
+                          >
+                            10
+                          </span>
+                        </span>
+                      </div>
+                      <div
+                        class="flex items-center space-x-3 divide-x divide-theme-secondary-300 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                        data-testid="Input__addon-end"
+                      >
+                        <div
+                          class=""
+                        >
+                          <div
+                            class="flex items-center"
+                          >
+                            <div
+                              class="flex items-center justify-center"
+                              data-testid="SelectDropdown__caret"
+                            >
+                              <div
+                                class="absolute inset-0 block cursor-pointer md:hidden"
+                              />
+                              <div
+                                class="transition-transform text-theme-secondary-500 css-15txs7d"
+                                height="10"
+                                width="10"
+                              >
+                                <svg
+                                  id="chevron-down-small"
+                                  viewBox="0 0 10 10"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
+                                >
+                                  <path
+                                    d="M9 3.1L5.2 6.9c-.1.1-.3.1-.4 0L1 3.1"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    aria-labelledby="downshift-15-label"
+                    id="downshift-15-menu"
+                    role="listbox"
+                  />
+                </div>
+              </div>
+            </div>
+            <span>
+              Records
+            </span>
+          </div>
+          <nav
+            class="relative w-full sm:w-auto css-4ybc2s"
+            data-testid="Pagination"
+          >
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 px-4 py-1.5"
+              data-testid="Pagination__first"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  First
+                </span>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:bg-theme-secondary-200 disabled:text-theme-secondary-400 dark:disabled:bg-theme-secondary-800 dark:disabled:text-theme-secondary-700 h-8 w-8 p-2.5"
+              data-testid="Pagination__previous"
+              disabled=""
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-left-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M6.938 9l-3.8-3.8c-.1-.1-.1-.3 0-.4l3.8-3.8"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <div
+              class="flex rounded bg-theme-primary-100 dark:bg-theme-secondary-800"
+            >
+              <button
+                class="group css-eti7fq"
+                data-testid="PaginationSearchButton"
+                type="button"
+              >
+                <span
+                  class="group-hover:invisible"
+                >
+                  <span
+                    class="font-semibold"
+                  >
+                    Page 1 of 2
+                  </span>
+                </span>
+                <span
+                  class="invisible absolute bottom-0 left-0 right-0 top-0 flex items-center justify-center group-hover:visible"
+                  data-testid="PaginationSearchButton__search"
+                >
+                  <div
+                    class="css-v0ob3f"
+                    height="16"
+                    width="16"
+                  >
+                    <svg
+                      id="magnifying-glass"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M12.1 16.4c4.1-1.7 6-6.5 4.3-10.5C14.7 1.8 9.9 0 5.9 1.6s-6 6.5-4.3 10.5h0c1.8 4.1 6.4 6 10.5 4.3h0zM14.7 14.7L19 19"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </span>
+              </button>
+            </div>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 h-8 w-8 p-2.5"
+              data-testid="Pagination__next"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <div
+                  class="css-15txs7d"
+                  height="10"
+                  width="10"
+                >
+                  <svg
+                    id="chevron-right-small"
+                    viewBox="0 0 10 10"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                  >
+                    <path
+                      d="M3.063 1l3.8 3.8c.1.1.1.3 0 .4L3.063 9"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </button>
+            <button
+              class="space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed dark:bg-theme-secondary-800 dark:text-theme-secondary-200 bg-theme-primary-100 text-theme-primary-600 hover:bg-theme-primary-800 green:hover:bg-theme-primary-700 hover:text-white dark:hover:bg-theme-primary-500 px-4 py-1.5"
+              data-testid="Pagination__last"
+              type="button"
+            >
+              <div
+                class="flex items-center space-x-2"
+              >
+                <span>
+                  Last
+                </span>
+              </div>
+            </button>
+          </nav>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[portfolio] default to having the list open](https://app.clickup.com/t/86dv5gpgz)

## Summary

- `use-accordion` has been refactored and it will now be opened by default.
- This change will be reflected on wallet accordions (as seen in image), contacts list (in mobile), and custom peers accordion.

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/29a52f10-127e-4457-b4c7-ccd1a45d8cac">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
