### PR TITLE
refactor: remove ligatures from addresses

### DIFF
--- a/src/app/components/Address/AddressLink.tsx
+++ b/src/app/components/Address/AddressLink.tsx
@@ -14,7 +14,7 @@ export const AddressLink = ({ children, explorerLink }: { explorerLink: string; 
 );
 
 export const AddressLabel = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-	<div className={twMerge("text-theme-secondary-900 dark:text-theme-text", className)}>
+	<div className={twMerge("text-theme-secondary-900 dark:text-theme-text no-ligatures", className)}>
 		<Truncate truncFrom="middle">{children}</Truncate>
 	</div>
 );

--- a/src/app/components/Address/AddressLink.tsx
+++ b/src/app/components/Address/AddressLink.tsx
@@ -14,7 +14,7 @@ export const AddressLink = ({ children, explorerLink }: { explorerLink: string; 
 );
 
 export const AddressLabel = ({ children, className }: { children: React.ReactNode; className?: string }) => (
-	<div className={twMerge("text-theme-secondary-900 dark:text-theme-text no-ligatures", className)}>
+	<div className={twMerge("no-ligatures text-theme-secondary-900 dark:text-theme-text", className)}>
 		<Truncate truncFrom="middle">{children}</Truncate>
 	</div>
 );

--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AmountLabel > should render 1`] = `
 <DocumentFragment>
   <div
-    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
     data-testid="AmountLabel__wrapper"
   >
     <div
@@ -23,7 +23,7 @@ exports[`AmountLabel > should render 1`] = `
 exports[`AmountLabel > should render compact 1`] = `
 <DocumentFragment>
   <div
-    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
     data-testid="AmountLabel__wrapper"
   >
     <div
@@ -43,7 +43,7 @@ exports[`AmountLabel > should render compact 1`] = `
 exports[`AmountLabel > should render compact with hint 1`] = `
 <DocumentFragment>
   <div
-    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
     data-testid="AmountLabel__wrapper"
   >
     <div
@@ -101,7 +101,7 @@ exports[`AmountLabel > should render compact with hint 1`] = `
 exports[`AmountLabel > should render negative 1`] = `
 <DocumentFragment>
   <div
-    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
     data-testid="AmountLabel__wrapper"
   >
     <div
@@ -121,7 +121,7 @@ exports[`AmountLabel > should render negative 1`] = `
 exports[`AmountLabel > should render with hint 1`] = `
 <DocumentFragment>
   <div
-    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
     data-testid="AmountLabel__wrapper"
   >
     <div
@@ -179,7 +179,7 @@ exports[`AmountLabel > should render with hint 1`] = `
 exports[`AmountLabel > should render zero 1`] = `
 <DocumentFragment>
   <div
-    class="font-semibold overflow-hidden text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+    class="font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-base flex h-full w-fit items-center justify-center rounded px-1.5"
     data-testid="AmountLabel__wrapper"
   >
     <div

--- a/src/app/components/Label/Label.styles.tsx
+++ b/src/app/components/Label/Label.styles.tsx
@@ -1,7 +1,7 @@
 import { LabelProperties } from "./Label";
 import { Size } from "@/types";
 
-const baseStyle = "inline-block font-semibold overflow-hidden";
+const baseStyle = "inline-block font-semibold overflow-hidden no-ligatures";
 
 export type ColorType =
 	| "primary"

--- a/src/app/components/Label/__snapshots__/Label.test.tsx.snap
+++ b/src/app/components/Label/__snapshots__/Label.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Label > should render 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-base"
   />
 </div>
 `;
@@ -11,7 +11,7 @@ exports[`Label > should render 1`] = `
 exports[`Label > should render a large one 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-lg"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-lg"
   />
 </div>
 `;
@@ -19,7 +19,7 @@ exports[`Label > should render a large one 1`] = `
 exports[`Label > should render a small one 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-sm"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-sm"
   />
 </div>
 `;
@@ -27,7 +27,7 @@ exports[`Label > should render a small one 1`] = `
 exports[`Label > should render as solid 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 bg-theme-primary-100 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 bg-theme-primary-100 text-base"
   />
 </div>
 `;
@@ -35,7 +35,7 @@ exports[`Label > should render as solid 1`] = `
 exports[`Label > should render as solid and danger 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-danger-500 border-theme-danger-100 bg-theme-danger-100 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-danger-500 border-theme-danger-100 bg-theme-danger-100 text-base"
   />
 </div>
 `;
@@ -43,7 +43,7 @@ exports[`Label > should render as solid and danger 1`] = `
 exports[`Label > should render as solid and default 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-success-600 border-theme-success-200 bg-theme-success-200 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-success-600 border-theme-success-200 bg-theme-success-200 text-base"
   />
 </div>
 `;
@@ -51,7 +51,7 @@ exports[`Label > should render as solid and default 1`] = `
 exports[`Label > should render as solid and primary 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 bg-theme-primary-100 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 bg-theme-primary-100 text-base"
   />
 </div>
 `;
@@ -59,7 +59,7 @@ exports[`Label > should render as solid and primary 1`] = `
 exports[`Label > should render as solid and success 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-success-600 border-theme-success-200 bg-theme-success-200 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-success-600 border-theme-success-200 bg-theme-success-200 text-base"
   />
 </div>
 `;
@@ -67,7 +67,7 @@ exports[`Label > should render as solid and success 1`] = `
 exports[`Label > should render danger color 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 text-base"
   />
 </div>
 `;
@@ -75,7 +75,7 @@ exports[`Label > should render danger color 1`] = `
 exports[`Label > should render neutral color 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:text-theme-secondary-500 dark:bg-transparent dark:border-theme-secondary-800 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:text-theme-secondary-500 dark:bg-transparent dark:border-theme-secondary-800 text-base"
   />
 </div>
 `;
@@ -83,7 +83,7 @@ exports[`Label > should render neutral color 1`] = `
 exports[`Label > should render primary color 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-primary-500 border-theme-primary-100 dark:border-theme-primary-500 text-base"
   />
 </div>
 `;
@@ -91,7 +91,7 @@ exports[`Label > should render primary color 1`] = `
 exports[`Label > should render success color 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-success-600 border-theme-success-200 dark:border-theme-success-600 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-success-600 border-theme-success-200 dark:border-theme-success-600 text-base"
   />
 </div>
 `;
@@ -99,7 +99,7 @@ exports[`Label > should render success color 1`] = `
 exports[`Label > should render warning color 1`] = `
 <div>
   <div
-    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-warning-700 border-theme-danger-100 dark:border-theme-warning-700 text-base"
+    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-warning-700 border-theme-danger-100 dark:border-theme-warning-700 text-base"
   />
 </div>
 `;

--- a/src/app/components/Notifications/__snapshots__/NotificationTransactionItem.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationTransactionItem.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Notifications > should render in xs 1`] = `
                 Amount
               </div>
               <div
-                class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
@@ -135,7 +135,7 @@ exports[`Notifications > should render in xs 2`] = `
                 Amount
               </div>
               <div
-                class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
@@ -229,7 +229,7 @@ exports[`Notifications > should render in xs 3`] = `
                 class="h-5"
               >
                 <div
-                  class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                  class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
@@ -327,7 +327,7 @@ exports[`Notifications > should render in xs 4`] = `
                 class="h-5"
               >
                 <div
-                  class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                  class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
@@ -425,7 +425,7 @@ exports[`Notifications > should render in xs 5`] = `
                 class="h-5"
               >
                 <div
-                  class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                  class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                   data-testid="AmountLabel__wrapper"
                 >
                   <div
@@ -523,7 +523,7 @@ exports[`Notifications > should render notification item 1`] = `
                 class="h-5"
               >
                 <div
-                  class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                  class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                   data-testid="AmountLabel__wrapper"
                 >
                   <div

--- a/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`Notifications > should emit transactionClick event 1`] = `
                           class="h-5"
                         >
                           <div
-                            class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                            class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
@@ -176,7 +176,7 @@ exports[`Notifications > should emit transactionClick event 1`] = `
                           class="h-5"
                         >
                           <div
-                            class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                            class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
@@ -258,7 +258,7 @@ exports[`Notifications > should emit transactionClick event 1`] = `
                           class="h-5"
                         >
                           <div
-                            class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                            class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
@@ -488,7 +488,7 @@ exports[`Notifications > should render with transactions and plugins 1`] = `
                           class="h-5"
                         >
                           <div
-                            class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                            class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
@@ -570,7 +570,7 @@ exports[`Notifications > should render with transactions and plugins 1`] = `
                           class="h-5"
                         >
                           <div
-                            class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                            class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div
@@ -652,7 +652,7 @@ exports[`Notifications > should render with transactions and plugins 1`] = `
                           class="h-5"
                         >
                           <div
-                            class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                            class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                             data-testid="AmountLabel__wrapper"
                           >
                             <div

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -135,7 +135,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                       class="grow font-semibold sm:px-4"
                     >
                       <div
-                        class="text-theme-secondary-900 dark:text-theme-text"
+                        class="no-ligatures text-theme-secondary-900 dark:text-theme-text"
                       >
                         127d3...b10cd
                       </div>
@@ -482,7 +482,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                                     Method
                                   </div>
                                   <div
-                                    class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:text-theme-secondary-500 dark:bg-transparent dark:border-theme-secondary-800 text-xs leading-[15px]"
+                                    class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:text-theme-secondary-500 dark:bg-transparent dark:border-theme-secondary-800 text-xs leading-[15px]"
                                   >
                                     Transfer
                                   </div>
@@ -547,7 +547,7 @@ exports[`Notifications > should open and close transaction details modal 1`] = `
                                   Amount
                                 </div>
                                 <div
-                                  class="font-semibold overflow-hidden text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-base flex w-fit items-center justify-center px-1.5 h-[21px] rounded dark:border"
+                                  class="font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-base flex w-fit items-center justify-center px-1.5 h-[21px] rounded dark:border"
                                   data-testid="AmountLabel__wrapper"
                                 >
                                   <div

--- a/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeForm/__snapshots__/ExchangeForm.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`ConfirmationStep > should render 1`] = `
                 Amount Sent
               </span>
               <div
-                class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 text-base mr-auto whitespace-nowrap"
+                class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 text-base mr-auto whitespace-nowrap"
               >
                 <span
                   class="whitespace-nowrap font-semibold leading-5"
@@ -414,7 +414,7 @@ exports[`ConfirmationStep > should render 1`] = `
                 Amount Received
               </span>
               <div
-                class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-success-600 border-theme-success-200 dark:border-theme-success-600 text-base mr-auto whitespace-nowrap"
+                class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-success-600 border-theme-success-200 dark:border-theme-success-600 text-base mr-auto whitespace-nowrap"
               >
                 <span
                   class="whitespace-nowrap font-semibold leading-5"
@@ -1353,7 +1353,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         Amount Sent
                       </span>
                       <div
-                        class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 text-base mr-auto whitespace-nowrap"
+                        class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 text-base mr-auto whitespace-nowrap"
                       >
                         <span
                           class="whitespace-nowrap font-semibold leading-5"
@@ -1610,7 +1610,7 @@ exports[`ExchangeForm > should render exchange form with id of finished order 1`
                         Amount Received
                       </span>
                       <div
-                        class="inline-block font-semibold overflow-hidden px-1 border-2 rounded text-theme-success-600 border-theme-success-200 dark:border-theme-success-600 text-base mr-auto whitespace-nowrap"
+                        class="inline-block font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-success-600 border-theme-success-200 dark:border-theme-success-600 text-base mr-auto whitespace-nowrap"
                       >
                         <span
                           class="whitespace-nowrap font-semibold leading-5"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
@@ -385,7 +385,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -400,7 +400,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -460,7 +460,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -483,7 +483,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -690,7 +690,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -705,7 +705,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -765,7 +765,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -788,7 +788,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -995,7 +995,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1010,7 +1010,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1070,7 +1070,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1093,7 +1093,7 @@ exports[`ExchangeTransactionsTable > should render 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1627,7 +1627,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1642,7 +1642,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1702,7 +1702,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1725,7 +1725,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1932,7 +1932,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1947,7 +1947,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2007,7 +2007,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2030,7 +2030,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2237,7 +2237,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2252,7 +2252,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2312,7 +2312,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2335,7 +2335,7 @@ exports[`ExchangeTransactionsTable > should render compact 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2869,7 +2869,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2884,7 +2884,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2944,7 +2944,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -2967,7 +2967,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3174,7 +3174,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3189,7 +3189,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3249,7 +3249,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3272,7 +3272,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3479,7 +3479,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3494,7 +3494,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3554,7 +3554,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -3577,7 +3577,7 @@ exports[`ExchangeTransactionsTable > should render desktop 1`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4111,7 +4111,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4126,7 +4126,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4186,7 +4186,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4209,7 +4209,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4416,7 +4416,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4431,7 +4431,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4491,7 +4491,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4514,7 +4514,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4721,7 +4721,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4736,7 +4736,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4796,7 +4796,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -4819,7 +4819,7 @@ exports[`ExchangeTransactionsTable > should render desktop 2`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5353,7 +5353,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5368,7 +5368,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5428,7 +5428,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5451,7 +5451,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5658,7 +5658,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5673,7 +5673,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5733,7 +5733,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5756,7 +5756,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5963,7 +5963,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -5978,7 +5978,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                     </div>
                   </div>
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -6038,7 +6038,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -6061,7 +6061,7 @@ exports[`ExchangeTransactionsTable > should render desktop 3`] = `
                   class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -6398,7 +6398,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                          class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -6426,7 +6426,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                          class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -6651,7 +6651,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                          class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -6679,7 +6679,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                          class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -6904,7 +6904,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                          class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -6932,7 +6932,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                          class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -7185,7 +7185,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                          class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -7213,7 +7213,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                          class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -7438,7 +7438,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                          class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -7466,7 +7466,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                          class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -7691,7 +7691,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                          class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div
@@ -7719,7 +7719,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
                         class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                       >
                         <div
-                          class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                          class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                           data-testid="AmountLabel__wrapper"
                         >
                           <div

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRow.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRow.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -85,7 +85,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -108,7 +108,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -131,7 +131,7 @@ exports[`ExchangeTransactionsRow > should render (Expired) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -318,7 +318,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -333,7 +333,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -356,7 +356,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -379,7 +379,7 @@ exports[`ExchangeTransactionsRow > should render (Failed) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -557,7 +557,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -572,7 +572,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -595,7 +595,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -618,7 +618,7 @@ exports[`ExchangeTransactionsRow > should render (Finished) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -796,7 +796,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -811,7 +811,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -871,7 +871,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -894,7 +894,7 @@ exports[`ExchangeTransactionsRow > should render (New) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded pr-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1110,7 +1110,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1125,7 +1125,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1148,7 +1148,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1171,7 +1171,7 @@ exports[`ExchangeTransactionsRow > should render (Refunded) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1354,7 +1354,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1369,7 +1369,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1392,7 +1392,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1415,7 +1415,7 @@ exports[`ExchangeTransactionsRow > should render (Verifying) 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1598,7 +1598,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
             class="px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 items-end flex flex-col gap-1.5 my-1 py-2.5 lg:py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1613,7 +1613,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
               </div>
             </div>
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1636,7 +1636,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div
@@ -1659,7 +1659,7 @@ exports[`ExchangeTransactionsRow > should render compact 1`] = `
             class="flex px-3 transition-colors duration-100 min-h-11 dark:group-hover:bg-black group-hover:bg-theme-secondary-200 gap-3 justify-end items-start xl:items-center my-1 py-2 xl:my-0"
           >
             <div
-              class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
+              class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-base flex h-full w-fit items-center justify-center rounded px-1.5"
               data-testid="AmountLabel__wrapper"
             >
               <div

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRowMobile.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRowMobile.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Expired) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -208,7 +208,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Expired) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -404,7 +404,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Failed) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -432,7 +432,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Failed) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -628,7 +628,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Finished) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -656,7 +656,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Finished) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -853,7 +853,7 @@ exports[`ExchangeTransactionsRowMobile > should render (New) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -881,7 +881,7 @@ exports[`ExchangeTransactionsRowMobile > should render (New) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded pr-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1119,7 +1119,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Refunded) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1147,7 +1147,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Refunded) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1348,7 +1348,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Verifying) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1376,7 +1376,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Verifying) 1`] = `
                   class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
                 >
                   <div
-                    class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                    class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                     data-testid="AmountLabel__wrapper"
                   >
                     <div
@@ -1569,7 +1569,7 @@ exports[`ExchangeTransactionsRowMobile > should render N/A if no orderId 1`] = `
               class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
             >
               <div
-                class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
@@ -1597,7 +1597,7 @@ exports[`ExchangeTransactionsRowMobile > should render N/A if no orderId 1`] = `
               class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
             >
               <div
-                class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
@@ -1791,7 +1791,7 @@ exports[`ExchangeTransactionsRowMobile > should render transaction provider 1`] 
               class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
             >
               <div
-                class="font-semibold overflow-hidden text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                class="font-semibold overflow-hidden no-ligatures text-theme-danger-info-text bg-theme-danger-info-background dark:border dark:bg-transparent dark:border-theme-danger-info-border text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                 data-testid="AmountLabel__wrapper"
               >
                 <div
@@ -1819,7 +1819,7 @@ exports[`ExchangeTransactionsRowMobile > should render transaction provider 1`] 
               class="text-sm font-semibold text-theme-secondary-900 dark:text-theme-secondary-200"
             >
               <div
-                class="font-semibold overflow-hidden bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
+                class="font-semibold overflow-hidden no-ligatures bg-theme-success-100 text-theme-success-700 dark:border dark:border-theme-success-700 dark:bg-transparent dark:text-theme-success-500 text-sm flex h-full w-fit items-center justify-center rounded px-1.5"
                 data-testid="AmountLabel__wrapper"
               >
                 <div

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -2496,7 +2496,7 @@ exports[`WalletVote > single vote networks > should render a vote for a delegate
             Voting for
           </span>
           <div
-            class="text-theme-secondary-900 dark:text-theme-text"
+            class="no-ligatures text-theme-secondary-900 dark:text-theme-text"
           >
             D8rr7...6YUYD
           </div>
@@ -2677,7 +2677,7 @@ exports[`WalletVote > single vote networks > should render a vote for a standby 
             Voting for
           </span>
           <div
-            class="text-theme-secondary-900 dark:text-theme-text"
+            class="no-ligatures text-theme-secondary-900 dark:text-theme-text"
           >
             D8rr7...6YUYD
           </div>
@@ -2858,7 +2858,7 @@ exports[`WalletVote > single vote networks > should render a vote for an active 
             Voting for
           </span>
           <div
-            class="text-theme-secondary-900 dark:text-theme-text"
+            class="no-ligatures text-theme-secondary-900 dark:text-theme-text"
           >
             D8rr7...6YUYD
           </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vault] apply no-ligatures to vote](https://app.clickup.com/t/86dvm8m67) & [[general] apply no-ligatures to tx methods](https://app.clickup.com/t/86dvm8pfc)

## Summary

- Font ligatures have been removed from the following components:
   - Address link
   - Labels
- This will prevent the x from being placed in the middle when having numbers on the address.

## Screenshots

1. Address link
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/d4243de4-9b67-490d-be5e-874033de4f2f" />

2. Labels
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/951a9332-ea29-4d0a-8e06-b73dd1a11850" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
