### PR TITLE
refactor: adjust transactions table spacing

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -55,7 +55,7 @@ export const TransactionRow = memo(
 			<TableRow onClick={onClick} className={twMerge("relative", className)} {...properties}>
 				<TableCell
 					variant="start"
-					innerClassName={cn("items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5", {
+					innerClassName={cn("items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 lg:min-w-36", {
 						"min-h-14 my-1 pt-1": hideSender,
 						"min-h-[66px] py-1 my-0 md-lg:min-h-14": !hideSender,
 					})}
@@ -78,6 +78,7 @@ export const TransactionRow = memo(
 						"text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3",
 						{
 							"xl:min-w-32": !hideSender,
+							"lg:min-w-40": hideSender,
 						},
 					)}
 					data-testid="TransactionRow__timestamp"
@@ -138,7 +139,7 @@ export const TransactionRow = memo(
 						"hidden md-lg:table-cell": !hideSender,
 					})}
 					innerClassName={cn("space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11", {
-						"min-h-16 my-1 py-2": !hideSender,
+						"min-h-16 my-1 py-2 lg:min-w-36": !hideSender,
 					})}
 				>
 					<TransactionRowAddressing

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -77,8 +77,8 @@ export const TransactionRow = memo(
 					innerClassName={cn(
 						"text-sm text-theme-secondary-900 dark:text-theme-secondary-200 font-semibold items-start my-1 min-h-11 xl:max-h-11 xl:pt-3",
 						{
-							"xl:min-w-32": !hideSender,
 							"lg:min-w-40": hideSender,
+							"xl:min-w-32": !hideSender,
 						},
 					)}
 					data-testid="TransactionRow__timestamp"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -93,7 +93,8 @@ export const TransactionRow = memo(
 				<TableCell
 					innerClassName={cn("items-start xl:min-h-11 xl:pt-3", {
 						"min-h-14 my-1 pt-2": hideSender,
-						"min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 lg:min-w-24 xl:min-w-38 xl:w-auto": !hideSender,
+						"min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 lg:min-w-24 xl:min-w-38 xl:w-auto":
+							!hideSender,
 					})}
 				>
 					<Label

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRow.tsx
@@ -93,7 +93,7 @@ export const TransactionRow = memo(
 				<TableCell
 					innerClassName={cn("items-start xl:min-h-11 xl:pt-3", {
 						"min-h-14 my-1 pt-2": hideSender,
-						"min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 xl:w-auto": !hideSender,
+						"min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 lg:min-w-24 xl:min-w-38 xl:w-auto": !hideSender,
 					})}
 				>
 					<Label
@@ -162,7 +162,7 @@ export const TransactionRow = memo(
 				<TableCell
 					className="hidden lg:table-cell"
 					innerClassName={cn("justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3", {
-						"lg:w-44 xl:w-auto": !hideSender,
+						"lg:w-34 xl:w-auto": !hideSender,
 					})}
 				>
 					<div className="flex flex-col items-end gap-1">

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
         </td>
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start xl:min-h-11 xl:pt-3 min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 xl:w-auto"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start xl:min-h-11 xl:pt-3 min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 lg:min-w-24 xl:min-w-38 xl:w-auto"
           >
             <div
               class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] max-w-40 truncate whitespace-nowrap rounded px-1 py-[3px] dark:border"
@@ -411,7 +411,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
           class="hidden lg:table-cell"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3 lg:w-44 xl:w-auto"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3 lg:w-34 xl:w-auto"
           >
             <div
               class="flex flex-col items-end gap-1"
@@ -523,7 +523,7 @@ exports[`TransactionRow > should render 1`] = `
         </td>
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start xl:min-h-11 xl:pt-3 min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 xl:w-auto"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start xl:min-h-11 xl:pt-3 min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 lg:min-w-24 xl:min-w-38 xl:w-auto"
           >
             <div
               class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] max-w-40 truncate whitespace-nowrap rounded px-1 py-[3px] dark:border"
@@ -865,7 +865,7 @@ exports[`TransactionRow > should render 1`] = `
           class="hidden lg:table-cell"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3 lg:w-44 xl:w-auto"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3 lg:w-34 xl:w-auto"
           >
             <div
               class="flex flex-col items-end gap-1"
@@ -1846,7 +1846,7 @@ exports[`TransactionRow > should render with currency 1`] = `
         </td>
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start xl:min-h-11 xl:pt-3 min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 xl:w-auto"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start xl:min-h-11 xl:pt-3 min-h-[66px] py-1 my-0 md-lg:min-h-14 md-lg:pt-2 lg:w-24 lg:min-w-24 xl:min-w-38 xl:w-auto"
           >
             <div
               class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] max-w-40 truncate whitespace-nowrap rounded px-1 py-[3px] dark:border"
@@ -2188,7 +2188,7 @@ exports[`TransactionRow > should render with currency 1`] = `
           class="hidden lg:table-cell"
         >
           <div
-            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3 lg:w-44 xl:w-auto"
+            class="flex px-3 transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 justify-end items-start my-1 min-h-14 pt-2 xl:min-h-11 xl:my-0 xl:pt-3 lg:w-34 xl:w-auto"
           >
             <div
               class="flex flex-col items-end gap-1"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
       >
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 min-h-[66px] py-1 my-0 md-lg:min-h-14"
+            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 lg:min-w-36 min-h-[66px] py-1 my-0 md-lg:min-h-14"
           >
             <div
               class="flex flex-col gap-1 font-semibold"
@@ -99,52 +99,8 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
                   From
                 </div>
                 <div
-                  class="grow"
-                  data-testid="TransactionRowAddressing__address-container"
+                  class="flex min-w-36 grow items-center justify-between space-x-4"
                 >
-                  <div
-                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
-                  >
-                    <span
-                      class="font-semibold text-sm text-theme-text"
-                      data-testid="Address__alias"
-                    >
-                      <span
-                        class="no-ligatures transition-colors duration-200"
-                        data-testid="TruncateEnd"
-                      >
-                        ARK Wallet 1
-                      </span>
-                    </span>
-                    <div
-                      class="relative grow leading-[17px] sm:leading-5 text-left"
-                    >
-                      <span
-                        class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                        data-testid="Address__address"
-                      >
-                        D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                      </span>
-                      <span>
-                         
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="md-lg:hidden"
-              >
-                <div
-                  class="flex w-full flex-row gap-2"
-                  data-testid="TransactionRowAddressing__container_advanced_recipient"
-                >
-                  <div
-                    class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] !flex h-[21px] w-12 min-w-12 items-center justify-center rounded px-1 py-[3px] dark:border"
-                    data-testid="TransactionRowAddressing__label"
-                  >
-                    To
-                  </div>
                   <div
                     class="grow"
                     data-testid="TransactionRowAddressing__address-container"
@@ -163,20 +119,124 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
                           ARK Wallet 1
                         </span>
                       </span>
+                    </div>
+                  </div>
+                  <button
+                    class="ring-focus relative focus:outline-none"
+                    data-ring-focus-margin="-m-1"
+                    data-testid="clipboard-icon__wrapper"
+                    type="button"
+                  >
+                    <div
+                      class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                    >
                       <div
-                        class="relative grow leading-[17px] sm:leading-5 text-left"
+                        style="height: 16px; width: 16px;"
+                      >
+                        <svg
+                          id="copy"
+                          style="height: 100%; width: 100%;"
+                          viewBox="0 0 20 20"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <g
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          >
+                            <path
+                              d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                            />
+                            <path
+                              d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                            />
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="md-lg:hidden"
+              >
+                <div
+                  class="flex w-full flex-row gap-2"
+                  data-testid="TransactionRowAddressing__container_advanced_recipient"
+                >
+                  <div
+                    class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] !flex h-[21px] w-12 min-w-12 items-center justify-center rounded px-1 py-[3px] dark:border"
+                    data-testid="TransactionRowAddressing__label"
+                  >
+                    To
+                  </div>
+                  <div
+                    class="flex min-w-36 grow items-center justify-between space-x-4"
+                  >
+                    <div
+                      class="grow"
+                      data-testid="TransactionRowAddressing__address-container"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                       >
                         <span
-                          class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                          data-testid="Address__address"
+                          class="font-semibold text-sm text-theme-text"
+                          data-testid="Address__alias"
                         >
-                          D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                        </span>
-                        <span>
-                           
+                          <span
+                            class="no-ligatures transition-colors duration-200"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
                         </span>
                       </div>
                     </div>
+                    <button
+                      class="ring-focus relative focus:outline-none"
+                      data-ring-focus-margin="-m-1"
+                      data-testid="clipboard-icon__wrapper"
+                      type="button"
+                    >
+                      <div
+                        class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                      >
+                        <div
+                          style="height: 16px; width: 16px;"
+                        >
+                          <svg
+                            id="copy"
+                            style="height: 100%; width: 100%;"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -187,7 +247,7 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
           class="hidden md-lg:table-cell"
         >
           <div
-            class="flex transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11 min-h-16 my-1 py-2"
+            class="flex transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11 min-h-16 my-1 py-2 lg:min-w-36"
           >
             <div
               class="flex w-full flex-row gap-2"
@@ -200,37 +260,67 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
                 To
               </div>
               <div
-                class="grow"
-                data-testid="TransactionRowAddressing__address-container"
+                class="flex min-w-36 grow items-center justify-between space-x-4"
               >
                 <div
-                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                  class="grow"
+                  data-testid="TransactionRowAddressing__address-container"
                 >
-                  <span
-                    class="font-semibold text-sm text-theme-text"
-                    data-testid="Address__alias"
-                  >
-                    <span
-                      class="no-ligatures transition-colors duration-200"
-                      data-testid="TruncateEnd"
-                    >
-                      ARK Wallet 1
-                    </span>
-                  </span>
                   <div
-                    class="relative grow leading-[17px] sm:leading-5 text-left"
+                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                   >
                     <span
-                      class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                      data-testid="Address__address"
+                      class="font-semibold text-sm text-theme-text"
+                      data-testid="Address__alias"
                     >
-                      D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                    </span>
-                    <span>
-                       
+                      <span
+                        class="no-ligatures transition-colors duration-200"
+                        data-testid="TruncateEnd"
+                      >
+                        ARK Wallet 1
+                      </span>
                     </span>
                   </div>
                 </div>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                  >
+                    <div
+                      style="height: 16px; width: 16px;"
+                    >
+                      <svg
+                        id="copy"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>
@@ -252,37 +342,67 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
                 To
               </div>
               <div
-                class="grow"
-                data-testid="TransactionRowAddressing__address-container"
+                class="flex min-w-36 grow items-center justify-between space-x-4"
               >
                 <div
-                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                  class="grow"
+                  data-testid="TransactionRowAddressing__address-container"
                 >
-                  <span
-                    class="font-semibold text-sm text-theme-text"
-                    data-testid="Address__alias"
-                  >
-                    <span
-                      class="no-ligatures transition-colors duration-200"
-                      data-testid="TruncateEnd"
-                    >
-                      ARK Wallet 1
-                    </span>
-                  </span>
                   <div
-                    class="relative grow leading-[17px] sm:leading-5 text-left"
+                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                   >
                     <span
-                      class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                      data-testid="Address__address"
+                      class="font-semibold text-sm text-theme-text"
+                      data-testid="Address__alias"
                     >
-                      D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                    </span>
-                    <span>
-                       
+                      <span
+                        class="no-ligatures transition-colors duration-200"
+                        data-testid="TruncateEnd"
+                      >
+                        ARK Wallet 1
+                      </span>
                     </span>
                   </div>
                 </div>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                  >
+                    <div
+                      style="height: 16px; width: 16px;"
+                    >
+                      <svg
+                        id="copy"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>
@@ -344,7 +464,7 @@ exports[`TransactionRow > should render 1`] = `
       >
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 min-h-[66px] py-1 my-0 md-lg:min-h-14"
+            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 lg:min-w-36 min-h-[66px] py-1 my-0 md-lg:min-h-14"
           >
             <div
               class="flex flex-col gap-1 font-semibold"
@@ -433,52 +553,8 @@ exports[`TransactionRow > should render 1`] = `
                   From
                 </div>
                 <div
-                  class="grow"
-                  data-testid="TransactionRowAddressing__address-container"
+                  class="flex min-w-36 grow items-center justify-between space-x-4"
                 >
-                  <div
-                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
-                  >
-                    <span
-                      class="font-semibold text-sm text-theme-text"
-                      data-testid="Address__alias"
-                    >
-                      <span
-                        class="no-ligatures transition-colors duration-200"
-                        data-testid="TruncateEnd"
-                      >
-                        ARK Wallet 1
-                      </span>
-                    </span>
-                    <div
-                      class="relative grow leading-[17px] sm:leading-5 text-left"
-                    >
-                      <span
-                        class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                        data-testid="Address__address"
-                      >
-                        D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                      </span>
-                      <span>
-                         
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="md-lg:hidden"
-              >
-                <div
-                  class="flex w-full flex-row gap-2"
-                  data-testid="TransactionRowAddressing__container_advanced_recipient"
-                >
-                  <div
-                    class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] !flex h-[21px] w-12 min-w-12 items-center justify-center rounded px-1 py-[3px] dark:border"
-                    data-testid="TransactionRowAddressing__label"
-                  >
-                    To
-                  </div>
                   <div
                     class="grow"
                     data-testid="TransactionRowAddressing__address-container"
@@ -497,20 +573,124 @@ exports[`TransactionRow > should render 1`] = `
                           ARK Wallet 1
                         </span>
                       </span>
+                    </div>
+                  </div>
+                  <button
+                    class="ring-focus relative focus:outline-none"
+                    data-ring-focus-margin="-m-1"
+                    data-testid="clipboard-icon__wrapper"
+                    type="button"
+                  >
+                    <div
+                      class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                    >
                       <div
-                        class="relative grow leading-[17px] sm:leading-5 text-left"
+                        style="height: 16px; width: 16px;"
+                      >
+                        <svg
+                          id="copy"
+                          style="height: 100%; width: 100%;"
+                          viewBox="0 0 20 20"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <g
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          >
+                            <path
+                              d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                            />
+                            <path
+                              d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                            />
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="md-lg:hidden"
+              >
+                <div
+                  class="flex w-full flex-row gap-2"
+                  data-testid="TransactionRowAddressing__container_advanced_recipient"
+                >
+                  <div
+                    class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] !flex h-[21px] w-12 min-w-12 items-center justify-center rounded px-1 py-[3px] dark:border"
+                    data-testid="TransactionRowAddressing__label"
+                  >
+                    To
+                  </div>
+                  <div
+                    class="flex min-w-36 grow items-center justify-between space-x-4"
+                  >
+                    <div
+                      class="grow"
+                      data-testid="TransactionRowAddressing__address-container"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                       >
                         <span
-                          class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                          data-testid="Address__address"
+                          class="font-semibold text-sm text-theme-text"
+                          data-testid="Address__alias"
                         >
-                          D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                        </span>
-                        <span>
-                           
+                          <span
+                            class="no-ligatures transition-colors duration-200"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
                         </span>
                       </div>
                     </div>
+                    <button
+                      class="ring-focus relative focus:outline-none"
+                      data-ring-focus-margin="-m-1"
+                      data-testid="clipboard-icon__wrapper"
+                      type="button"
+                    >
+                      <div
+                        class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                      >
+                        <div
+                          style="height: 16px; width: 16px;"
+                        >
+                          <svg
+                            id="copy"
+                            style="height: 100%; width: 100%;"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -521,7 +701,7 @@ exports[`TransactionRow > should render 1`] = `
           class="hidden md-lg:table-cell"
         >
           <div
-            class="flex transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11 min-h-16 my-1 py-2"
+            class="flex transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11 min-h-16 my-1 py-2 lg:min-w-36"
           >
             <div
               class="flex w-full flex-row gap-2"
@@ -534,37 +714,67 @@ exports[`TransactionRow > should render 1`] = `
                 To
               </div>
               <div
-                class="grow"
-                data-testid="TransactionRowAddressing__address-container"
+                class="flex min-w-36 grow items-center justify-between space-x-4"
               >
                 <div
-                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                  class="grow"
+                  data-testid="TransactionRowAddressing__address-container"
                 >
-                  <span
-                    class="font-semibold text-sm text-theme-text"
-                    data-testid="Address__alias"
-                  >
-                    <span
-                      class="no-ligatures transition-colors duration-200"
-                      data-testid="TruncateEnd"
-                    >
-                      ARK Wallet 1
-                    </span>
-                  </span>
                   <div
-                    class="relative grow leading-[17px] sm:leading-5 text-left"
+                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                   >
                     <span
-                      class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                      data-testid="Address__address"
+                      class="font-semibold text-sm text-theme-text"
+                      data-testid="Address__alias"
                     >
-                      D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                    </span>
-                    <span>
-                       
+                      <span
+                        class="no-ligatures transition-colors duration-200"
+                        data-testid="TruncateEnd"
+                      >
+                        ARK Wallet 1
+                      </span>
                     </span>
                   </div>
                 </div>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                  >
+                    <div
+                      style="height: 16px; width: 16px;"
+                    >
+                      <svg
+                        id="copy"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>
@@ -586,37 +796,67 @@ exports[`TransactionRow > should render 1`] = `
                 To
               </div>
               <div
-                class="grow"
-                data-testid="TransactionRowAddressing__address-container"
+                class="flex min-w-36 grow items-center justify-between space-x-4"
               >
                 <div
-                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                  class="grow"
+                  data-testid="TransactionRowAddressing__address-container"
                 >
-                  <span
-                    class="font-semibold text-sm text-theme-text"
-                    data-testid="Address__alias"
-                  >
-                    <span
-                      class="no-ligatures transition-colors duration-200"
-                      data-testid="TruncateEnd"
-                    >
-                      ARK Wallet 1
-                    </span>
-                  </span>
                   <div
-                    class="relative grow leading-[17px] sm:leading-5 text-left"
+                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                   >
                     <span
-                      class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                      data-testid="Address__address"
+                      class="font-semibold text-sm text-theme-text"
+                      data-testid="Address__alias"
                     >
-                      D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                    </span>
-                    <span>
-                       
+                      <span
+                        class="no-ligatures transition-colors duration-200"
+                        data-testid="TruncateEnd"
+                      >
+                        ARK Wallet 1
+                      </span>
                     </span>
                   </div>
                 </div>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                  >
+                    <div
+                      style="height: 16px; width: 16px;"
+                    >
+                      <svg
+                        id="copy"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>
@@ -759,37 +999,67 @@ exports[`TransactionRow > should render responsive 1`] = `
                         From
                       </div>
                       <div
-                        class="grow"
-                        data-testid="TransactionRowAddressing__address-container"
+                        class="flex min-w-36 grow items-center justify-between space-x-4"
                       >
                         <div
-                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                          class="grow"
+                          data-testid="TransactionRowAddressing__address-container"
                         >
-                          <span
-                            class="font-semibold text-sm text-theme-text"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures transition-colors duration-200"
-                              data-testid="TruncateEnd"
-                            >
-                              ARK Wallet 1
-                            </span>
-                          </span>
                           <div
-                            class="relative grow leading-[17px] sm:leading-5 text-left"
+                            class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                           >
                             <span
-                              class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                              data-testid="Address__address"
+                              class="font-semibold text-sm text-theme-text"
+                              data-testid="Address__alias"
                             >
-                              D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                            </span>
-                            <span>
-                               
+                              <span
+                                class="no-ligatures transition-colors duration-200"
+                                data-testid="TruncateEnd"
+                              >
+                                ARK Wallet 1
+                              </span>
                             </span>
                           </div>
                         </div>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                          >
+                            <div
+                              style="height: 16px; width: 16px;"
+                            >
+                              <svg
+                                id="copy"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
                       </div>
                     </div>
                     <div
@@ -803,37 +1073,67 @@ exports[`TransactionRow > should render responsive 1`] = `
                         To
                       </div>
                       <div
-                        class="grow"
-                        data-testid="TransactionRowAddressing__address-container"
+                        class="flex min-w-36 grow items-center justify-between space-x-4"
                       >
                         <div
-                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                          class="grow"
+                          data-testid="TransactionRowAddressing__address-container"
                         >
-                          <span
-                            class="font-semibold text-sm text-theme-text"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures transition-colors duration-200"
-                              data-testid="TruncateEnd"
-                            >
-                              ARK Wallet 1
-                            </span>
-                          </span>
                           <div
-                            class="relative grow leading-[17px] sm:leading-5 text-left"
+                            class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                           >
                             <span
-                              class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                              data-testid="Address__address"
+                              class="font-semibold text-sm text-theme-text"
+                              data-testid="Address__alias"
                             >
-                              D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                            </span>
-                            <span>
-                               
+                              <span
+                                class="no-ligatures transition-colors duration-200"
+                                data-testid="TruncateEnd"
+                              >
+                                ARK Wallet 1
+                              </span>
                             </span>
                           </div>
                         </div>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                          >
+                            <div
+                              style="height: 16px; width: 16px;"
+                            >
+                              <svg
+                                id="copy"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -977,37 +1277,67 @@ exports[`TransactionRow > should render responsive 2`] = `
                         From
                       </div>
                       <div
-                        class="grow"
-                        data-testid="TransactionRowAddressing__address-container"
+                        class="flex min-w-36 grow items-center justify-between space-x-4"
                       >
                         <div
-                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                          class="grow"
+                          data-testid="TransactionRowAddressing__address-container"
                         >
-                          <span
-                            class="font-semibold text-sm text-theme-text"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures transition-colors duration-200"
-                              data-testid="TruncateEnd"
-                            >
-                              ARK Wallet 1
-                            </span>
-                          </span>
                           <div
-                            class="relative grow leading-[17px] sm:leading-5 text-left"
+                            class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                           >
                             <span
-                              class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                              data-testid="Address__address"
+                              class="font-semibold text-sm text-theme-text"
+                              data-testid="Address__alias"
                             >
-                              D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                            </span>
-                            <span>
-                               
+                              <span
+                                class="no-ligatures transition-colors duration-200"
+                                data-testid="TruncateEnd"
+                              >
+                                ARK Wallet 1
+                              </span>
                             </span>
                           </div>
                         </div>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                          >
+                            <div
+                              style="height: 16px; width: 16px;"
+                            >
+                              <svg
+                                id="copy"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
                       </div>
                     </div>
                     <div
@@ -1021,37 +1351,67 @@ exports[`TransactionRow > should render responsive 2`] = `
                         To
                       </div>
                       <div
-                        class="grow"
-                        data-testid="TransactionRowAddressing__address-container"
+                        class="flex min-w-36 grow items-center justify-between space-x-4"
                       >
                         <div
-                          class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                          class="grow"
+                          data-testid="TransactionRowAddressing__address-container"
                         >
-                          <span
-                            class="font-semibold text-sm text-theme-text"
-                            data-testid="Address__alias"
-                          >
-                            <span
-                              class="no-ligatures transition-colors duration-200"
-                              data-testid="TruncateEnd"
-                            >
-                              ARK Wallet 1
-                            </span>
-                          </span>
                           <div
-                            class="relative grow leading-[17px] sm:leading-5 text-left"
+                            class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                           >
                             <span
-                              class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                              data-testid="Address__address"
+                              class="font-semibold text-sm text-theme-text"
+                              data-testid="Address__alias"
                             >
-                              D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                            </span>
-                            <span>
-                               
+                              <span
+                                class="no-ligatures transition-colors duration-200"
+                                data-testid="TruncateEnd"
+                              >
+                                ARK Wallet 1
+                              </span>
                             </span>
                           </div>
                         </div>
+                        <button
+                          class="ring-focus relative focus:outline-none"
+                          data-ring-focus-margin="-m-1"
+                          data-testid="clipboard-icon__wrapper"
+                          type="button"
+                        >
+                          <div
+                            class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                          >
+                            <div
+                              style="height: 16px; width: 16px;"
+                            >
+                              <svg
+                                id="copy"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
+                              >
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                >
+                                  <path
+                                    d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                                  />
+                                  <path
+                                    d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
+                          </div>
+                        </button>
                       </div>
                     </div>
                   </div>
@@ -1427,7 +1787,7 @@ exports[`TransactionRow > should render with currency 1`] = `
       >
         <td>
           <div
-            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 min-h-[66px] py-1 my-0 md-lg:min-h-14"
+            class="flex px-3 transition-colors duration-100 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 items-start pr-0 lg:pr-3 xl:min-h-11 xl:max-h-11 xl:pt-2.5 lg:min-w-36 min-h-[66px] py-1 my-0 md-lg:min-h-14"
           >
             <div
               class="flex flex-col gap-1 font-semibold"
@@ -1516,52 +1876,8 @@ exports[`TransactionRow > should render with currency 1`] = `
                   From
                 </div>
                 <div
-                  class="grow"
-                  data-testid="TransactionRowAddressing__address-container"
+                  class="flex min-w-36 grow items-center justify-between space-x-4"
                 >
-                  <div
-                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
-                  >
-                    <span
-                      class="font-semibold text-sm text-theme-text"
-                      data-testid="Address__alias"
-                    >
-                      <span
-                        class="no-ligatures transition-colors duration-200"
-                        data-testid="TruncateEnd"
-                      >
-                        ARK Wallet 1
-                      </span>
-                    </span>
-                    <div
-                      class="relative grow leading-[17px] sm:leading-5 text-left"
-                    >
-                      <span
-                        class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                        data-testid="Address__address"
-                      >
-                        D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                      </span>
-                      <span>
-                         
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="md-lg:hidden"
-              >
-                <div
-                  class="flex w-full flex-row gap-2"
-                  data-testid="TransactionRowAddressing__container_advanced_recipient"
-                >
-                  <div
-                    class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] !flex h-[21px] w-12 min-w-12 items-center justify-center rounded px-1 py-[3px] dark:border"
-                    data-testid="TransactionRowAddressing__label"
-                  >
-                    To
-                  </div>
                   <div
                     class="grow"
                     data-testid="TransactionRowAddressing__address-container"
