### PR TITLE
refactor: change default labels

### DIFF
--- a/src/app/contexts/Ledger/hooks/import.ts
+++ b/src/app/contexts/Ledger/hooks/import.ts
@@ -25,7 +25,6 @@ export const useLedgerImport = ({ device, env }: LedgerWalletImportProperties) =
 
 				wallet.mutator().alias(
 					getDefaultAlias({
-						network: wallet.network(),
 						profile,
 					}),
 				);

--- a/src/domains/wallet/pages/CreateWallet/CreateWallet.test.tsx
+++ b/src/domains/wallet/pages/CreateWallet/CreateWallet.test.tsx
@@ -335,7 +335,7 @@ describe("CreateWallet", () => {
 
 		const wallet = profile.wallets().first();
 
-		expect(wallet.alias()).toBe("ARK Devnet #1");
+		expect(wallet.alias()).toBe("Address #1");
 
 		await waitFor(() => expect(historySpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/dashboard`));
 

--- a/src/domains/wallet/pages/CreateWallet/CreateWallet.tsx
+++ b/src/domains/wallet/pages/CreateWallet/CreateWallet.tsx
@@ -172,7 +172,7 @@ export const CreateWallet = () => {
 
 			assertWallet(wallet);
 
-			wallet.mutator().alias(getDefaultAlias({ network, profile: activeProfile }));
+			wallet.mutator().alias(getDefaultAlias({ profile: activeProfile }));
 
 			setValue("wallet", wallet);
 

--- a/src/domains/wallet/pages/ImportWallet/ImportWallet.tsx
+++ b/src/domains/wallet/pages/ImportWallet/ImportWallet.tsx
@@ -195,7 +195,6 @@ export const ImportWallet = () => {
 
 		wallet.mutator().alias(
 			getDefaultAlias({
-				network: wallet.network(),
 				profile: activeProfile,
 			}),
 		);

--- a/src/domains/wallet/pages/ImportWallet/Ledger/LedgerImportStep.test.tsx
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/LedgerImportStep.test.tsx
@@ -36,7 +36,6 @@ describe("LedgerImportStep", () => {
 
 			wallet.mutator().alias(
 				getDefaultAlias({
-					network: wallet.network(),
 					profile,
 				}),
 			);

--- a/src/domains/wallet/pages/ImportWallet/Ledger/LedgerTabs.Keyboard.test.tsx
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/LedgerTabs.Keyboard.test.tsx
@@ -51,7 +51,6 @@ describe("LedgerTabs", () => {
 
 		ledgerWallet.mutator().alias(
 			getDefaultAlias({
-				network: wallet.network(),
 				profile,
 			}),
 		);

--- a/src/domains/wallet/pages/ImportWallet/Ledger/LedgerTabs.test.tsx
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/LedgerTabs.test.tsx
@@ -57,7 +57,6 @@ describe("LedgerTabs", () => {
 
 		ledgerWallet.mutator().alias(
 			getDefaultAlias({
-				network: wallet.network(),
 				profile,
 			}),
 		);

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`LedgerImportStep > should render with multiple import 1`] = `
             <span
               class="text-sm font-semibold text-theme-secondary-700 dark:text-theme-secondary-500"
             >
-              ARK Devnet #3
+              Address #3
             </span>
             <button
               class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none !p-0 text-theme-primary-600 dark:text-theme-secondary-500"
@@ -241,7 +241,7 @@ exports[`LedgerImportStep > should render with multiple import 1`] = `
             <span
               class="text-sm font-semibold text-theme-secondary-700 dark:text-theme-secondary-500"
             >
-              ARK Devnet #4
+              Address #4
             </span>
             <button
               class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none !p-0 text-theme-primary-600 dark:text-theme-secondary-500"
@@ -606,7 +606,7 @@ exports[`LedgerImportStep > should render with multiple import 2`] = `
                             class="no-ligatures transition-colors duration-200"
                             data-testid="TruncateEnd"
                           >
-                            ARK Devnet #3
+                            Address #3
                           </span>
                         </span>
                         <div
@@ -736,7 +736,7 @@ exports[`LedgerImportStep > should render with multiple import 2`] = `
                             class="no-ligatures transition-colors duration-200"
                             data-testid="TruncateEnd"
                           >
-                            ARK Devnet #4
+                            Address #4
                           </span>
                         </span>
                         <div
@@ -1065,7 +1065,7 @@ exports[`LedgerImportStep > should render with single import (lg) 1`] = `
                   class="flex w-full flex-row items-center justify-between"
                 >
                   <span>
-                    ARK Devnet #4
+                    Address #4
                   </span>
                   <button
                     class="px-5 py-3 space-x-3 text-base relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none !p-0 text-theme-primary-600 dark:text-theme-secondary-500"
@@ -1325,7 +1325,7 @@ exports[`LedgerImportStep > should render with single import (xs) 1`] = `
               <div
                 class="flex flex-row items-center gap-2"
               >
-                ARK Devnet #4
+                Address #4
                 <hr
                   class="h-5 w-px border-transparent bg-theme-secondary-300 dark:bg-theme-secondary-800"
                 />

--- a/src/domains/wallet/utils/get-default-alias.test.ts
+++ b/src/domains/wallet/utils/get-default-alias.test.ts
@@ -30,7 +30,7 @@ describe("getDefaultAlias", () => {
 			profile,
 		});
 
-		expect(result).toBe("ARK Devnet #1");
+		expect(result).toBe("Address #1");
 	});
 
 	it("should not return alias that already exist", async () => {
@@ -42,13 +42,13 @@ describe("getDefaultAlias", () => {
 
 		profile.wallets().push(wallet);
 
-		wallet.mutator().alias("ARK Devnet #1");
+		wallet.mutator().alias("Address #1");
 
 		const result = getDefaultAlias({
 			network: wallet.network(),
 			profile,
 		});
 
-		expect(result).toBe("ARK Devnet #2");
+		expect(result).toBe("Address #2");
 	});
 });

--- a/src/domains/wallet/utils/get-default-alias.test.ts
+++ b/src/domains/wallet/utils/get-default-alias.test.ts
@@ -26,7 +26,6 @@ describe("getDefaultAlias", () => {
 		profile.wallets().push(wallet);
 
 		const result = getDefaultAlias({
-			network: wallet.network(),
 			profile,
 		});
 
@@ -45,10 +44,39 @@ describe("getDefaultAlias", () => {
 		wallet.mutator().alias("Address #1");
 
 		const result = getDefaultAlias({
-			network: wallet.network(),
 			profile,
 		});
 
 		expect(result).toBe("Address #2");
+	});
+
+	it("should increase the alias number regardless of the network", async () => {
+		const wallet = await profile.walletFactory().fromMnemonicWithBIP39({
+			coin: "ARK",
+			mnemonic: MNEMONICS[0],
+			network: "ark.devnet",
+		});
+
+		profile.wallets().push(wallet);
+
+		const result = getDefaultAlias({
+			profile,
+		});
+
+		expect(result).toBe("Address #1");
+
+		const wallet2 = await profile.walletFactory().fromMnemonicWithBIP39({
+			coin: "ARK",
+			mnemonic: MNEMONICS[0],
+			network: "ark.mainnet",
+		});
+
+		profile.wallets().push(wallet2);
+
+		const result2 = getDefaultAlias({
+			profile,
+		});
+
+		expect(result2).toBe("Address #2");
 	});
 });

--- a/src/domains/wallet/utils/get-default-alias.ts
+++ b/src/domains/wallet/utils/get-default-alias.ts
@@ -7,8 +7,8 @@ interface GetDefaultAliasInput {
 	network: Networks.Network;
 }
 
-export const getDefaultAlias = ({ profile, network }: GetDefaultAliasInput): string => {
-	const makeAlias = (count: number) => `${networkDisplayName(network)} #${count}`;
+export const getDefaultAlias = ({ profile, network}: GetDefaultAliasInput): string => {
+	const makeAlias = (count: number) => `Address #${count}`;
 
 	const sameCoinWallets = profile.wallets().findByCoinWithNetwork(network.coin(), network.id());
 

--- a/src/domains/wallet/utils/get-default-alias.ts
+++ b/src/domains/wallet/utils/get-default-alias.ts
@@ -1,13 +1,12 @@
-import { Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
-import { networkDisplayName } from "@/utils/network-utils";
 
 interface GetDefaultAliasInput {
 	profile: Contracts.IProfile;
 }
 
+const makeAlias = (count: number) => `Address #${count}`;
+
 export const getDefaultAlias = ({ profile}: GetDefaultAliasInput): string => {
-	const makeAlias = (count: number) => `Address #${count}`;
 
 	let counter = profile.wallets().count();
 

--- a/src/domains/wallet/utils/get-default-alias.ts
+++ b/src/domains/wallet/utils/get-default-alias.ts
@@ -6,8 +6,7 @@ interface GetDefaultAliasInput {
 
 const makeAlias = (count: number) => `Address #${count}`;
 
-export const getDefaultAlias = ({ profile}: GetDefaultAliasInput): string => {
-
+export const getDefaultAlias = ({ profile }: GetDefaultAliasInput): string => {
 	let counter = profile.wallets().count();
 
 	if (counter === 0) {

--- a/src/domains/wallet/utils/get-default-alias.ts
+++ b/src/domains/wallet/utils/get-default-alias.ts
@@ -4,15 +4,12 @@ import { networkDisplayName } from "@/utils/network-utils";
 
 interface GetDefaultAliasInput {
 	profile: Contracts.IProfile;
-	network: Networks.Network;
 }
 
-export const getDefaultAlias = ({ profile, network}: GetDefaultAliasInput): string => {
+export const getDefaultAlias = ({ profile}: GetDefaultAliasInput): string => {
 	const makeAlias = (count: number) => `Address #${count}`;
 
-	const sameCoinWallets = profile.wallets().findByCoinWithNetwork(network.coin(), network.id());
-
-	let counter = sameCoinWallets.length;
+	let counter = profile.wallets().count();
 
 	if (counter === 0) {
 		counter = 1;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] change default labels](https://app.clickup.com/t/86dvwyt18)

## Summary

- `get-default-alias` hook has been refactored to set the name of new addresses imported regardless of the network.
- Unit tests have been added and refactored to support this change.
 

<img width="573" alt="image" src="https://github.com/user-attachments/assets/45bcce68-0ea5-4fe1-b304-0b28b8a71d49" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
