### PR TITLE
chore: ignore psdk sourcemaps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,6 @@ export default defineConfig(() => {
 			rollupOptions: {
 				// https://rollupjs.org/guide/en/#big-list-of-options
 				output: {
-					sourcemap: false,
 					manualChunks: {
 						react: [
 							"react",
@@ -58,12 +57,12 @@ export default defineConfig(() => {
 				},
 				plugins: [
 					process.env.ANALYZE_BUNDLE &&
-						visualizer({
-							open: true,
-							brotliSize: true,
-							gzipSize: true,
-							template: "treemap",
-						}),
+					visualizer({
+						open: true,
+						brotliSize: true,
+						gzipSize: true,
+						template: "treemap",
+					}),
 				],
 			},
 		},
@@ -131,13 +130,20 @@ export default defineConfig(() => {
 			}),
 			{
 				// Vite does not ignore sourcemaps for PSDK files, even when `server.sourcemap` or `rollupOptions.output.sourcemap` are set to `false`.
-				// This plugin explicitly removes sourcemaps by unsetting the `mappings` field, which potentially improves build performance as well.
-				name: "ignore-sourcemaps",
-				transform(code) {
-					return {
-						code,
-						map: { mappings: "" },
-					};
+				// This plugin explicitly removes sourcemaps for psdk files, by unsetting the `mappings` field.
+				name: "ignore-sdk-sourcemaps",
+				transform(code, path) {
+					const sdkPackage = /\/node_modules\/.*@ardenthq\/sdk/;
+
+					if (sdkPackage.test(path)) {
+						return {
+							code,
+							map: { mappings: "" }, // Remove sourcemaps
+						};
+					}
+
+					return null;
+
 				},
 			},
 		],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,12 +57,12 @@ export default defineConfig(() => {
 				},
 				plugins: [
 					process.env.ANALYZE_BUNDLE &&
-					visualizer({
-						open: true,
-						brotliSize: true,
-						gzipSize: true,
-						template: "treemap",
-					}),
+						visualizer({
+							open: true,
+							brotliSize: true,
+							gzipSize: true,
+							template: "treemap",
+						}),
 				],
 			},
 		},
@@ -143,7 +143,6 @@ export default defineConfig(() => {
 					}
 
 					return null;
-
 				},
 			},
 		],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig(() => {
 			rollupOptions: {
 				// https://rollupjs.org/guide/en/#big-list-of-options
 				output: {
+					sourcemap: false,
 					manualChunks: {
 						react: [
 							"react",
@@ -130,6 +131,17 @@ export default defineConfig(() => {
 					],
 				},
 			}),
+			{
+				// Vite does not ignore sourcemaps for PSDK files, even when `server.sourcemap` or `rollupOptions.output.sourcemap` are set to `false`.
+				// This plugin explicitly removes sourcemaps by unsetting the `mappings` field, which potentially improves build performance as well.
+				name: "ignore-sourcemaps",
+				transform(code) {
+					return {
+						code,
+						map: { mappings: "" },
+					};
+				},
+			},
 		],
 	};
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig((env) => {
 				isolate: true,
 				setupFiles: ["./vitest.setup.ts"],
 				server: {
+					sourcemap: false,
 					deps: {
 						fallbackCJS: true,
 					},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,6 @@ export default defineConfig((env) => {
 				isolate: true,
 				setupFiles: ["./vitest.setup.ts"],
 				server: {
-					sourcemap: false,
 					deps: {
 						fallbackCJS: true,
 					},


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes https://app.clickup.com/t/86dvn155b

Fixes sourcemap warnings in tests 
![2025-01-09-105911_2553x1081_scrot](https://github.com/user-attachments/assets/d81faceb-abcb-415c-a38e-16f495ff7d75)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
