### PR TITLE
fix: ios sidepanel click

### DIFF
--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -40,7 +40,7 @@ export const SidePanel = ({
 	const role = useRole(context);
 	const dismiss = useDismiss(context, {
 		outsidePress: (event) => !(event.target as HTMLElement).closest(".Toastify"),
-		outsidePressEvent: "mousedown",
+		outsidePressEvent: "pointerdown",
 	});
 
 	const { getFloatingProps } = useInteractions([click, role, dismiss]);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] sliders close when selecting an input on iOS](https://app.clickup.com/t/86dw7796c)

## Summary

- Mouse action to close the slide menus has been changed from `mousedown` to `pointerdown` to prevent the side panels from closing while using them on iOS devices.

https://github.com/user-attachments/assets/c5cd7189-43fb-449b-9297-76ae851745f8


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
