### PR TITLE
fix: resigned label color

### DIFF
--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.blocks.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.blocks.tsx
@@ -33,7 +33,15 @@ export const DelegateStatus = ({ votes, activeDelegates }: DelegateStatusPropert
 	const activeCount = votes.filter(({ wallet }) => wallet?.rank() <= activeDelegates).length;
 	const resignedCount = votes.filter(({ wallet }) => wallet?.isResignedDelegate()).length;
 	const standbyCount = votes.length - activeCount - resignedCount;
-
+	return (
+		<Label
+			color="danger"
+			className="flex h-fit w-fit items-center justify-center border-none py-0.5 text-xs dark:border-solid"
+			variant="solid"
+		>
+			{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.RESIGNED", { count: resignedCount })}
+		</Label>
+	);
 	if (activeCount === votes.length) {
 		return (
 			<Label
@@ -61,6 +69,7 @@ export const DelegateStatus = ({ votes, activeDelegates }: DelegateStatusPropert
 			<Label
 				color="danger"
 				className="flex h-fit w-fit items-center justify-center border-none py-0.5 text-xs dark:border-solid"
+				variant="solid"
 			>
 				{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.RESIGNED", { count: resignedCount })}
 			</Label>

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.blocks.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/WalletVote.blocks.tsx
@@ -33,15 +33,7 @@ export const DelegateStatus = ({ votes, activeDelegates }: DelegateStatusPropert
 	const activeCount = votes.filter(({ wallet }) => wallet?.rank() <= activeDelegates).length;
 	const resignedCount = votes.filter(({ wallet }) => wallet?.isResignedDelegate()).length;
 	const standbyCount = votes.length - activeCount - resignedCount;
-	return (
-		<Label
-			color="danger"
-			className="flex h-fit w-fit items-center justify-center border-none py-0.5 text-xs dark:border-solid"
-			variant="solid"
-		>
-			{t("WALLETS.PAGE_WALLET_DETAILS.VOTES.RESIGNED", { count: resignedCount })}
-		</Label>
-	);
+
 	if (activeCount === votes.length) {
 		return (
 			<Label

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -274,7 +274,7 @@ exports[`WalletVote > should render as all resigned 1`] = `
           Delegate Status
         </p>
         <div
-          class="font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-danger-400 border-theme-danger-100 dark:border-theme-danger-400 flex h-fit w-fit items-center justify-center border-none py-0.5 text-xs dark:border-solid"
+          class="font-semibold overflow-hidden no-ligatures px-1 border-2 rounded text-theme-danger-500 border-theme-danger-100 bg-theme-danger-100 flex h-fit w-fit items-center justify-center border-none py-0.5 text-xs dark:border-solid"
         >
           All Resigned
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[portfolio] resigned label missing background colour](https://app.clickup.com/t/86dvyyadp)

## Summary

- The resigned label has been refactored and assigned the `solid` variant to adjust its colors.

<img width="296" alt="image" src="https://github.com/user-attachments/assets/bfea3b20-92f3-4813-9043-8599cb67be45" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
