### PR TITLE
refactor: move toast position to bottom left

### DIFF
--- a/src/app/services/ToastService.tsx
+++ b/src/app/services/ToastService.tsx
@@ -58,7 +58,7 @@ export class ToastService {
 		closeButton: false,
 		hideProgressBar: true,
 		pauseOnFocusLoss: true,
-		position: "bottom-center",
+		position: "bottom-left",
 	};
 
 	public options() {

--- a/src/app/services/ToastService.tsx
+++ b/src/app/services/ToastService.tsx
@@ -58,7 +58,7 @@ export class ToastService {
 		closeButton: false,
 		hideProgressBar: true,
 		pauseOnFocusLoss: true,
-		position: "bottom-right",
+		position: "bottom-center",
 	};
 
 	public options() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] centre toast messages](https://app.clickup.com/t/86dw34293)

## Summary

- Toast messages have been centered so it can be reviewed to see how it looks and feels.



## Screenshots

![image](https://github.com/user-attachments/assets/586cb2ac-ad19-4645-8ef6-f2cf8459725b)

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/5c8b7d24-a400-4d36-aa60-08307fd3dfee" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
