### PR TITLE
fix: set default fee value 

### DIFF
--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -216,7 +216,9 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 			return;
 		}
 
-		const remaining = BigNumber.make(remainingBalance).isGreaterThan(fee || 0) ? +remainingNetBalance : remainingBalance;
+		const remaining = BigNumber.make(remainingBalance).isGreaterThan(fee || 0)
+			? +remainingNetBalance
+			: remainingBalance;
 
 		setValue("amount", remaining, {
 			shouldDirty: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction] click on "send all" button crashes the app](https://app.clickup.com/t/86dvfdv8z)

## Summary

- When clicking on the "send all" button in a transaction form, the fee will be taken as zero in case the fees haven't been loaded yet.
- This will prevent the app from crashing since the fees were taken as undefined and making the app to crash.
- The app still validates the amount once the fees have loaded correctly.

<!-- What changes are being made? -->

https://github.com/user-attachments/assets/6ae0bb36-c102-4f76-8868-759ea925bf9a



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
