### PR TITLE
refactor: initial loading screen navbar

### DIFF
--- a/src/app/components/PageSkeleton/ProfilePageSkeleton.tsx
+++ b/src/app/components/PageSkeleton/ProfilePageSkeleton.tsx
@@ -26,13 +26,13 @@ export const ProfilePageSkeleton: React.FC = () => (
 
 						<div className="my-auto ml-4 hidden items-center space-x-4 sm:flex">
 							<Skeleton height={28} width={28} className="hidden sm:flex" />
-							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<div className="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12" />
 							<Skeleton height={28} width={28} className="hidden sm:flex" />
-							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<div className="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12" />
 							<Skeleton height={28} width={28} className="hidden sm:flex" />
-							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<div className="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12" />
 							<Skeleton height={28} width={28} className="hidden sm:flex" />
-							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<div className="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12" />
 						</div>
 
 						<div className="my-auto ml-4 flex items-center">

--- a/src/app/components/PageSkeleton/ProfilePageSkeleton.tsx
+++ b/src/app/components/PageSkeleton/ProfilePageSkeleton.tsx
@@ -5,50 +5,43 @@ import { Logo } from "@/app/components/Logo";
 
 const MenuItemSkeleton = ({ isCircle = false }: { isCircle?: boolean }) => (
 	<div>
-		<div className="hidden sm:visible">
-			<Skeleton height={40} width={40} circle={isCircle} />
-		</div>
-
-		<div className="visible sm:hidden">
-			<Skeleton height={25} width={25} circle={isCircle} />
-		</div>
+		<Skeleton height={28} width={28} circle={isCircle} />
 	</div>
 );
 
 export const ProfilePageSkeleton: React.FC = () => (
 	<div className="relative flex min-h-screen flex-col" data-testid="ProfilePageSkeleton">
 		<div className="sticky inset-x-0 top-0 border-b border-theme-secondary-300 dark:border-theme-secondary-800">
-			<div className="relative flex h-14 sm:h-21">
-				<div className="flex flex-1 justify-between px-6 sm:ml-12 sm:px-8">
-					<div className="my-auto mr-4 flex h-8 w-8 items-center justify-center rounded-md bg-theme-primary-600 text-white sm:h-11 sm:w-11 sm:rounded-xl">
-						<div className="hidden sm:block">
-							<Logo height={28} />
-						</div>
-						<div className="block sm:hidden">
-							<Logo height={23} />
-						</div>
+			<div className="relative flex h-12 items-center">
+				<div className="flex flex-1 justify-between px-6 sm:ml-7 sm:px-8">
+					<div className="my-auto flex h-6 w-6 items-center justify-center rounded-md bg-theme-primary-600 text-white">
+						<Logo height={16} />
 					</div>
 
 					<div className="flex">
-						<div className="my-auto flex items-center space-x-4">
+						<div className="my-auto flex items-center space-x-4 sm:hidden">
 							<MenuItemSkeleton />
-							<div className="h-8 border-r border-theme-secondary-300 dark:border-theme-secondary-800" />
+							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-dark-700" />
 						</div>
 
 						<div className="my-auto ml-4 hidden items-center space-x-4 sm:flex">
-							<Skeleton height={40} width={40} className="hidden sm:visible" />
-							<div className="h-8 border-r border-theme-secondary-300 dark:border-theme-secondary-800" />
-							<Skeleton height={40} width={40} className="hidden sm:visible" />
-							<div className="h-8 border-r border-theme-secondary-300 dark:border-theme-secondary-800" />
+							<Skeleton height={28} width={28} className="hidden sm:flex" />
+							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<Skeleton height={28} width={28} className="hidden sm:flex" />
+							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<Skeleton height={28} width={28} className="hidden sm:flex" />
+							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
+							<Skeleton height={28} width={28} className="hidden sm:flex" />
+							<div className="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12" />
 						</div>
 
 						<div className="my-auto ml-4 flex items-center">
 							<div className="mx-4 hidden space-y-2 md:block">
 								<p>
-									<Skeleton width={80} height={16} />
+									<Skeleton width={80} height={12} />
 								</p>
 								<p>
-									<Skeleton width={80} height={16} />
+									<Skeleton width={80} height={12} />
 								</p>
 							</div>
 

--- a/src/app/components/PageSkeleton/__snapshots__/ProfilePageSkeleton.test.tsx.snap
+++ b/src/app/components/PageSkeleton/__snapshots__/ProfilePageSkeleton.test.tsx.snap
@@ -10,105 +10,57 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
       class="sticky inset-x-0 top-0 border-b border-theme-secondary-300 dark:border-theme-secondary-800"
     >
       <div
-        class="relative flex h-14 sm:h-21"
+        class="relative flex h-12 items-center"
       >
         <div
-          class="flex flex-1 justify-between px-6 sm:ml-12 sm:px-8"
+          class="flex flex-1 justify-between px-6 sm:ml-7 sm:px-8"
         >
           <div
-            class="my-auto mr-4 flex h-8 w-8 items-center justify-center rounded-md bg-theme-primary-600 text-white sm:h-11 sm:w-11 sm:rounded-xl"
+            class="my-auto flex h-6 w-6 items-center justify-center rounded-md bg-theme-primary-600 text-white"
           >
-            <div
-              class="hidden sm:block"
+            <span
+              class="relative"
             >
-              <span
-                class="relative"
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 363 363"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  fill="none"
-                  height="28"
-                  viewBox="0 0 363 363"
-                  xmlns="http://www.w3.org/2000/svg"
+                <g
+                  clip-path="url(#clip0_434_4442)"
                 >
-                  <g
-                    clip-path="url(#clip0_434_4442)"
-                  >
-                    <path
-                      d="M174.182 352.325a279.256 279.256 0 0 1-25.627-20.536c-8.518-7.525-17.006-15.66-25.229-24.178a470.15 470.15 0 0 1-29.234-33.315 449.417 449.417 0 0 1-57.68-93.623 420.933 420.933 0 0 1-22.044-60.102A416.702 416.702 0 0 1 1.126 51.749c-.512-4.803-.303-10.73 5.9-13.842a393.077 393.077 0 0 1 54.42-19.94 459.697 459.697 0 0 1 52.646-12.195A374.409 374.409 0 0 1 176.15.333h11.6a374.406 374.406 0 0 1 62.057 5.44 459.723 459.723 0 0 1 52.646 12.195 393.328 393.328 0 0 1 54.422 19.939c6.203 3.115 6.41 9.034 5.898 13.842a416.672 416.672 0 0 1-13.242 68.822 421.133 421.133 0 0 1-22.044 60.102 449.395 449.395 0 0 1-57.68 93.623 470 470 0 0 1-29.234 33.315c-8.223 8.518-16.711 16.653-25.229 24.178a279.73 279.73 0 0 1-25.627 20.536 17.811 17.811 0 0 1-15.528 0h-.007zm6.769-230.087c-.412.547-28.363 29.571-48.772 50.764-7.035 7.318-13.229 13.736-17.187 17.853a49.345 49.345 0 0 0-14.37 29.355 42.981 42.981 0 0 0 2.034 17.531 59.295 59.295 0 0 0 10.41 18.547 369.34 369.34 0 0 0 42.811 44.915 223.324 223.324 0 0 0 20.072 16.051 13.364 13.364 0 0 0 12.005 0 223.333 223.333 0 0 0 20.07-16.051 369.191 369.191 0 0 0 42.811-44.915 59.297 59.297 0 0 0 10.411-18.547 42.98 42.98 0 0 0 2.033-17.531 49.34 49.34 0 0 0-14.377-29.358l-14.811-15.385-1.779-1.848c-20.66-21.451-48.955-50.832-49.371-51.383a1.179 1.179 0 0 0-.995-.548 1.184 1.184 0 0 0-.995.548v.002zm1.408-69.483c.136.215.321.505.582.869.391.544 6.257 9.93 14.382 22.92 19.488 31.162 52.102 83.315 60.679 96.014 6.342 9.377 14.353 14.77 21.974 14.772 7.402 0 18.108-5.031 27.079-29.067a332.382 332.382 0 0 0 19.124-81.095c.409-3.84.243-8.568-4.713-11.056a314.32 314.32 0 0 0-43.468-15.926 367.237 367.237 0 0 0-42.052-9.743 299.13 299.13 0 0 0-49.568-4.345h-8.871a299.13 299.13 0 0 0-49.568 4.345 367.225 367.225 0 0 0-42.051 9.743 314.427 314.427 0 0 0-43.469 15.926c-4.951 2.486-5.12 7.213-4.712 11.056a332.313 332.313 0 0 0 19.124 81.095c4.952 13.265 13.67 29.067 27.078 29.067 7.624 0 15.63-5.384 21.974-14.772 8.57-12.687 41.169-64.811 60.643-95.955l.032-.053c8.124-12.993 13.995-22.38 14.384-22.921.259-.364.455-.657.58-.87.209-.327.311-.491.416-.491.105 0 .214.16.421.487zm-55.455 149.533l19.652-20.614h69.159l19.649 20.614h-108.46zm34.197-35.377l20.162-20.871 20.159 20.871h-40.321z"
-                      fill="currentColor"
-                    />
-                  </g>
-                </svg>
-              </span>
-            </div>
-            <div
-              class="block sm:hidden"
-            >
-              <span
-                class="relative"
-              >
-                <svg
-                  fill="none"
-                  height="23"
-                  viewBox="0 0 363 363"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <g
-                    clip-path="url(#clip0_434_4442)"
-                  >
-                    <path
-                      d="M174.182 352.325a279.256 279.256 0 0 1-25.627-20.536c-8.518-7.525-17.006-15.66-25.229-24.178a470.15 470.15 0 0 1-29.234-33.315 449.417 449.417 0 0 1-57.68-93.623 420.933 420.933 0 0 1-22.044-60.102A416.702 416.702 0 0 1 1.126 51.749c-.512-4.803-.303-10.73 5.9-13.842a393.077 393.077 0 0 1 54.42-19.94 459.697 459.697 0 0 1 52.646-12.195A374.409 374.409 0 0 1 176.15.333h11.6a374.406 374.406 0 0 1 62.057 5.44 459.723 459.723 0 0 1 52.646 12.195 393.328 393.328 0 0 1 54.422 19.939c6.203 3.115 6.41 9.034 5.898 13.842a416.672 416.672 0 0 1-13.242 68.822 421.133 421.133 0 0 1-22.044 60.102 449.395 449.395 0 0 1-57.68 93.623 470 470 0 0 1-29.234 33.315c-8.223 8.518-16.711 16.653-25.229 24.178a279.73 279.73 0 0 1-25.627 20.536 17.811 17.811 0 0 1-15.528 0h-.007zm6.769-230.087c-.412.547-28.363 29.571-48.772 50.764-7.035 7.318-13.229 13.736-17.187 17.853a49.345 49.345 0 0 0-14.37 29.355 42.981 42.981 0 0 0 2.034 17.531 59.295 59.295 0 0 0 10.41 18.547 369.34 369.34 0 0 0 42.811 44.915 223.324 223.324 0 0 0 20.072 16.051 13.364 13.364 0 0 0 12.005 0 223.333 223.333 0 0 0 20.07-16.051 369.191 369.191 0 0 0 42.811-44.915 59.297 59.297 0 0 0 10.411-18.547 42.98 42.98 0 0 0 2.033-17.531 49.34 49.34 0 0 0-14.377-29.358l-14.811-15.385-1.779-1.848c-20.66-21.451-48.955-50.832-49.371-51.383a1.179 1.179 0 0 0-.995-.548 1.184 1.184 0 0 0-.995.548v.002zm1.408-69.483c.136.215.321.505.582.869.391.544 6.257 9.93 14.382 22.92 19.488 31.162 52.102 83.315 60.679 96.014 6.342 9.377 14.353 14.77 21.974 14.772 7.402 0 18.108-5.031 27.079-29.067a332.382 332.382 0 0 0 19.124-81.095c.409-3.84.243-8.568-4.713-11.056a314.32 314.32 0 0 0-43.468-15.926 367.237 367.237 0 0 0-42.052-9.743 299.13 299.13 0 0 0-49.568-4.345h-8.871a299.13 299.13 0 0 0-49.568 4.345 367.225 367.225 0 0 0-42.051 9.743 314.427 314.427 0 0 0-43.469 15.926c-4.951 2.486-5.12 7.213-4.712 11.056a332.313 332.313 0 0 0 19.124 81.095c4.952 13.265 13.67 29.067 27.078 29.067 7.624 0 15.63-5.384 21.974-14.772 8.57-12.687 41.169-64.811 60.643-95.955l.032-.053c8.124-12.993 13.995-22.38 14.384-22.921.259-.364.455-.657.58-.87.209-.327.311-.491.416-.491.105 0 .214.16.421.487zm-55.455 149.533l19.652-20.614h69.159l19.649 20.614h-108.46zm34.197-35.377l20.162-20.871 20.159 20.871h-40.321z"
-                      fill="currentColor"
-                    />
-                  </g>
-                </svg>
-              </span>
-            </div>
+                  <path
+                    d="M174.182 352.325a279.256 279.256 0 0 1-25.627-20.536c-8.518-7.525-17.006-15.66-25.229-24.178a470.15 470.15 0 0 1-29.234-33.315 449.417 449.417 0 0 1-57.68-93.623 420.933 420.933 0 0 1-22.044-60.102A416.702 416.702 0 0 1 1.126 51.749c-.512-4.803-.303-10.73 5.9-13.842a393.077 393.077 0 0 1 54.42-19.94 459.697 459.697 0 0 1 52.646-12.195A374.409 374.409 0 0 1 176.15.333h11.6a374.406 374.406 0 0 1 62.057 5.44 459.723 459.723 0 0 1 52.646 12.195 393.328 393.328 0 0 1 54.422 19.939c6.203 3.115 6.41 9.034 5.898 13.842a416.672 416.672 0 0 1-13.242 68.822 421.133 421.133 0 0 1-22.044 60.102 449.395 449.395 0 0 1-57.68 93.623 470 470 0 0 1-29.234 33.315c-8.223 8.518-16.711 16.653-25.229 24.178a279.73 279.73 0 0 1-25.627 20.536 17.811 17.811 0 0 1-15.528 0h-.007zm6.769-230.087c-.412.547-28.363 29.571-48.772 50.764-7.035 7.318-13.229 13.736-17.187 17.853a49.345 49.345 0 0 0-14.37 29.355 42.981 42.981 0 0 0 2.034 17.531 59.295 59.295 0 0 0 10.41 18.547 369.34 369.34 0 0 0 42.811 44.915 223.324 223.324 0 0 0 20.072 16.051 13.364 13.364 0 0 0 12.005 0 223.333 223.333 0 0 0 20.07-16.051 369.191 369.191 0 0 0 42.811-44.915 59.297 59.297 0 0 0 10.411-18.547 42.98 42.98 0 0 0 2.033-17.531 49.34 49.34 0 0 0-14.377-29.358l-14.811-15.385-1.779-1.848c-20.66-21.451-48.955-50.832-49.371-51.383a1.179 1.179 0 0 0-.995-.548 1.184 1.184 0 0 0-.995.548v.002zm1.408-69.483c.136.215.321.505.582.869.391.544 6.257 9.93 14.382 22.92 19.488 31.162 52.102 83.315 60.679 96.014 6.342 9.377 14.353 14.77 21.974 14.772 7.402 0 18.108-5.031 27.079-29.067a332.382 332.382 0 0 0 19.124-81.095c.409-3.84.243-8.568-4.713-11.056a314.32 314.32 0 0 0-43.468-15.926 367.237 367.237 0 0 0-42.052-9.743 299.13 299.13 0 0 0-49.568-4.345h-8.871a299.13 299.13 0 0 0-49.568 4.345 367.225 367.225 0 0 0-42.051 9.743 314.427 314.427 0 0 0-43.469 15.926c-4.951 2.486-5.12 7.213-4.712 11.056a332.313 332.313 0 0 0 19.124 81.095c4.952 13.265 13.67 29.067 27.078 29.067 7.624 0 15.63-5.384 21.974-14.772 8.57-12.687 41.169-64.811 60.643-95.955l.032-.053c8.124-12.993 13.995-22.38 14.384-22.921.259-.364.455-.657.58-.87.209-.327.311-.491.416-.491.105 0 .214.16.421.487zm-55.455 149.533l19.652-20.614h69.159l19.649 20.614h-108.46zm34.197-35.377l20.162-20.871 20.159 20.871h-40.321z"
+                    fill="currentColor"
+                  />
+                </g>
+              </svg>
+            </span>
           </div>
           <div
             class="flex"
           >
             <div
-              class="my-auto flex items-center space-x-4"
+              class="my-auto flex items-center space-x-4 sm:hidden"
             >
               <div>
-                <div
-                  class="hidden sm:visible"
+                <span
+                  aria-busy="true"
+                  aria-live="polite"
+                  class="flex w-auto max-w-full items-center overflow-hidden leading-none"
                 >
                   <span
-                    aria-busy="true"
-                    aria-live="polite"
-                    class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                    class="react-loading-skeleton"
+                    style="width: 28px; height: 28px;"
                   >
-                    <span
-                      class="react-loading-skeleton"
-                      style="width: 40px; height: 40px;"
-                    >
-                      ‌
-                    </span>
-                    <br />
+                    ‌
                   </span>
-                </div>
-                <div
-                  class="visible sm:hidden"
-                >
-                  <span
-                    aria-busy="true"
-                    aria-live="polite"
-                    class="flex w-auto max-w-full items-center overflow-hidden leading-none"
-                  >
-                    <span
-                      class="react-loading-skeleton"
-                      style="width: 25px; height: 25px;"
-                    >
-                      ‌
-                    </span>
-                    <br />
-                  </span>
-                </div>
+                  <br />
+                </span>
               </div>
               <div
-                class="h-8 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+                class="h-6 border-r border-theme-secondary-300 dark:border-theme-dark-700"
               />
             </div>
             <div
@@ -120,15 +72,15 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 class="flex w-auto max-w-full items-center overflow-hidden leading-none"
               >
                 <span
-                  class="react-loading-skeleton hidden sm:visible"
-                  style="width: 40px; height: 40px;"
+                  class="react-loading-skeleton hidden sm:flex"
+                  style="width: 28px; height: 28px;"
                 >
                   ‌
                 </span>
                 <br />
               </span>
               <div
-                class="h-8 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
               />
               <span
                 aria-busy="true"
@@ -136,15 +88,47 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 class="flex w-auto max-w-full items-center overflow-hidden leading-none"
               >
                 <span
-                  class="react-loading-skeleton hidden sm:visible"
-                  style="width: 40px; height: 40px;"
+                  class="react-loading-skeleton hidden sm:flex"
+                  style="width: 28px; height: 28px;"
                 >
                   ‌
                 </span>
                 <br />
               </span>
               <div
-                class="h-8 border-r border-theme-secondary-300 dark:border-theme-secondary-800"
+                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
+              />
+              <span
+                aria-busy="true"
+                aria-live="polite"
+                class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+              >
+                <span
+                  class="react-loading-skeleton hidden sm:flex"
+                  style="width: 28px; height: 28px;"
+                >
+                  ‌
+                </span>
+                <br />
+              </span>
+              <div
+                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
+              />
+              <span
+                aria-busy="true"
+                aria-live="polite"
+                class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+              >
+                <span
+                  class="react-loading-skeleton hidden sm:flex"
+                  style="width: 28px; height: 28px;"
+                >
+                  ‌
+                </span>
+                <br />
+              </span>
+              <div
+                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
               />
             </div>
             <div
@@ -161,7 +145,7 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                   >
                     <span
                       class="react-loading-skeleton"
-                      style="width: 80px; height: 16px;"
+                      style="width: 80px; height: 12px;"
                     >
                       ‌
                     </span>
@@ -176,7 +160,7 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                   >
                     <span
                       class="react-loading-skeleton"
-                      style="width: 80px; height: 16px;"
+                      style="width: 80px; height: 12px;"
                     >
                       ‌
                     </span>
@@ -185,40 +169,19 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 </p>
               </div>
               <div>
-                <div
-                  class="hidden sm:visible"
+                <span
+                  aria-busy="true"
+                  aria-live="polite"
+                  class="flex w-auto max-w-full items-center overflow-hidden leading-none"
                 >
                   <span
-                    aria-busy="true"
-                    aria-live="polite"
-                    class="flex w-auto max-w-full items-center overflow-hidden leading-none"
+                    class="react-loading-skeleton"
+                    style="width: 28px; height: 28px; border-radius: 50%;"
                   >
-                    <span
-                      class="react-loading-skeleton"
-                      style="width: 40px; height: 40px; border-radius: 50%;"
-                    >
-                      ‌
-                    </span>
-                    <br />
+                    ‌
                   </span>
-                </div>
-                <div
-                  class="visible sm:hidden"
-                >
-                  <span
-                    aria-busy="true"
-                    aria-live="polite"
-                    class="flex w-auto max-w-full items-center overflow-hidden leading-none"
-                  >
-                    <span
-                      class="react-loading-skeleton"
-                      style="width: 25px; height: 25px; border-radius: 50%;"
-                    >
-                      ‌
-                    </span>
-                    <br />
-                  </span>
-                </div>
+                  <br />
+                </span>
               </div>
             </div>
           </div>

--- a/src/app/components/PageSkeleton/__snapshots__/ProfilePageSkeleton.test.tsx.snap
+++ b/src/app/components/PageSkeleton/__snapshots__/ProfilePageSkeleton.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 <br />
               </span>
               <div
-                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
+                class="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12"
               />
               <span
                 aria-busy="true"
@@ -96,7 +96,7 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 <br />
               </span>
               <div
-                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
+                class="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12"
               />
               <span
                 aria-busy="true"
@@ -112,7 +112,7 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 <br />
               </span>
               <div
-                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
+                class="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12"
               />
               <span
                 aria-busy="true"
@@ -128,7 +128,7 @@ exports[`ProfilePageSkeleton > should render without profile 1`] = `
                 <br />
               </span>
               <div
-                class="h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 hidden sm:flex sm:h-12"
+                class="hidden h-6 border-r border-theme-secondary-300 dark:border-theme-secondary-800 sm:flex sm:h-12"
               />
             </div>
             <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] initial loading screen shows a larger navbar](https://app.clickup.com/t/86dw0r341)

## Summary

- Navbar skeleton has been refactored to match the new redesign in both the mobile and desktop version

## Screenshots

- Mobile:
<img width="315" alt="image" src="https://github.com/user-attachments/assets/977b4167-c9f1-4d43-8cc5-72aeb1a1cff8" />


- Desktop:
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/780050b9-6c65-44de-b501-8b02e564a193" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
