### PR TITLE
fix: add nowrap to table headers

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
@@ -14,7 +14,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			{
 				Header: t("COMMON.TX_ID"),
 				cellWidth: "w-32 lg:w-36 xl:w-48",
-				headerClassName: "no-border",
+				headerClassName: "no-border text-nowrap",
 				noRoundedBorders: true,
 			},
 			{
@@ -34,7 +34,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			{
 				Header: t("COMMON.ADDRESSING"),
 				cellWidth: "w-full lg:w-24",
-				headerClassName: "no-border",
+				headerClassName: "no-border text-nowrap",
 			},
 			...(hideSender
 				? []
@@ -45,10 +45,10 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 						},
 					]),
 			{
-				Header: `${t(hideSender ? "COMMON.VALUE" : "COMMON.AMOUNT")} ${coinLabel}`,
+				Header: `${t("COMMON.AMOUNT")} ${coinLabel}`,
 				accessor: (transaction) => transaction.total?.(),
 				className: "justify-end",
-				headerClassName: "no-border",
+				headerClassName: "no-border text-nowrap",
 				id: "amount",
 			},
 			{
@@ -56,7 +56,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 				accessor: () => "fiatValue",
 				cellWidth: "w-36",
 				className: "justify-end",
-				headerClassName: `no-border hidden lg:table-cell ${hideSender ? "" : "!pl-0 xl:min-w-28"}`,
+				headerClassName: `no-border text-nowrap hidden lg:table-cell ${hideSender ? "" : "!pl-0 xl:min-w-28"}`,
 				noRoundedBorders: true,
 			},
 		];

--- a/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
@@ -1,9 +1,8 @@
+import { Column } from "react-table";
 import { DTO } from "@ardenthq/sdk-profiles";
+import { PendingTransaction } from "@/domains/transaction/components/TransactionTable/PendingTransactionsTable/PendingTransactionsTable.contracts";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Column } from "react-table";
-
-import { PendingTransaction } from "@/domains/transaction/components/TransactionTable/PendingTransactionsTable/PendingTransactionsTable.contracts";
 
 export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string; hideSender?: boolean }) => {
 	const { t } = useTranslation();
@@ -14,7 +13,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			{
 				Header: t("COMMON.TX_ID"),
 				cellWidth: "w-32 lg:w-36 xl:w-48",
-				headerClassName: "no-border text-nowrap",
+				headerClassName: "no-border whitespace-nowrap",
 				noRoundedBorders: true,
 			},
 			{
@@ -34,7 +33,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			{
 				Header: t("COMMON.ADDRESSING"),
 				cellWidth: "w-full lg:w-24",
-				headerClassName: "no-border text-nowrap",
+				headerClassName: "no-border whitespace-nowrap",
 			},
 			...(hideSender
 				? []
@@ -48,7 +47,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 				Header: `${t("COMMON.AMOUNT")} ${coinLabel}`,
 				accessor: (transaction) => transaction.total?.(),
 				className: "justify-end",
-				headerClassName: "no-border text-nowrap",
+				headerClassName: "no-border whitespace-nowrap",
 				id: "amount",
 			},
 			{
@@ -56,7 +55,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 				accessor: () => "fiatValue",
 				cellWidth: "w-36",
 				className: "justify-end",
-				headerClassName: `no-border text-nowrap hidden lg:table-cell ${hideSender ? "" : "!pl-0 xl:min-w-28"}`,
+				headerClassName: `no-border whitespace-nowrap hidden lg:table-cell ${hideSender ? "" : "!pl-0 xl:min-w-28"}`,
 				noRoundedBorders: true,
 			},
 		];


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] add nowrap to table headers](https://app.clickup.com/t/86dvz06up)

## Summary

- `text-nowrap` class has been added to table headers, as a result the table headers will stop breaking in many lines.
- 
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/3a5b0ed0-f492-4145-9ede-01c73f0675c0" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