@@ -1580,20 +1896,124 @@ exports[`TransactionRow > should render with currency 1`] = `
                           ARK Wallet 1
                         </span>
                       </span>
+                    </div>
+                  </div>
+                  <button
+                    class="ring-focus relative focus:outline-none"
+                    data-ring-focus-margin="-m-1"
+                    data-testid="clipboard-icon__wrapper"
+                    type="button"
+                  >
+                    <div
+                      class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                    >
                       <div
-                        class="relative grow leading-[17px] sm:leading-5 text-left"
+                        style="height: 16px; width: 16px;"
+                      >
+                        <svg
+                          id="copy"
+                          style="height: 100%; width: 100%;"
+                          viewBox="0 0 20 20"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <g
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          >
+                            <path
+                              d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                            />
+                            <path
+                              d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                            />
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="md-lg:hidden"
+              >
+                <div
+                  class="flex w-full flex-row gap-2"
+                  data-testid="TransactionRowAddressing__container_advanced_recipient"
+                >
+                  <div
+                    class="inline-block font-semibold overflow-hidden no-ligatures text-theme-secondary-700 bg-theme-secondary-200 border-theme-secondary-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:bg-transparent group-hover:bg-theme-secondary-300 dark:group-hover:bg-transparent text-xs leading-[15px] !flex h-[21px] w-12 min-w-12 items-center justify-center rounded px-1 py-[3px] dark:border"
+                    data-testid="TransactionRowAddressing__label"
+                  >
+                    To
+                  </div>
+                  <div
+                    class="flex min-w-36 grow items-center justify-between space-x-4"
+                  >
+                    <div
+                      class="grow"
+                      data-testid="TransactionRowAddressing__address-container"
+                    >
+                      <div
+                        class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                       >
                         <span
-                          class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                          data-testid="Address__address"
+                          class="font-semibold text-sm text-theme-text"
+                          data-testid="Address__alias"
                         >
-                          D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                        </span>
-                        <span>
-                           
+                          <span
+                            class="no-ligatures transition-colors duration-200"
+                            data-testid="TruncateEnd"
+                          >
+                            ARK Wallet 1
+                          </span>
                         </span>
                       </div>
                     </div>
+                    <button
+                      class="ring-focus relative focus:outline-none"
+                      data-ring-focus-margin="-m-1"
+                      data-testid="clipboard-icon__wrapper"
+                      type="button"
+                    >
+                      <div
+                        class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                      >
+                        <div
+                          style="height: 16px; width: 16px;"
+                        >
+                          <svg
+                            id="copy"
+                            style="height: 100%; width: 100%;"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
+                          >
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            >
+                              <path
+                                d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                              />
+                              <path
+                                d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                              />
+                            </g>
+                          </svg>
+                        </div>
+                      </div>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1604,7 +2024,7 @@ exports[`TransactionRow > should render with currency 1`] = `
           class="hidden md-lg:table-cell"
         >
           <div
