### PR TITLE
refactor: portfolio page title

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
+++ b/src/domains/dashboard/pages/Dashboard/Dashboard.tsx
@@ -90,7 +90,7 @@ export const Dashboard = () => {
 
 	return (
 		<>
-			<Page pageTitle={selectedWallet?.address()}>
+			<Page pageTitle={t("COMMON.PORTFOLIO")}>
 				<Section
 					className="pb-0 first:pt-0 md:px-0 md:pb-4 xl:mx-auto"
 					innerClassName="m-0 p-0 md:px-0 md:mx-auto"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[portfolio] rename page title](https://app.clickup.com/t/86dvz9r29)

## Summary

- Page title for Portfolio has been renamed to simply `Portfolio`

<img width="155" alt="image" src="https://github.com/user-attachments/assets/bdc95390-9130-475a-a00a-af54d2658414" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
