### PR TITLE
fix: flaky transaction test

### DIFF
--- a/src/domains/transaction/components/TransactionSuccessful/TransactionSuccessful.test.tsx
+++ b/src/domains/transaction/components/TransactionSuccessful/TransactionSuccessful.test.tsx
@@ -41,11 +41,11 @@ describe("TransactionSuccessful", () => {
 	it("should render", async () => {
 		const transaction = {
 			...TransactionFixture,
-			wallet: () => wallet,
 			timestamp: () => ({
-				unix: () => 1630497600,
 				format: () => "2021-09-01 12:00",
+				unix: () => 1_630_497_600,
 			}),
+			wallet: () => wallet,
 		};
 
 		vi.spyOn(transaction, "get").mockImplementation((attribute) =>

--- a/src/domains/transaction/components/TransactionSuccessful/TransactionSuccessful.test.tsx
+++ b/src/domains/transaction/components/TransactionSuccessful/TransactionSuccessful.test.tsx
@@ -42,6 +42,10 @@ describe("TransactionSuccessful", () => {
 		const transaction = {
 			...TransactionFixture,
 			wallet: () => wallet,
+			timestamp: () => ({
+				unix: () => 1630497600,
+				format: () => "2021-09-01 12:00",
+			}),
 		};
 
 		vi.spyOn(transaction, "get").mockImplementation((attribute) =>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tests] flaky test on transaction domain](https://app.clickup.com/t/86dv6d7yx)

## Summary

- The transaction fixture for the flaky unit test in `src/domains/transaction/components/TransactionSuccessful/TransactionSuccessful.test.tsx` has been refactored to prevent the test from randomly failing.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