-            class="flex transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11 min-h-16 my-1 py-2"
+            class="flex transition-colors duration-100 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-secondary-200 space-x-4 items-start px-0 lg:px-3 xl:pt-3 xl:min-h-11 min-h-16 my-1 py-2 lg:min-w-36"
           >
             <div
               class="flex w-full flex-row gap-2"
@@ -1617,37 +2037,67 @@ exports[`TransactionRow > should render with currency 1`] = `
                 To
               </div>
               <div
-                class="grow"
-                data-testid="TransactionRowAddressing__address-container"
+                class="flex min-w-36 grow items-center justify-between space-x-4"
               >
                 <div
-                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                  class="grow"
+                  data-testid="TransactionRowAddressing__address-container"
                 >
-                  <span
-                    class="font-semibold text-sm text-theme-text"
-                    data-testid="Address__alias"
-                  >
-                    <span
-                      class="no-ligatures transition-colors duration-200"
-                      data-testid="TruncateEnd"
-                    >
-                      ARK Wallet 1
-                    </span>
-                  </span>
                   <div
-                    class="relative grow leading-[17px] sm:leading-5 text-left"
+                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                   >
                     <span
-                      class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                      data-testid="Address__address"
+                      class="font-semibold text-sm text-theme-text"
+                      data-testid="Address__alias"
                     >
-                      D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                    </span>
-                    <span>
-                       
+                      <span
+                        class="no-ligatures transition-colors duration-200"
+                        data-testid="TruncateEnd"
+                      >
+                        ARK Wallet 1
+                      </span>
                     </span>
                   </div>
                 </div>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                  >
+                    <div
+                      style="height: 16px; width: 16px;"
+                    >
+                      <svg
+                        id="copy"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>
@@ -1669,37 +2119,67 @@ exports[`TransactionRow > should render with currency 1`] = `
                 To
               </div>
               <div
