### PR TITLE
refactor: improve import flow

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -94,12 +94,12 @@ export const ImportAddressesSidePanel = ({
 	const forgetImportedWallets = (importedWallet?: Contracts.IReadWriteWallet) => {
 		assertWallet(importedWallet);
 
-		for(const profileWallet of activeProfile.wallets().values()) {
+		for (const profileWallet of activeProfile.wallets().values()) {
 			if (profileWallet.address() === importedWallet.address()) {
 				activeProfile.wallets().forget(profileWallet.id());
 			}
 		}
-	}
+	};
 
 	const handleOpenChange = (open: boolean) => {
 		// remove added wallets if side panel is closed early
@@ -107,7 +107,7 @@ export const ImportAddressesSidePanel = ({
 			forgetImportedWallets(importedWallet);
 		}
 		onOpenChange(open);
-	}
+	};
 
 	const handleNext = () =>
 		({

--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -91,6 +91,24 @@ export const ImportAddressesSidePanel = ({
 		}
 	});
 
+	const forgetImportedWallets = (importedWallet?: Contracts.IReadWriteWallet) => {
+		assertWallet(importedWallet);
+
+		for(const profileWallet of activeProfile.wallets().values()) {
+			if (profileWallet.address() === importedWallet.address()) {
+				activeProfile.wallets().forget(profileWallet.id());
+			}
+		}
+	}
+
+	const handleOpenChange = (open: boolean) => {
+		// remove added wallets if side panel is closed early
+		if (!open && activeTab !== Step.SummaryStep && importedWallet) {
+			forgetImportedWallets(importedWallet);
+		}
+		onOpenChange(open);
+	}
+
 	const handleNext = () =>
 		({
 			// eslint-disable-next-line @typescript-eslint/require-await
@@ -131,8 +149,7 @@ export const ImportAddressesSidePanel = ({
 		}
 
 		if (activeTab === Step.EncryptPasswordStep) {
-			assertWallet(importedWallet);
-			activeProfile.wallets().forget(importedWallet.id());
+			forgetImportedWallets(importedWallet);
 		}
 
 		setActiveTab(activeTab - 1);
@@ -155,10 +172,10 @@ export const ImportAddressesSidePanel = ({
 		assertWallet(importedWallet);
 		assertString(walletGenerationInput);
 
-		importedWallet.signingKey().set(walletGenerationInput, encryptionPassword);
+		await importedWallet.signingKey().set(walletGenerationInput, encryptionPassword);
 
 		if (secondInput) {
-			importedWallet.confirmKey().set(secondInput, encryptionPassword);
+			await importedWallet.confirmKey().set(secondInput, encryptionPassword);
 		}
 
 		if (importedWallet.actsWithMnemonic()) {
@@ -216,7 +233,7 @@ export const ImportAddressesSidePanel = ({
 		<SidePanel
 			header={<StepHeader step={activeTab} importOption={importOption} />}
 			open={open}
-			onOpenChange={onOpenChange}
+			onOpenChange={handleOpenChange}
 			dataTestId="ImportAddressSidePanel"
 		>
 			<Form context={form} onSubmit={handleFinish} data-testid="ImportWallet__form">

--- a/src/domains/portfolio/components/ImportWallet/ImportDetailStep.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportDetailStep.tsx
@@ -2,7 +2,7 @@ import { Coins, Networks } from "@ardenthq/sdk";
 import { truncate } from "@ardenthq/sdk-helpers";
 import { Contracts } from "@ardenthq/sdk-profiles";
 import { TFunction } from "i18next";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -297,7 +297,7 @@ const ImportInputField = ({
 
 export const ImportDetailStep = ({ profile, network }: { profile: Contracts.IProfile; network: Networks.Network }) => {
 	const { t } = useTranslation();
-	const { watch, setValue, getValues } = useFormContext();
+	const { watch, setValue, getValues, clearErrors } = useFormContext();
 
 	const [coin] = useState(() => profile.coins().get(network.coin(), network.id()));
 
@@ -305,6 +305,10 @@ export const ImportDetailStep = ({ profile, network }: { profile: Contracts.IPro
 	const importOption = getValues("importOption") as ImportOption;
 
 	assertString(importOption.value);
+
+	useEffect(() => {
+		clearErrors(["validation", "confirmEncryptionPassword"]);
+	}, []);
 
 	const handleToggleEncryption = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setValue("useEncryption", event.target.checked);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dw5xcwe

This PR improves the import flow, changes are:

Removes added wallets when:
 - user navigates back to the enter mnemonic step from the enter password step
 - user closes sidebar early

and fixes the original issue: it handles the case when user enters an invalid password and then navigates back to the enter mnemonic screen


[Screencast from 2025-03-07 18-43-25.webm](https://github.com/user-attachments/assets/fce3c9e8-de6e-4f89-aa1f-4f40e0ed899c)



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
