### PR TITLE
refactor: transactions pages width increase

### DIFF
--- a/src/domains/message/pages/SignMessage/SignMessage.tsx
+++ b/src/domains/message/pages/SignMessage/SignMessage.tsx
@@ -161,7 +161,7 @@ export const SignMessage: React.VFC = () => {
 	return (
 		<Page pageTitle={t("MESSAGE.PAGE_SIGN_MESSAGE.TITLE")}>
 			<Section className="flex-1">
-				<Form className="mx-auto max-w-xl" data-testid="SignMessage" context={form} onSubmit={submitForm}>
+				<Form className="mx-auto max-w-172" data-testid="SignMessage" context={form} onSubmit={submitForm}>
 					<Tabs activeId={activeTab}>
 						<StepsProvider steps={selectedWallet?.isLedger() ? 3 : 2} activeStep={activeTab}>
 							<TabPanel tabId={Step.FormStep}>

--- a/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -708,7 +708,7 @@ exports[`SignMessage > Sign with Wallet > should render (lg) 1`] = `
           class="mx-auto px-6 lg:container md:px-10"
         >
           <form
-            class="mx-auto max-w-xl"
+            class="mx-auto max-w-172"
             data-testid="SignMessage"
           >
             <div>
@@ -1811,7 +1811,7 @@ exports[`SignMessage > Sign with Wallet > should render (xs) 1`] = `
           class="mx-auto px-6 lg:container md:px-10"
         >
           <form
-            class="mx-auto max-w-xl"
+            class="mx-auto max-w-172"
             data-testid="SignMessage"
           >
             <div>

--- a/src/domains/message/pages/VerifyMessage/VerifyMessage.tsx
+++ b/src/domains/message/pages/VerifyMessage/VerifyMessage.tsx
@@ -154,7 +154,7 @@ export const VerifyMessage = () => {
 	return (
 		<Page pageTitle={t("MESSAGE.PAGE_VERIFY_MESSAGE.TITLE")}>
 			<Section className="flex-1">
-				<Form className="mx-auto max-w-xl" data-testid="VerifyMessage" context={form} onSubmit={submitForm}>
+				<Form className="mx-auto max-w-172" data-testid="VerifyMessage" context={form} onSubmit={submitForm}>
 					<Tabs activeId={activeTab}>
 						<StepsProvider steps={2} activeStep={activeTab}>
 							<TabPanel tabId={Step.FormStep}>

--- a/src/domains/message/pages/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/message/pages/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -708,7 +708,7 @@ exports[`VerifyMessage > should render (lg) 1`] = `
           class="mx-auto px-6 lg:container md:px-10"
         >
           <form
-            class="mx-auto max-w-xl"
+            class="mx-auto max-w-172"
             data-testid="VerifyMessage"
           >
             <div>
@@ -1706,7 +1706,7 @@ exports[`VerifyMessage > should render (xs) 1`] = `
           class="mx-auto px-6 lg:container md:px-10"
         >
           <form
-            class="mx-auto max-w-xl"
+            class="mx-auto max-w-172"
             data-testid="VerifyMessage"
           >
             <div>

--- a/src/domains/transaction/pages/SendRegistration/SendRegistration.tsx
+++ b/src/domains/transaction/pages/SendRegistration/SendRegistration.tsx
@@ -250,7 +250,7 @@ export const SendRegistration = () => {
 				<StepsProvider steps={stepCount} activeStep={activeTab}>
 					<Form
 						data-testid="Registration__form"
-						className="mx-auto max-w-xl"
+						className="mx-auto max-w-172"
 						context={form}
 						onSubmit={handleSubmit}
 					>

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -388,7 +388,7 @@ export const SendTransfer = () => {
 	return (
 		<Page pageTitle={t("TRANSACTION.TRANSACTION_TYPES.TRANSFER")}>
 			<Section className="flex-1">
-				<Form className="mx-auto max-w-34" context={form}>
+				<Form className="mx-auto max-w-172" context={form}>
 					<Tabs activeId={activeTab}>{renderTabs()}</Tabs>
 
 					<QRModal

--- a/src/domains/transaction/pages/SendUsernameResignation/SendUsernameResignation.tsx
+++ b/src/domains/transaction/pages/SendUsernameResignation/SendUsernameResignation.tsx
@@ -156,7 +156,7 @@ export const SendUsernameResignation = () => {
 		<Page pageTitle={t("TRANSACTION.TRANSACTION_TYPES.USERNAME_RESIGNATION")}>
 			<Section className="flex-1">
 				<StepsProvider steps={4} activeStep={activeTab}>
-					<Form className="mx-auto max-w-xl" context={form} onSubmit={handleSubmit}>
+					<Form className="mx-auto max-w-172" context={form} onSubmit={handleSubmit}>
 						<Tabs activeId={activeTab}>
 							<TabPanel tabId={Step.FormStep}>
 								<FormStep

--- a/src/domains/transaction/pages/SendValidatorResignation/SendValidatorResignation.tsx
+++ b/src/domains/transaction/pages/SendValidatorResignation/SendValidatorResignation.tsx
@@ -156,7 +156,7 @@ export const SendValidatorResignation = () => {
 		<Page pageTitle={t("TRANSACTION.TRANSACTION_TYPES.VALIDATOR_RESIGNATION")}>
 			<Section className="flex-1">
 				<StepsProvider steps={4} activeStep={activeTab}>
-					<Form className="mx-auto max-w-xl" context={form} onSubmit={handleSubmit}>
+					<Form className="mx-auto max-w-172" context={form} onSubmit={handleSubmit}>
 						<Tabs activeId={activeTab}>
 							<TabPanel tabId={Step.FormStep}>
 								<FormStep

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -447,7 +447,7 @@ export const SendVote = () => {
 		<Page pageTitle={t("TRANSACTION.TRANSACTION_TYPES.VOTE")}>
 			<Section className="flex-1">
 				<StepsProvider activeStep={activeTab} steps={4}>
-					<Form className="mx-auto max-w-xl" context={form} onSubmit={submitForm}>
+					<Form className="mx-auto max-w-172" context={form} onSubmit={submitForm}>
 						<Tabs activeId={activeTab}>
 							<TabPanel tabId={Step.FormStep}>
 								<FormStep

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -230,6 +230,7 @@ module.exports = {
 				72: "18rem",
 				88: "22rem",
 				128: "32rem",
+				172: "43rem"
 			},
 			maxHeight: {
 				"17e": "4.25em",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -230,7 +230,7 @@ module.exports = {
 				72: "18rem",
 				88: "22rem",
 				128: "32rem",
-				172: "43rem"
+				172: "43rem",
 			},
 			maxHeight: {
 				"17e": "4.25em",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] transaction pages width increase](https://app.clickup.com/t/86dw76wah)

## Summary

- A new value in tailwind config has been added for max width: `172` (43rem).
- The max width for the forms, review, authentication, pending and confirmed steps for the following transaction types has been updated from `576px` to `688px`:
   - Transfer
   - Vote
   - Sign/Verify message
   - Username registration



<img width="1364" alt="image" src="https://github.com/user-attachments/assets/3a24ef3f-742c-4cc3-a244-934fe12fc29a" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