-                class="grow"
-                data-testid="TransactionRowAddressing__address-container"
+                class="flex min-w-36 grow items-center justify-between space-x-4"
               >
                 <div
-                  class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
+                  class="grow"
+                  data-testid="TransactionRowAddressing__address-container"
                 >
-                  <span
-                    class="font-semibold text-sm text-theme-text"
-                    data-testid="Address__alias"
-                  >
-                    <span
-                      class="no-ligatures transition-colors duration-200"
-                      data-testid="TruncateEnd"
-                    >
-                      ARK Wallet 1
-                    </span>
-                  </span>
                   <div
-                    class="relative grow leading-[17px] sm:leading-5 text-left"
+                    class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
                   >
                     <span
-                      class="no-ligatures min-w-0 overflow-hidden text-theme-secondary-700 dark:text-theme-secondary-500 font-semibold text-sm absolute w-full"
-                      data-testid="Address__address"
+                      class="font-semibold text-sm text-theme-text"
+                      data-testid="Address__alias"
                     >
-                      D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD
-                    </span>
-                    <span>
-                       
+                      <span
+                        class="no-ligatures transition-colors duration-200"
+                        data-testid="TruncateEnd"
+                      >
+                        ARK Wallet 1
+                      </span>
                     </span>
                   </div>
                 </div>
