### PR TITLE
fix: dropdown hover state margin

### DIFF
--- a/src/app/components/Dropdown/DropdownItem.tsx
+++ b/src/app/components/Dropdown/DropdownItem.tsx
@@ -11,7 +11,7 @@ export const DropdownItem = ({
 	<li
 		{...props}
 		className={twMerge(
-			"my-1 flex items-center space-x-2 whitespace-nowrap px-5 mx-1 py-4 text-left text-base font-semibold transition-colors-shadow duration-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400",
+			"mx-1 my-1 flex items-center space-x-2 whitespace-nowrap px-5 py-4 text-left text-base font-semibold transition-colors-shadow duration-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400",
 			cn({
 				"border-l-4": variant !== "navbar",
 				"border-theme-primary-600 bg-theme-primary-50 text-theme-primary-600 dark:bg-black": isActive,

--- a/src/app/components/Dropdown/DropdownItem.tsx
+++ b/src/app/components/Dropdown/DropdownItem.tsx
@@ -11,7 +11,7 @@ export const DropdownItem = ({
 	<li
 		{...props}
 		className={twMerge(
-			"my-1 flex items-center space-x-2 whitespace-nowrap px-6 py-4 text-left text-base font-semibold transition-colors-shadow duration-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400",
+			"my-1 flex items-center space-x-2 whitespace-nowrap px-5 mx-1 py-4 text-left text-base font-semibold transition-colors-shadow duration-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400",
 			cn({
 				"border-l-4": variant !== "navbar",
 				"border-theme-primary-600 bg-theme-primary-50 text-theme-primary-600 dark:bg-black": isActive,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dropdown] fix hover state](https://app.clickup.com/t/86dw7650m)

## Summary

- Margin in X axis has been added to the dropdown items hover state.

<img width="237" alt="image" src="https://github.com/user-attachments/assets/036425ac-b0d6-447c-a70b-544b7cdc2b9b" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
