### PR TITLE
fix: increase z index in transaction history date dropdown

### DIFF
--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/BasicSettings.tsx
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/BasicSettings.tsx
@@ -95,6 +95,7 @@ const DateRangeOptions = ({ isDisabled }: { isDisabled: boolean }) => {
 	return (
 		<FormField name="dateRange">
 			<Dropdown
+				wrapperClass="z-50"
 				variant="options"
 				data-testid="TransactionExportForm--daterange-options"
 				options={options}

--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/CsvSettings.tsx
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/CsvSettings.tsx
@@ -24,6 +24,7 @@ const SelectDelimiter = ({ value, onSelect }: { value: CsvDelimiter; onSelect?: 
 	return (
 		<FormField name="delimiter">
 			<Dropdown
+				wrapperClass="z-50"
 				data-testid="TransactionExportForm--delimiter-options"
 				options={delimiterOptions.options}
 				onSelect={(option) => onSelect?.(option.value as CsvDelimiter)}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dv94xyy

![2024-11-25-105605_837x390_scrot](https://github.com/user-attachments/assets/1525951b-7b12-412c-b781-86c961179256)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
