### PR TITLE
fix: back to wallet redirection

### DIFF
--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.test.tsx
@@ -739,7 +739,7 @@ describe("SendTransfer", () => {
 		const pushSpy = vi.spyOn(history, "push");
 		await userEvent.click(backToWalletButton());
 
-		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/wallets/${wallet.id()}`);
+		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/dashboard`);
 
 		goSpy.mockRestore();
 		pushSpy.mockRestore();
@@ -948,7 +948,7 @@ describe("SendTransfer", () => {
 		const pushSpy = vi.spyOn(history, "push");
 		await userEvent.click(backToWalletButton());
 
-		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/wallets/${wallet.id()}`);
+		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/dashboard`);
 
 		goSpy.mockRestore();
 		pushSpy.mockRestore();
@@ -1482,7 +1482,7 @@ describe("SendTransfer", () => {
 		const pushSpy = vi.spyOn(history, "push");
 		await userEvent.click(backToWalletButton());
 
-		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/wallets/${wallet.id()}`);
+		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/dashboard`);
 
 		goSpy.mockRestore();
 		pushSpy.mockRestore();
@@ -1698,7 +1698,7 @@ describe("SendTransfer", () => {
 		const pushSpy = vi.spyOn(history, "push");
 		await userEvent.click(backToWalletButton());
 
-		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/wallets/${wallet.id()}`);
+		expect(pushSpy).toHaveBeenCalledWith(`/profiles/${profile.id()}/dashboard`);
 
 		goSpy.mockRestore();
 		pushSpy.mockRestore();

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -346,7 +346,7 @@ export const SendTransfer = () => {
 				<ErrorStep
 					onClose={() => {
 						assertWallet(wallet);
-						history.push(`/profiles/${activeProfile.id()}/wallets/${wallet.id()}`);
+						history.push(`/profiles/${activeProfile.id()}/dashboard`);
 					}}
 					isBackDisabled={isSubmitting}
 					onBack={() => {
@@ -361,7 +361,7 @@ export const SendTransfer = () => {
 					onBackClick={handleBack}
 					onBackToWalletClick={() => {
 						assertWallet(wallet);
-						history.push(`/profiles/${activeProfile.id()}/wallets/${wallet.id()}`);
+						history.push(`/profiles/${activeProfile.id()}/dashboard`);
 					}}
 					onContinueClick={async () => await handleNext()}
 					onSend={() => {

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -497,9 +497,7 @@ export const SendVote = () => {
 
 							<TabPanel tabId={Step.ErrorStep}>
 								<ErrorStep
-									onClose={() =>
-										history.push(`/profiles/${activeProfile.id()}/dashboard`)
-									}
+									onClose={() => history.push(`/profiles/${activeProfile.id()}/dashboard`)}
 									isBackDisabled={isSubmitting}
 									onBack={() => {
 										setActiveTab(Step.FormStep);

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -498,7 +498,7 @@ export const SendVote = () => {
 							<TabPanel tabId={Step.ErrorStep}>
 								<ErrorStep
 									onClose={() =>
-										history.push(`/profiles/${activeProfile.id()}/wallets/${activeWallet?.id()}`)
+										history.push(`/profiles/${activeProfile.id()}/dashboard`)
 									}
 									isBackDisabled={isSubmitting}
 									onBack={() => {
@@ -512,7 +512,7 @@ export const SendVote = () => {
 								<StepNavigation
 									onBackClick={handleBack}
 									onBackToWalletClick={() =>
-										history.push(`/profiles/${activeProfile.id()}/wallets/${activeWallet?.id()}`)
+										history.push(`/profiles/${activeProfile.id()}/dashboard`)
 									}
 									onContinueClick={() => handleNext()}
 									isLoading={isSubmitting}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[transaction] "Back to Wallet" button routes to "Select Profile" page](https://app.clickup.com/t/86dw13m07)

## Summary

- The `Back to wallet` button redirection has been fixed for both the `Vote` and `Transfer` transaction flows.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

https://github.com/user-attachments/assets/65af4a68-a547-49e2-bf32-7fb79ce34092



## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
