### PR TITLE
refactor: input password icon color

### DIFF
--- a/src/app/components/Input/InputPassword.tsx
+++ b/src/app/components/Input/InputPassword.tsx
@@ -25,7 +25,11 @@ export const InputPassword = React.forwardRef<HTMLInputElement, InputPasswordPro
 							className="ring-focus relative flex h-full w-full items-center justify-center text-2xl focus:outline-none"
 							data-ring-focus-margin="-m-1"
 						>
-							<Icon name={show ? "EyeSlash" : "Eye"} size="lg" className="text-theme-secondary-700 dark:text-theme-dark-200" />
+							<Icon
+								name={show ? "EyeSlash" : "Eye"}
+								size="lg"
+								className="text-theme-secondary-700 dark:text-theme-dark-200"
+							/>
 						</button>
 					),
 				},

--- a/src/app/components/Input/InputPassword.tsx
+++ b/src/app/components/Input/InputPassword.tsx
@@ -25,7 +25,7 @@ export const InputPassword = React.forwardRef<HTMLInputElement, InputPasswordPro
 							className="ring-focus relative flex h-full w-full items-center justify-center text-2xl focus:outline-none"
 							data-ring-focus-margin="-m-1"
 						>
-							<Icon name={show ? "EyeSlash" : "Eye"} size="lg" />
+							<Icon name={show ? "EyeSlash" : "Eye"} size="lg" className="text-theme-secondary-700 dark:text-theme-dark-200" />
 						</button>
 					),
 				},

--- a/src/app/components/Input/__snapshots__/InputPassword.test.tsx.snap
+++ b/src/app/components/Input/__snapshots__/InputPassword.test.tsx.snap
@@ -29,7 +29,9 @@ exports[`InputPassword > should render as a password field 1`] = `
           data-testid="InputPassword__toggle"
           type="button"
         >
-          <div>
+          <div
+            class="text-theme-secondary-700 dark:text-theme-dark-200"
+          >
             <div
               style="height: 20px; width: 20px;"
             >
@@ -142,7 +144,9 @@ exports[`InputPassword > should render as a password isInvalid 1`] = `
           data-testid="InputPassword__toggle"
           type="button"
         >
-          <div>
+          <div
+            class="text-theme-secondary-700 dark:text-theme-dark-200"
+          >
             <div
               style="height: 20px; width: 20px;"
             >

--- a/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
+++ b/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
@@ -85,7 +85,9 @@ exports[`PasswordValidation > should render password rules 1`] = `
             data-testid="InputPassword__toggle"
             type="button"
           >
-            <div>
+            <div
+              class="text-theme-secondary-700 dark:text-theme-dark-200"
+            >
               <div
                 style="height: 20px; width: 20px;"
               >
@@ -356,7 +358,9 @@ exports[`PasswordValidation > should render password rules 1`] = `
             data-testid="InputPassword__toggle"
             type="button"
           >
-            <div>
+            <div
+              class="text-theme-secondary-700 dark:text-theme-dark-200"
+            >
               <div
                 style="height: 20px; width: 20px;"
               >

--- a/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -1028,7 +1028,9 @@ exports[`SignMessage > Sign with Wallet > should render (lg) 1`] = `
                                 data-testid="InputPassword__toggle"
                                 type="button"
                               >
-                                <div>
+                                <div
+                                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                                >
                                   <div
                                     style="height: 20px; width: 20px;"
                                   >
@@ -2131,7 +2133,9 @@ exports[`SignMessage > Sign with Wallet > should render (xs) 1`] = `
                                 data-testid="InputPassword__toggle"
                                 type="button"
                               >
-                                <div>
+                                <div
+                                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                                >
                                   <div
                                     style="height: 20px; width: 20px;"
                                   >

--- a/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
+++ b/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
@@ -115,7 +115,9 @@ exports[`PasswordModal > should render with title and description 1`] = `
                         data-testid="InputPassword__toggle"
                         type="button"
                       >
-                        <div>
+                        <div
+                          class="text-theme-secondary-700 dark:text-theme-dark-200"
+                        >
                           <div
                             style="height: 20px; width: 20px;"
                           >

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -162,7 +162,9 @@ exports[`SignIn > should render a modal 1`] = `
                         data-testid="InputPassword__toggle"
                         type="button"
                       >
-                        <div>
+                        <div
+                          class="text-theme-secondary-700 dark:text-theme-dark-200"
+                        >
                           <div
                             style="height: 20px; width: 20px;"
                           >

--- a/src/domains/wallet/components/EncryptPasswordStep/__snapshots__/EncryptPasswordStep.test.tsx.snap
+++ b/src/domains/wallet/components/EncryptPasswordStep/__snapshots__/EncryptPasswordStep.test.tsx.snap
@@ -149,7 +149,9 @@ exports[`EncryptPasswordStep > should trigger password confirmation validation w
                 data-testid="InputPassword__toggle"
                 type="button"
               >
-                <div>
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                >
                   <div
                     style="height: 20px; width: 20px;"
                   >
@@ -349,7 +351,9 @@ exports[`EncryptPasswordStep > should trigger password confirmation validation w
                 data-testid="InputPassword__toggle"
                 type="button"
               >
-                <div>
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                >
                   <div
                     style="height: 20px; width: 20px;"
                   >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] hide/view icon should be gray-700](https://app.clickup.com/t/86dw767zp)

## Summary

- The hide/view icon color has been adjusted in light mode to `gray-700` for password inputs.

<img width="554" alt="image" src="https://github.com/user-attachments/assets/cbdd03b8-2b58-44ee-a39e-d0fa7be1d165" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
