### PR TITLE
fix: show portfolio header only when profile has wallets

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
+++ b/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
@@ -107,14 +107,16 @@ export const Dashboard = () => {
 					className="pb-0 first:pt-0 md:px-0 md:pb-4 xl:mx-auto"
 					innerClassName="m-0 p-0 md:px-0 md:mx-auto"
 				>
-					<PortfolioHeader
-						profile={activeProfile}
-						votes={votes}
-						handleVotesButtonClick={handleVoteButton}
-						isLoadingVotes={isLoadingVotes}
-						isUpdatingTransactions={isUpdatingTransactions}
-						onUpdate={setIsUpdatingWallet}
-					/>
+					{activeProfile.wallets().count() > 0 && (
+						<PortfolioHeader
+							profile={activeProfile}
+							votes={votes}
+							handleVotesButtonClick={handleVoteButton}
+							isLoadingVotes={isLoadingVotes}
+							isUpdatingTransactions={isUpdatingTransactions}
+							onUpdate={setIsUpdatingWallet}
+						/>
+					)}
 				</Section>
 
 				<Tabs className="md:hidden" activeId={mobileActiveTab} onChange={setMobileActiveTab}>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dvvbch0 
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
