### PR TITLE
fix: restore single wallet actions

### DIFF
--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -46,7 +46,8 @@ export const PortfolioHeader = ({
 
 	const isRestored = wallet.hasBeenFullyRestored();
 	const { convert } = useExchangeRate({ exchangeTicker: wallet.exchangeCurrency(), ticker: wallet.currency() });
-	const { handleImport, handleCreate, handleSelectOption, handleSend, setActiveModal, activeModal } = useWalletActions(...selectedWallets);
+	const { handleImport, handleCreate, handleSelectOption, handleSend, setActiveModal, activeModal } =
+		useWalletActions(...selectedWallets);
 	const { primaryOptions, secondaryOptions, additionalOptions, registrationOptions } =
 		useWalletOptions(selectedWallets);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Should restore the "Transaction History", "Wallet Name" & "Receive Funds" modals and their functionality when a single wallet is selected.

Closes https://app.clickup.com/t/86dvxbqgr
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
