### PR TITLE
fix: make transaction row addresses occupy available space

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -114,7 +114,7 @@ export const TransactionRow = memo(
 						"min-h-16 my-1 py-2": !hideSender,
 					})}
 				>
-					<div className="flex flex-col gap-2">
+					<div className="flex grow flex-col gap-2">
 						<TransactionRowAddressing
 							transaction={transaction}
 							profile={profile}

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -41,10 +41,7 @@ export const TransactionRowLabel = ({ direction, style }: { direction: Direction
 
 const FormattedAddress = ({ alias, address }: { alias?: string; address: string }): JSX.Element => (
 	<div
-		className={cn({
-			"w-40 sm:w-40 md:w-32": alias,
-			"w-40 xs:w-50 sm:w-30": !alias,
-		})}
+		className="grow"
 		data-testid="TransactionRowAddressing__address-container"
 	>
 		<Address

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -40,10 +40,7 @@ export const TransactionRowLabel = ({ direction, style }: { direction: Direction
 };
 
 const FormattedAddress = ({ alias, address }: { alias?: string; address: string }): JSX.Element => (
-	<div
-		className="grow"
-		data-testid="TransactionRowAddressing__address-container"
-	>
+	<div className="grow" data-testid="TransactionRowAddressing__address-container">
 		<Address
 			walletName={alias}
 			address={address}
@@ -66,7 +63,7 @@ const ContractAddressing = ({
 	direction: Direction;
 	t: any;
 }) => (
-	<div className="flex flex-row gap-2" data-testid="TransactionRowAddressing__vote">
+	<div className="flex w-full flex-row gap-2" data-testid="TransactionRowAddressing__vote">
 		<TransactionRowLabel direction={direction} />
 		<Link
 			to={transaction.wallet().coin().link().wallet(transaction.recipient())}
@@ -168,7 +165,10 @@ export const TransactionRowAddressing = ({
 
 	if (isAdvanced && variant === "sender") {
 		return (
-			<div className="flex flex-row gap-2" data-testid="TransactionRowAddressing__container_advanced_sender">
+			<div
+				className="flex w-full flex-row gap-2"
+				data-testid="TransactionRowAddressing__container_advanced_sender"
+			>
 				<TransactionRowLabel direction="received" style="return" />
 				<FormattedAddress address={transaction.sender()} alias={senderAlias} />
 			</div>
@@ -178,7 +178,10 @@ export const TransactionRowAddressing = ({
 	if (isAdvanced && variant === "recipient" && !transaction.isMultiPayment()) {
 		if (isContract || isContractDeployment(transaction)) {
 			return (
-				<div className="flex flex-row gap-2" data-testid="TransactionRowAddressing__vote_advanced_recipient">
+				<div
+					className="flex w-full flex-row gap-2"
+					data-testid="TransactionRowAddressing__vote_advanced_recipient"
+				>
 					<TransactionRowLabel direction="sent" style="return" />
 					<Link
 						to={transaction.wallet().coin().link().wallet(transaction.recipient())}
@@ -193,7 +196,10 @@ export const TransactionRowAddressing = ({
 		}
 
 		return (
-			<div className="flex flex-row gap-2" data-testid="TransactionRowAddressing__container_advanced_recipient">
+			<div
+				className="flex w-full flex-row gap-2"
+				data-testid="TransactionRowAddressing__container_advanced_recipient"
+			>
 				<TransactionRowLabel direction="sent" style="return" />
 				<FormattedAddress address={transaction.recipient()} alias={alias} />
 			</div>
@@ -217,7 +223,7 @@ export const TransactionRowAddressing = ({
 	}
 
 	return (
-		<div className="flex flex-row gap-2" data-testid="TransactionRowAddressing__container">
+		<div className="flex w-full flex-row gap-2" data-testid="TransactionRowAddressing__container">
 			<TransactionRowLabel direction={direction} />
 			<FormattedAddress address={isNegative ? transaction.recipient() : transaction.sender()} alias={alias} />
 		</div>

--- a/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
@@ -33,6 +33,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			},
 			{
 				Header: t("COMMON.ADDRESSING"),
+				cellWidth: "w-full lg:w-24",
 				headerClassName: "no-border",
 			},
 			...(hideSender


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary



Closes https://app.clickup.com/t/86dvvnq9x

Previews:
![2025-02-04-171951_913x599_scrot](https://github.com/user-attachments/assets/23f21226-17a6-4f3f-a034-03a3c3393c2c)
![2025-02-04-172003_451x586_scrot](https://github.com/user-attachments/assets/bc0adbb0-fe70-4d3a-9599-6857aa0ac646)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
