### PR TITLE
refactor: move fee input to review step for transfer transactions

### DIFF
--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -94,7 +94,7 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 		watch();
 	const { sendTransfer } = useValidation();
 
-	const fee = calculateGasFee(gasPrice ?? 5, gasLimit ?? GasLimit['transfer']);
+	const fee = calculateGasFee(gasPrice ?? 5, gasLimit ?? GasLimit["transfer"]);
 
 	const ticker = network?.ticker();
 	const exchangeTicker = profile.settings().get<string>(Contracts.ProfileSetting.ExchangeCurrency) as string;

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -21,7 +21,7 @@ import { SelectRecipient } from "@/domains/profile/components/SelectRecipient";
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
 import { twMerge } from "tailwind-merge";
 import { calculateGasFee } from "@/domains/transaction/components/InputFee/InputFee";
-import { GasLimit } from "@/domains/transaction/components/FeeField/FeeField";
+import { GasLimit, MIN_GAS_PRICE } from "@/domains/transaction/components/FeeField/FeeField";
 
 const TransferType = ({ isSingle, disableMultiple, onChange, maxRecipients }: ToggleButtonProperties) => {
 	const { t } = useTranslation();
@@ -94,7 +94,7 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 		watch();
 	const { sendTransfer } = useValidation();
 
-	const fee = calculateGasFee(gasPrice ?? 5, gasLimit ?? GasLimit["transfer"]);
+	const fee = calculateGasFee(gasPrice ?? MIN_GAS_PRICE, gasLimit ?? GasLimit["transfer"]);
 
 	const ticker = network?.ticker();
 	const exchangeTicker = profile.settings().get<string>(Contracts.ProfileSetting.ExchangeCurrency) as string;

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -21,6 +21,7 @@ import { SelectRecipient } from "@/domains/profile/components/SelectRecipient";
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
 import { twMerge } from "tailwind-merge";
 import { calculateGasFee } from "@/domains/transaction/components/InputFee/InputFee";
+import { GasLimit } from "@/domains/transaction/components/FeeField/FeeField";
 
 const TransferType = ({ isSingle, disableMultiple, onChange, maxRecipients }: ToggleButtonProperties) => {
 	const { t } = useTranslation();
@@ -93,7 +94,7 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 		watch();
 	const { sendTransfer } = useValidation();
 
-	const fee = calculateGasFee(gasPrice, gasLimit);
+	const fee = calculateGasFee(gasPrice ?? 5, gasLimit ?? GasLimit['transfer']);
 
 	const ticker = network?.ticker();
 	const exchangeTicker = profile.settings().get<string>(Contracts.ProfileSetting.ExchangeCurrency) as string;

--- a/src/domains/transaction/pages/SendTransfer/FormStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/FormStep.tsx
@@ -1,6 +1,6 @@
 import { Enums, Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
-import React from "react";
+import React, { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -45,7 +45,11 @@ export const FormStep = ({
 
 	const { isXs } = useBreakpoint();
 
-	const { setValue, getValues } = useFormContext();
+	const { setValue, getValues, unregister } = useFormContext();
+
+	useEffect(() => {
+		unregister(["gasLimit", "gasPrice"]);
+	}, [unregister]);
 
 	const { recipients } = getValues();
 

--- a/src/domains/transaction/pages/SendTransfer/FormStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/FormStep.tsx
@@ -1,17 +1,14 @@
 import { Enums, Networks } from "@ardenthq/sdk";
 import { Contracts } from "@ardenthq/sdk-profiles";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
-import { getFeeType } from "./utils";
 import { FormField, FormLabel } from "@/app/components/Form";
 import { useBreakpoint } from "@/app/hooks";
 import { SelectAddress } from "@/domains/profile/components/SelectAddress";
 import { AddRecipient } from "@/domains/transaction/components/AddRecipient";
-import { FeeField } from "@/domains/transaction/components/FeeField";
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
-import { buildTransferData } from "@/domains/transaction/pages/SendTransfer/SendTransfer.helpers";
 import { StepHeader } from "@/app/components/StepHeader";
 import { ThemeIcon, Icon } from "@/app/components/Icon";
 import { Button } from "@/app/components/Button";

--- a/src/domains/transaction/pages/SendTransfer/FormStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/FormStep.tsx
@@ -44,43 +44,15 @@ export const FormStep = ({
 	onScan?: () => void;
 	onChange?: ({ sender }: { sender?: Contracts.IReadWriteWallet }) => void;
 }) => {
-	const isMounted = useRef(true);
-
 	const { t } = useTranslation();
 
 	const { isXs } = useBreakpoint();
 
-	const { getValues, setValue } = useFormContext();
+	const { setValue, getValues } = useFormContext();
+
 	const { recipients } = getValues();
 
 	const { allWallets } = usePortfolio({ profile });
-
-	const [feeTransactionData, setFeeTransactionData] = useState<Record<string, any> | undefined>();
-
-	const coin = profile.coins().get(network.coin(), network.id());
-	useEffect(() => {
-		const updateFeeTransactionData = async () => {
-			const transferData = await buildTransferData({
-				coin,
-				recipients,
-			});
-
-			/* istanbul ignore next -- @preserve */
-			if (isMounted.current) {
-				setFeeTransactionData(transferData);
-			}
-		};
-
-		updateFeeTransactionData();
-	}, [recipients, coin]);
-
-	useEffect(
-		/* istanbul ignore next -- @preserve */
-		() => () => {
-			isMounted.current = false;
-		},
-		[],
-	);
 
 	const getRecipients = (): RecipientItem[] => {
 		if (deeplinkProps.recipient && deeplinkProps.amount) {
@@ -110,8 +82,6 @@ export const FormStep = ({
 			sender,
 		});
 	};
-
-	const showFeeInput = useMemo(() => !network.chargesZeroFees(), [network]);
 
 	return (
 		<section data-testid="SendTransfer__form-step">
@@ -189,20 +159,6 @@ export const FormStep = ({
 						wallet={senderWallet}
 					/>
 				</div>
-
-				{showFeeInput && (
-					<FormField name="fee" disableStateHints>
-						<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
-						{!!network && (
-							<FeeField
-								type={getFeeType(recipients?.length)}
-								data={feeTransactionData}
-								network={network}
-								profile={profile}
-							/>
-						)}
-					</FormField>
-				)}
 			</div>
 		</section>
 	);

--- a/src/domains/transaction/pages/SendTransfer/ReviewStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/ReviewStep.tsx
@@ -24,7 +24,7 @@ interface ReviewStepProperties {
 export const ReviewStep: React.VFC<ReviewStepProperties> = ({ wallet, network }) => {
 	const { t } = useTranslation();
 
-	const { unregister, watch, } = useFormContext();
+	const { unregister, watch } = useFormContext();
 	const { recipients } = watch();
 	const profile = useActiveProfile();
 
@@ -88,10 +88,7 @@ export const ReviewStep: React.VFC<ReviewStepProperties> = ({ wallet, network })
 
 				<div className="space-y-3 sm:space-y-2">
 					<div className="mx-3 sm:mx-0">
-						<DetailWrapper
-							label={t("COMMON.TRANSACTION_SUMMARY")}
-							className="rounded-xl"
-						>
+						<DetailWrapper label={t("COMMON.TRANSACTION_SUMMARY")} className="rounded-xl">
 							<div className="flex flex-col gap-3">
 								<div
 									className="flex items-center justify-between space-x-2 sm:justify-start sm:space-x-0"
@@ -113,7 +110,6 @@ export const ReviewStep: React.VFC<ReviewStepProperties> = ({ wallet, network })
 						</DetailWrapper>
 					</div>
 				</div>
-
 
 				{showFeeInput && (
 					<FormField name="fee" disableStateHints>

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -319,7 +319,7 @@ export const SendTransfer = () => {
 			</TabPanel>
 
 			<TabPanel tabId={SendTransferStep.ReviewStep}>
-				<ReviewStep wallet={wallet!} />
+				<ReviewStep wallet={wallet!} network={activeNetwork} />
 			</TabPanel>
 
 			<TabPanel tabId={SendTransferStep.AuthenticationStep}>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
As a part of: https://app.clickup.com/t/86dw6qy8m

This PR moves fee options to the review step for transfer tx, also adjusts `Send All` button to deduct `5*21_000` before setting amount.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