+                <button
+                  class="ring-focus relative focus:outline-none"
+                  data-ring-focus-margin="-m-1"
+                  data-testid="clipboard-icon__wrapper"
+                  type="button"
+                >
+                  <div
+                    class="text-theme-secondary-700 hover:text-theme-primary-700 dark:text-theme-secondary-600 dark:hover:text-white"
+                  >
+                    <div
+                      style="height: 16px; width: 16px;"
+                    >
+                      <svg
+                        id="copy"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                      >
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                        >
+                          <path
+                            d="M7 17.765C7 18.485 7.496 19 8.09 19h-.099 8.82c.694 0 1.189-.618 1.189-1.235V6.235C18 5.515 17.405 5 16.81 5h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C7 8.09 7 8.397 7 8.706v9.059z"
+                          />
+                          <path
+                            d="M13 5V2.235C13 1.515 12.405 1 11.81 1h0-6.242c-.298 0-.595.103-.892.309l-2.379 2.47C2 4.09 2 4.397 2 4.706v9.059C2 14.485 2.496 15 3.09 15h-.099H7"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>

--- a/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
@@ -46,8 +46,8 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			{
 				Header: `${t("COMMON.AMOUNT")} ${coinLabel}`,
 				accessor: (transaction) => transaction.total?.(),
-				className: "justify-end",
 				cellWidth: "lg:min-w-24 xl:min-w-32",
+				className: "justify-end",
 				headerClassName: "no-border whitespace-nowrap",
 				id: "amount",
 			},

