### PR TITLE
fix: correct dark background color on tx rows mobile views

### DIFF
--- a/src/app/components/Table/Mobile/MobileCard.tsx
+++ b/src/app/components/Table/Mobile/MobileCard.tsx
@@ -8,7 +8,7 @@ interface MobileCardProps extends HTMLAttributes<HTMLDivElement> {
 export const MobileCard: FC<MobileCardProps> = ({ className, children, ...props }) => (
 	<div
 		className={cn(
-			"w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900",
+			"w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-kackground",
 			className,
 		)}
 		{...props}

--- a/src/app/components/Table/Mobile/MobileCard.tsx
+++ b/src/app/components/Table/Mobile/MobileCard.tsx
@@ -8,7 +8,7 @@ interface MobileCardProps extends HTMLAttributes<HTMLDivElement> {
 export const MobileCard: FC<MobileCardProps> = ({ className, children, ...props }) => (
 	<div
 		className={cn(
-			"w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-kackground",
+			"w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background",
 			className,
 		)}
 		{...props}

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionTable.test.tsx.snap
@@ -6236,7 +6236,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
             >
               <td>
                 <div
-                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
                 >
                   <div
                     class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -6489,7 +6489,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
             >
               <td>
                 <div
-                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
                 >
                   <div
                     class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -6742,7 +6742,7 @@ exports[`ExchangeTransactionsTable > should render mobile 1`] = `
             >
               <td>
                 <div
-                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
                 >
                   <div
                     class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -7023,7 +7023,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
             >
               <td>
                 <div
-                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
                 >
                   <div
                     class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -7276,7 +7276,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
             >
               <td>
                 <div
-                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
                 >
                   <div
                     class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -7529,7 +7529,7 @@ exports[`ExchangeTransactionsTable > should render mobile 2`] = `
             >
               <td>
                 <div
-                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+                  class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
                 >
                   <div
                     class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"

--- a/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRowMobile.test.tsx.snap
+++ b/src/domains/exchange/components/ExchangeTransactionsTable/__snapshots__/ExchangeTransactionsRowMobile.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Expired) 1`] = `
       >
         <td>
           <div
-            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
           >
             <div
               class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -243,7 +243,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Failed) 1`] = `
       >
         <td>
           <div
-            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
           >
             <div
               class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -467,7 +467,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Finished) 1`] = `
       >
         <td>
           <div
-            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
           >
             <div
               class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -691,7 +691,7 @@ exports[`ExchangeTransactionsRowMobile > should render (New) 1`] = `
       >
         <td>
           <div
-            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
           >
             <div
               class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -953,7 +953,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Refunded) 1`] = `
       >
         <td>
           <div
-            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
           >
             <div
               class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -1182,7 +1182,7 @@ exports[`ExchangeTransactionsRowMobile > should render (Verifying) 1`] = `
       >
         <td>
           <div
-            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+            class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
           >
             <div
               class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -1409,7 +1409,7 @@ exports[`ExchangeTransactionsRowMobile > should render N/A if no orderId 1`] = `
   >
     <td>
       <div
-        class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+        class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
       >
         <div
           class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"
@@ -1628,7 +1628,7 @@ exports[`ExchangeTransactionsRowMobile > should render transaction provider 1`] 
   >
     <td>
       <div
-        class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900 mb-3"
+        class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background mb-3"
       >
         <div
           class="flex h-11 w-full items-center justify-between bg-theme-secondary-100 px-4 dark:bg-black"

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`LedgerImportStep > should render with multiple import 1`] = `
         class="flex flex-col gap-2"
       >
         <div
-          class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900"
+          class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background"
           data-testid="LedgerMobileItem__wrapper"
         >
           <div
@@ -232,7 +232,7 @@ exports[`LedgerImportStep > should render with multiple import 1`] = `
           </div>
         </div>
         <div
-          class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-secondary-900"
+          class="w-full cursor-pointer overflow-hidden rounded border border-theme-secondary-300 bg-white dark:border-theme-secondary-800 dark:bg-theme-background"
           data-testid="LedgerMobileItem__wrapper"
         >
           <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dvx2kwt 

Fixes wrong background colors in dark mode, for mobile & small devices for transaction rows:
![2025-02-04-172856_539x317_scrot](https://github.com/user-attachments/assets/3014f419-278d-457a-aa15-aa547117a2fa)
![2025-02-04-172902_721x188_scrot](https://github.com/user-attachments/assets/f790b8a1-3a13-4d7e-bd48-34a85d4ff9a9)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
