### PR TITLE
chore: fix `act` warning in wallet domain

### DIFF
--- a/src/domains/wallet/pages/ImportWallet/Ledger/LedgerTabs.Keyboard.test.tsx
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/LedgerTabs.Keyboard.test.tsx
@@ -166,7 +166,7 @@ describe("LedgerTabs", () => {
 
 			expect(screen.getByTestId("NetworkStep")).toBeVisible();
 
-			userEvent.keyboard("{enter}");
+			await userEvent.keyboard("{enter}");
 
 			await waitFor(() => expect(screen.getByTestId("LedgerConnectionStep")).toBeVisible());
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fixes an `act` error that appeared in wallet domain, spotted in https://github.com/ArdentHQ/arkvault/actions/runs/12808742552/job/35712994174?pr=894#step:9:1075
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
