### PR TITLE
fix: handle `enter` key in import flow

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -236,7 +236,7 @@ export const ImportAddressesSidePanel = ({
 			onOpenChange={handleOpenChange}
 			dataTestId="ImportAddressSidePanel"
 		>
-			<Form context={form} onSubmit={handleFinish} data-testid="ImportWallet__form">
+			<Form context={form} data-testid="ImportWallet__form">
 				{isLedgerImport ? (
 					<LedgerTabs onClickEditWalletName={handleEditLedgerAlias} />
 				) : (
@@ -302,7 +302,7 @@ export const ImportAddressesSidePanel = ({
 								{activeTab === Step.SummaryStep && (
 									<Button
 										disabled={isSubmitting}
-										type="submit"
+										onClick={handleFinish}
 										data-testid="ImportWallet__finish-button"
 									>
 										{t("COMMON.GO_TO_PORTFOLIO")}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dw7npnr

This PR adjusts import flow to prevent early form submit when `enter` key pressed.

Testing:
- Open up the `Import` side panel
- Pick a way of import
- Fill the value and press `enter` - you should get navigated to the next step



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
