### PR TITLE
refactor: sidepanel blur effect

### DIFF
--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -68,8 +68,10 @@ export const SidePanel = ({
 		<>
 			<FloatingPortal>
 				{isMounted && (
+					<>
+					<div className="fixed inset-0 z-40 backdrop-blur-xl bg-[#212225] bg-opacity-10 dark:bg-[#101627] dark:bg-opacity-10" />
 					<FloatingOverlay
-						className="z-50 bg-theme-secondary-900-rgba/40 transition-opacity duration-300 dark:bg-black-rgba/40 dark:bg-opacity-80"
+						className="z-50 transition-opacity duration-300"
 						lockScroll
 					>
 						<FloatingFocusManager context={context}>
@@ -107,6 +109,7 @@ export const SidePanel = ({
 							</div>
 						</FloatingFocusManager>
 					</FloatingOverlay>
+					</>
 				)}
 			</FloatingPortal>
 		</>

--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -69,46 +69,43 @@ export const SidePanel = ({
 			<FloatingPortal>
 				{isMounted && (
 					<>
-					<div className="fixed inset-0 z-40 backdrop-blur-xl bg-[#212225] bg-opacity-10 dark:bg-[#101627] dark:bg-opacity-10" />
-					<FloatingOverlay
-						className="z-50 transition-opacity duration-300"
-						lockScroll
-					>
-						<FloatingFocusManager context={context}>
-							<div
-								data-testid={dataTestId}
-								className="Dialog"
-								ref={refs.setFloating}
-								{...getFloatingProps()}
-							>
-								<div style={{ ...styles }} className={cn("fixed right-0 top-0", className)}>
-									<div className="custom-scroll h-screen w-full overflow-y-scroll bg-theme-background p-4 text-theme-text shadow-[0_15px_35px_0px_rgba(33,34,37,0.08)] sm:p-6 md:w-[608px] md:p-8">
-										<div className="relative mb-4 flex items-start justify-between">
-											{typeof header === "string" ? (
-												<h2 className="mb-0 text-lg font-bold md:pt-0 md:text-2xl md:leading-[29px]">
-													{header}
-												</h2>
-											) : (
-												<>{header}</>
-											)}
-											<div className="h-8 w-8 rounded bg-theme-primary-100 transition-all duration-100 ease-linear hover:bg-theme-primary-800 hover:text-white dark:bg-theme-secondary-800 dark:text-theme-secondary-200 dark:hover:bg-theme-primary-500 dark:hover:text-white">
-												<Button
-													data-testid="SidePanel__close-button"
-													variant="transparent"
-													size="icon"
-													onClick={() => onOpenChange(false)}
-													className="h-8 w-8"
-												>
-													<Icon name="Cross" />
-												</Button>
+						<div className="fixed inset-0 z-40 bg-[#212225] bg-opacity-10 backdrop-blur-xl dark:bg-[#101627] dark:bg-opacity-10" />
+						<FloatingOverlay className="z-50 transition-opacity duration-300" lockScroll>
+							<FloatingFocusManager context={context}>
+								<div
+									data-testid={dataTestId}
+									className="Dialog"
+									ref={refs.setFloating}
+									{...getFloatingProps()}
+								>
+									<div style={{ ...styles }} className={cn("fixed right-0 top-0", className)}>
+										<div className="custom-scroll h-screen w-full overflow-y-scroll bg-theme-background p-4 text-theme-text shadow-[0_15px_35px_0px_rgba(33,34,37,0.08)] sm:p-6 md:w-[608px] md:p-8">
+											<div className="relative mb-4 flex items-start justify-between">
+												{typeof header === "string" ? (
+													<h2 className="mb-0 text-lg font-bold md:pt-0 md:text-2xl md:leading-[29px]">
+														{header}
+													</h2>
+												) : (
+													<>{header}</>
+												)}
+												<div className="h-8 w-8 rounded bg-theme-primary-100 transition-all duration-100 ease-linear hover:bg-theme-primary-800 hover:text-white dark:bg-theme-secondary-800 dark:text-theme-secondary-200 dark:hover:bg-theme-primary-500 dark:hover:text-white">
+													<Button
+														data-testid="SidePanel__close-button"
+														variant="transparent"
+														size="icon"
+														onClick={() => onOpenChange(false)}
+														className="h-8 w-8"
+													>
+														<Icon name="Cross" />
+													</Button>
+												</div>
 											</div>
+											<div>{children}</div>
 										</div>
-										<div>{children}</div>
 									</div>
 								</div>
-							</div>
-						</FloatingFocusManager>
-					</FloatingOverlay>
+							</FloatingFocusManager>
+						</FloatingOverlay>
 					</>
 				)}
 			</FloatingPortal>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] blur background more when side panel is open](https://app.clickup.com/t/86dw480pn)

## Summary

- Backdrop blur of 24px has been added to the overlay container in side panels to match the designs.

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/8de4d7bf-1197-4b5f-927a-0eeadffd0294" />

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/73272c44-b4a4-44e5-bc0c-330950267d43" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