--- a/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionTable.helpers.tsx
@@ -27,7 +27,7 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 			},
 			{
 				Header: t("COMMON.METHOD"),
-				cellWidth: "w-40 lg:w-24",
+				cellWidth: "w-40 lg:w-24 lg:min-w-24 xl:min-w-32",
 				headerClassName: "no-border",
 			},
 			{
@@ -47,13 +47,13 @@ export const useTransactionTableColumns = ({ coin, hideSender }: { coin?: string
 				Header: `${t("COMMON.AMOUNT")} ${coinLabel}`,
 				accessor: (transaction) => transaction.total?.(),
 				className: "justify-end",
+				cellWidth: "lg:min-w-24 xl:min-w-32",
 				headerClassName: "no-border whitespace-nowrap",
 				id: "amount",
 			},
 			{
 				Header: t("COMMON.FIAT_VALUE"),
 				accessor: () => "fiatValue",
-				cellWidth: "w-36",
 				className: "justify-end",
 				headerClassName: `no-border whitespace-nowrap hidden lg:table-cell ${hideSender ? "" : "!pl-0 xl:min-w-28"}`,
 				noRoundedBorders: true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx table] no space for from/to](https://app.clickup.com/t/86dvxqp91)

## Summary

- Spacing in the transactions table has been fixed to prevent overlays between the columns in desktop views when a single wallet is selected.

## Screenshots

- 960px:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/22dfec4c-b88c-4da2-b3c5-13e391b2002d" />

- 1024px:
<img width="983" alt="image" src="https://github.com/user-attachments/assets/4e935f2a-f632-4fbc-aa09-e1da751cee03" />

- 1280px:
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/3a825454-e00b-4913-9b43-c74b4e8eddc6" />

- +1300px:
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/3616338e-c921-4f4f-b3ed-fc01e24d202b" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
