### PR TITLE
refactor: wallet encryption toggle

### DIFF
--- a/src/domains/portfolio/components/CreateWallet/ConfirmPassphraseStep.tsx
+++ b/src/domains/portfolio/components/CreateWallet/ConfirmPassphraseStep.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { MnemonicVerification } from "@/domains/wallet/components/MnemonicVerification";
 import { Checkbox } from "@/app/components/Checkbox";
-import { Toggle } from "@/app/components/Toggle";
+import { WalletEncryptionBanner } from "@/domains/wallet/components/WalletEncryptionBanner.tsx";
 
 export const ConfirmPassphraseStep = () => {
 	const { getValues, setValue, watch, clearErrors, register } = useFormContext();
@@ -13,6 +13,9 @@ export const ConfirmPassphraseStep = () => {
 	const mnemonic = watch("mnemonic");
 
 	const { t } = useTranslation();
+
+	const useEncryption = watch("useEncryption");
+	const acceptResponsibility = watch("acceptResponsibility");
 
 	const handleComplete = (isComplete: boolean) => {
 		setMnemonicValidated(isComplete);
@@ -33,6 +36,10 @@ export const ConfirmPassphraseStep = () => {
 
 	const handleToggleEncryption = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setValue("useEncryption", event.target.checked);
+	};
+
+	const handleToggleResponsibility = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setValue("acceptResponsibility", event.target.checked);
 	};
 
 	return (
@@ -58,27 +65,12 @@ export const ConfirmPassphraseStep = () => {
 				</div>
 			</div>
 
-			<div className="rounded-lg border border-theme-secondary-300 transition-all dark:border-theme-dark-700">
-				<div className="flex flex-1 items-center justify-between space-x-5 px-4 py-4 sm:px-6">
-					<span className="font-semibold leading-[17px] text-theme-secondary-900 dark:text-theme-dark-50 sm:leading-5">
-						{t("WALLETS.PAGE_CREATE_WALLET.PASSPHRASE_STEP.ENCRYPTION.TITLE")}
-					</span>
-
-					<span data-testid="CreateWallet__encryption">
-						<Toggle
-							data-testid="CreateWallet__encryption-toggle"
-							defaultChecked={getValues("useEncryption")}
-							onChange={handleToggleEncryption}
-						/>
-					</span>
-				</div>
-
-				<div className="rounded-b-lg bg-theme-secondary-100 px-4 pb-4 pt-3 dark:bg-theme-dark-950 sm:px-6">
-					<span className="text-sm text-theme-secondary-700 dark:text-theme-dark-200">
-						{t("WALLETS.PAGE_CREATE_WALLET.PASSPHRASE_STEP.ENCRYPTION.DESCRIPTION")}
-					</span>
-				</div>
-			</div>
+			<WalletEncryptionBanner
+				toggleChecked={useEncryption}
+				toggleOnChange={handleToggleEncryption}
+				checkboxChecked={acceptResponsibility}
+				checkboxOnChange={handleToggleResponsibility}
+			/>
 		</section>
 	);
 };

--- a/src/domains/portfolio/components/CreateWallet/EncryptionPasswordStep.test.tsx
+++ b/src/domains/portfolio/components/CreateWallet/EncryptionPasswordStep.test.tsx
@@ -81,7 +81,8 @@ describe("EncryptionPasswordStep", () => {
 
 		await expect(screen.findByTestId("CreateWallet__WalletOverviewStep")).resolves.toBeVisible();
 
-		await userEvent.click(screen.getByTestId("CreateWallet__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 
 		await userEvent.click(continueButton);
 
@@ -169,7 +170,8 @@ describe("EncryptionPasswordStep", () => {
 
 		await expect(screen.findByTestId("CreateWallet__WalletOverviewStep")).resolves.toBeVisible();
 
-		await userEvent.click(screen.getByTestId("CreateWallet__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 
 		await userEvent.click(continueButton);
 

--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -62,12 +62,21 @@ export const ImportAddressesSidePanel = ({
 
 	const { getValues, formState, register, watch } = form;
 	const { isDirty, isSubmitting, isValid } = formState;
-	const { value, importOption, encryptionPassword, confirmEncryptionPassword, secondInput, useEncryption } = watch();
+	const {
+		value,
+		importOption,
+		encryptionPassword,
+		confirmEncryptionPassword,
+		secondInput,
+		useEncryption,
+		acceptResponsibility,
+	} = watch();
 	const isLedgerImport = !!importOption && importOption.value === OptionsValue.LEDGER;
 
 	useEffect(() => {
 		register({ name: "importOption", type: "custom" });
-		register("useEncryption");
+		register({ name: "useEncryption", type: "boolean", value: false });
+		register({ name: "acceptResponsibility", type: "boolean", value: false });
 	}, [register]);
 
 	useEffect(() => {
@@ -208,6 +217,9 @@ export const ImportAddressesSidePanel = ({
 	};
 
 	const isNextDisabled = useMemo(() => {
+		if (activeTab === Step.ImportDetailStep) {
+			return useEncryption && !acceptResponsibility;
+		}
 		if (activeTab < Step.EncryptPasswordStep) {
 			return isDirty ? !isValid || isImporting : true;
 		}
@@ -215,7 +227,17 @@ export const ImportAddressesSidePanel = ({
 		if (activeTab === Step.EncryptPasswordStep) {
 			return isEncrypting || !isValid || !encryptionPassword || !confirmEncryptionPassword;
 		}
-	}, [activeTab, confirmEncryptionPassword, encryptionPassword, isDirty, isEncrypting, isImporting, isValid]);
+	}, [
+		activeTab,
+		acceptResponsibility,
+		useEncryption,
+		confirmEncryptionPassword,
+		encryptionPassword,
+		isDirty,
+		isEncrypting,
+		isImporting,
+		isValid,
+	]);
 
 	const allSteps = useMemo(() => {
 		const steps: string[] = [];

--- a/src/domains/portfolio/components/ImportWallet/ImportDetailStep.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportDetailStep.tsx
@@ -8,10 +8,9 @@ import { useTranslation } from "react-i18next";
 
 import { FormField, FormLabel } from "@/app/components/Form";
 import { Input, InputAddress, InputPassword } from "@/app/components/Input";
-import { Toggle } from "@/app/components/Toggle";
-import { Tooltip } from "@/app/components/Tooltip";
 import { ImportOption, OptionsValue } from "@/domains/wallet/hooks/use-import-options";
 import { Alert } from "@/app/components/Alert";
+import { WalletEncryptionBanner } from "@/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner";
 
 const validateAddress = async ({
 	findAddress,
@@ -303,12 +302,12 @@ export const ImportDetailStep = ({
 	network: Networks.Network;
 	importOption: ImportOption;
 }) => {
-	const { t } = useTranslation();
 	const { watch, setValue, clearErrors } = useFormContext();
 
 	const [coin] = useState(() => profile.coins().get(network.coin(), network.id()));
 
 	const useEncryption = watch("useEncryption") as boolean;
+	const acceptResponsibility = watch("acceptResponsibility") as boolean;
 
 	useEffect(() => {
 		clearErrors(["validation", "confirmEncryptionPassword"]);
@@ -316,6 +315,15 @@ export const ImportDetailStep = ({
 
 	const handleToggleEncryption = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setValue("useEncryption", event.target.checked);
+
+		if (!event.target.checked) {
+			setValue("acceptResponsibility", false);
+			clearErrors("acceptResponsibility");
+		}
+	};
+
+	const handleToggleResponsibility = (event: React.ChangeEvent<HTMLInputElement>) => {
+		setValue("acceptResponsibility", event.target.checked);
 	};
 
 	return (
@@ -328,34 +336,13 @@ export const ImportDetailStep = ({
 					network={network}
 				/>
 
-				<div className="rounded-lg border border-theme-secondary-300 transition-all dark:border-theme-dark-700">
-					<div className="flex flex-1 items-center justify-between space-x-5 px-4 py-4 sm:px-6">
-						<span className="font-semibold leading-[17px] text-theme-secondary-900 dark:text-theme-dark-50 sm:leading-5">
-							{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.TITLE")}
-						</span>
-
-						<Tooltip
-							className="-ml-3 mb-1"
-							content={t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.NOT_AVAILABLE")}
-							disabled={importOption.canBeEncrypted}
-						>
-							<span data-testid="ImportWallet__encryption">
-								<Toggle
-									data-testid="ImportWallet__encryption-toggle"
-									disabled={!importOption.canBeEncrypted}
-									checked={useEncryption ?? false}
-									onChange={handleToggleEncryption}
-								/>
-							</span>
-						</Tooltip>
-					</div>
-
-					<div className="rounded-b-lg bg-theme-secondary-100 px-4 pb-4 pt-3 dark:bg-theme-dark-950 sm:px-6">
-						<span className="text-sm text-theme-secondary-700 dark:text-theme-dark-200">
-							{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.DESCRIPTION")}
-						</span>
-					</div>
-				</div>
+				<WalletEncryptionBanner
+					importOption={importOption}
+					toggleChecked={useEncryption}
+					toggleOnChange={handleToggleEncryption}
+					checkboxChecked={acceptResponsibility}
+					checkboxOnChange={handleToggleResponsibility}
+				/>
 			</div>
 		</section>
 	);

--- a/src/domains/portfolio/components/ImportWallet/ImportWallet.Methods.test.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportWallet.Methods.test.tsx
@@ -26,7 +26,8 @@ const randomPublicKeyInvalid = "a34151a3ec46b5670a682b0a63394f863587d1bc97483b1b
 
 const route = `/profiles/${fixtureProfileId}/dashboard`;
 
-const enableEncryptionToggle = async () => await userEvent.click(screen.getByTestId("ImportWallet__encryption-toggle"));
+const enableEncryptionToggle = async () => await userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+const toggleEncryptionCheckbox = async () => await userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 const continueButton = () => screen.getByTestId("ImportWallet__continue-button");
 const backButton = () => screen.getByTestId("ImportWallet__back-button");
 const addressInput = () => screen.findByTestId("ImportWallet__address-input");
@@ -269,9 +270,10 @@ describe("ImportAddress Methods", () => {
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
 		await enableEncryptionToggle();
+		await toggleEncryptionCheckbox();
 
 		await waitFor(() => {
-			expect(screen.getByTestId("ImportWallet__encryption-toggle")).toBeEnabled();
+			expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeEnabled();
 		});
 
 		await userEvent.click(continueButton());
@@ -336,7 +338,7 @@ describe("ImportAddress Methods", () => {
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
 		await enableEncryptionToggle();
-
+		await toggleEncryptionCheckbox();
 		await userEvent.click(continueButton());
 
 		await waitFor(() => {
@@ -396,7 +398,7 @@ describe("ImportAddress Methods", () => {
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
 		await enableEncryptionToggle();
-
+		await toggleEncryptionCheckbox();
 		await userEvent.click(continueButton());
 
 		await waitFor(() => {

--- a/src/domains/portfolio/components/ImportWallet/ImportWallet.Mnemonic.test.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportWallet.Mnemonic.test.tsx
@@ -28,7 +28,8 @@ const randomAddress = "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib";
 
 const route = `/profiles/${fixtureProfileId}/dashboard`;
 
-const enableEncryptionToggle = () => userEvent.click(screen.getByTestId("ImportWallet__encryption-toggle"));
+const enableEncryptionToggle = () => userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+const toggleEncryptionCheckbox = () => userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 const continueButton = () => screen.getByTestId("ImportWallet__continue-button");
 const mnemonicInput = () => screen.getByTestId("ImportWallet__mnemonic-input");
 const addressInput = () => screen.findByTestId("ImportWallet__address-input");
@@ -143,8 +144,8 @@ describe("ImportAddress", () => {
 
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
-		enableEncryptionToggle();
-
+		await enableEncryptionToggle();
+		await toggleEncryptionCheckbox();
 		await userEvent.click(continueButton());
 
 		await waitFor(() => {
@@ -192,11 +193,12 @@ describe("ImportAddress", () => {
 
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
-		expect(screen.getByTestId("ImportWallet__encryption-toggle")).not.toBeChecked();
+		expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).not.toBeChecked();
 
-		enableEncryptionToggle();
+		await enableEncryptionToggle();
+		await toggleEncryptionCheckbox();
 
-		await waitFor(() => expect(screen.getByTestId("ImportWallet__encryption-toggle")).toBeChecked());
+		await waitFor(() => expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeChecked());
 
 		await userEvent.click(screen.getByText(commonTranslations.BACK));
 
@@ -208,7 +210,7 @@ describe("ImportAddress", () => {
 
 		await expect(addressInput()).resolves.toBeVisible();
 
-		await waitFor(() => expect(screen.getByTestId("ImportWallet__encryption-toggle")).not.toBeChecked());
+		await waitFor(() => expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).not.toBeChecked());
 	});
 
 	it("should import by mnemonic with second signature and use password to encrypt both", async () => {
@@ -236,7 +238,8 @@ describe("ImportAddress", () => {
 
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
-		enableEncryptionToggle();
+		await enableEncryptionToggle();
+		await toggleEncryptionCheckbox();
 
 		await userEvent.click(continueButton());
 
@@ -292,7 +295,8 @@ describe("ImportAddress", () => {
 
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
-		enableEncryptionToggle();
+		await enableEncryptionToggle();
+		await toggleEncryptionCheckbox();
 
 		await userEvent.click(continueButton());
 

--- a/src/domains/portfolio/components/ImportWallet/ImportWallet.Validations.test.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportWallet.Validations.test.tsx
@@ -30,7 +30,8 @@ const addressInput = () => screen.findByTestId("ImportWallet__address-input");
 const successStep = () => screen.getByTestId("ImportWallet__success-step");
 const methodStep = () => screen.getByTestId("ImportWallet__method-step");
 const detailStep = () => screen.getByTestId("ImportWallet__detail-step");
-const enableEncryptionToggle = async () => await userEvent.click(screen.getByTestId("ImportWallet__encryption-toggle"));
+const enableEncryptionToggle = async () => await userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+const toggleEncryptionCheckbox = async () => await userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 
 const secretInputID = "ImportWallet__secret-input";
 const errorText = "data-errortext";
@@ -175,7 +176,7 @@ describe("ImportAddress Validations", () => {
 		await waitFor(() => expect(continueButton()).toBeEnabled());
 
 		await enableEncryptionToggle();
-
+		await toggleEncryptionCheckbox();
 		await userEvent.click(continueButton());
 
 		await waitFor(() => {

--- a/src/domains/wallet/components/CreateAddressSidePanel/CreateAddressSidePanel.test.tsx
+++ b/src/domains/wallet/components/CreateAddressSidePanel/CreateAddressSidePanel.test.tsx
@@ -193,7 +193,8 @@ describe("CreateAddressSidePanel", () => {
 
 		await userEvent.click(continueButton());
 
-		await userEvent.click(screen.getByTestId("CreateWallet__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 
 		expect(within(steps).getAllByRole("listitem")).toHaveLength(4);
 
@@ -284,7 +285,8 @@ describe("CreateAddressSidePanel", () => {
 
 		await userEvent.click(continueButton());
 
-		await userEvent.click(screen.getByTestId("CreateWallet__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__encryption-toggle"));
+		await userEvent.click(screen.getByTestId("WalletEncryptionBanner__checkbox"));
 
 		expect(within(steps).getAllByRole("listitem")).toHaveLength(4);
 

--- a/src/domains/wallet/components/CreateAddressSidePanel/CreateAddressSidePanel.tsx
+++ b/src/domains/wallet/components/CreateAddressSidePanel/CreateAddressSidePanel.tsx
@@ -59,7 +59,8 @@ export const CreateAddressesSidePanel = ({
 	const { getValues, formState, register, setValue, watch } = form;
 	const { isDirty, isSubmitting, isValid } = formState;
 
-	const { useEncryption, encryptionPassword, confirmEncryptionPassword, wallet, mnemonic } = watch();
+	const { useEncryption, encryptionPassword, confirmEncryptionPassword, wallet, mnemonic, acceptResponsibility } =
+		watch();
 
 	const [isGeneratingWallet, setIsGeneratingWallet] = useState(true);
 	const [_, setGenerationError] = useState<string | DefaultTReturn<TOptions>>("");
@@ -67,9 +68,10 @@ export const CreateAddressesSidePanel = ({
 
 	useEffect(() => {
 		register("network", { required: true });
+		register({ name: "useEncryption", type: "boolean", value: false });
+		register({ name: "acceptResponsibility", type: "boolean", value: false });
 		register("wallet");
 		register("mnemonic");
-		register("useEncryption");
 		register("passphraseDisclaimer");
 	}, [register, open]);
 
@@ -229,6 +231,12 @@ export const CreateAddressesSidePanel = ({
 		return steps;
 	}, [useEncryption, t]);
 
+	const isNextDisabled = useMemo(() => {
+		if (activeTab === Step.ConfirmPassphraseStep) {
+			return useEncryption && !acceptResponsibility;
+		}
+	}, [activeTab, acceptResponsibility, useEncryption]);
+
 	return (
 		<SidePanel
 			header={<StepHeader step={activeTab} />}
@@ -283,7 +291,7 @@ export const CreateAddressesSidePanel = ({
 								{activeTab < Step.EncryptPasswordStep && (
 									<Button
 										data-testid="CreateWallet__continue-button"
-										disabled={isDirty ? !isValid || isGeneratingWallet : true}
+										disabled={isDirty ? !isValid || isGeneratingWallet || isNextDisabled : true}
 										isLoading={isGeneratingWallet}
 										onClick={() => handleNext()}
 									>

--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.test.tsx
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.test.tsx
@@ -31,7 +31,4 @@ describe("WalletEncryptionBanner", () => {
 
         expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeEnabled();
     });
-    
-    
-    
 });

--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.test.tsx
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { WalletEncryptionBanner } from "./WalletEncryptionBanner";
+import { OptionsValue } from "@/domains/wallet/hooks/use-import-options";
+import {
+	render,
+	screen,
+} from "@/utils/testing-library";
+import { vi } from "vitest";
+
+describe("WalletEncryptionBanner", () => {
+    it("should render", () => {
+        render(<WalletEncryptionBanner toggleOnChange={vi.fn()} toggleChecked={false} checkboxChecked={false} checkboxOnChange={vi.fn()} />);
+
+        expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeInTheDocument();
+    });
+
+    it("should disable the toggle when the import option is not available", () => {
+        render(<WalletEncryptionBanner toggleOnChange={vi.fn()} toggleChecked={false} checkboxChecked={false} checkboxOnChange={vi.fn()} importOption={{ value: OptionsValue.LEDGER, canBeEncrypted: false }} />);
+
+        expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeDisabled();
+    });
+
+    it("should disable the toggle when the import option is available but the wallet cannot be encrypted", () => {
+        render(<WalletEncryptionBanner toggleOnChange={vi.fn()} toggleChecked={false} checkboxChecked={false} checkboxOnChange={vi.fn()} importOption={{ value: OptionsValue.LEDGER, canBeEncrypted: false }} />);
+
+        expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeDisabled();
+    });
+    
+    it("should enable the toggle when the import option is available and the wallet can be encrypted", () => {
+        render(<WalletEncryptionBanner toggleOnChange={vi.fn()} toggleChecked={false} checkboxChecked={false} checkboxOnChange={vi.fn()} importOption={{ value: OptionsValue.LEDGER, canBeEncrypted: true }} />);
+
+        expect(screen.getByTestId("WalletEncryptionBanner__encryption-toggle")).toBeEnabled();
+    });
+    
+    
+    
+});

--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
@@ -1,0 +1,86 @@
+import React, { ChangeEventHandler } from "react";
+import cn from "classnames";
+import { Tooltip } from "@/app/components/Tooltip";
+import { useTranslation } from "react-i18next";
+import { ImportOption } from "@/domains/wallet/hooks/use-import-options";
+import { Toggle } from "@/app/components/Toggle";
+import { Checkbox } from "@/app/components/Checkbox";
+
+export const WalletEncryptionBanner = ({
+	importOption,
+	toggleOnChange,
+	toggleChecked,
+	checkboxChecked,
+	checkboxOnChange,
+}: {
+	importOption?: ImportOption;
+	toggleOnChange: ChangeEventHandler<HTMLInputElement>;
+	toggleChecked: boolean;
+	checkboxChecked: boolean;
+	checkboxOnChange: ChangeEventHandler<HTMLInputElement>;
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<div
+			className={cn("flex w-full flex-col overflow-hidden rounded-xl border", {
+				"border-theme-secondary-300 dark:border-theme-dark-700": !toggleChecked,
+				"border-theme-warning-300 dark:border-theme-warning-700": toggleChecked,
+			})}
+		>
+			<div className="flex flex-row justify-between px-6 py-4">
+				<div className="flex max-w-96 flex-col gap-1">
+					<span className="text-base font-semibold leading-5 text-theme-secondary-900 dark:text-theme-dark-50">
+						{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.TITLE")}
+					</span>
+					<p className="text-sm leading-[21px] text-theme-secondary-700 dark:text-theme-dark-200">
+						{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.DESCRIPTION")}
+					</p>
+				</div>
+
+				<Tooltip
+					className="-ml-3 mb-1"
+					content={t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.NOT_AVAILABLE")}
+					disabled={importOption && !importOption?.canBeEncrypted}
+				>
+					<span data-testid="WalletEncryptionBanner__encryption">
+						<Toggle
+							data-testid="WalletEncryptionBanner__encryption-toggle"
+							disabled={importOption && !importOption?.canBeEncrypted}
+							checked={toggleChecked}
+							onChange={toggleOnChange}
+						/>
+					</span>
+				</Tooltip>
+			</div>
+
+			<div
+				className={cn(
+					"flex flex-col gap-3 bg-theme-warning-50 transition-all duration-300 dark:bg-theme-dark-950",
+					{
+						"h-0 opacity-0": !toggleChecked,
+						"min-h-[120px] px-6 pb-5 pt-3 opacity-100": toggleChecked,
+					},
+				)}
+			>
+				<p className="text-sm font-normal leading-[21px] text-theme-secondary-900 dark:text-theme-dark-50">
+					{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.WARNING")}
+				</p>
+
+				<hr className="border border-dashed border-theme-warning-300 dark:border-theme-dark-700" />
+
+				<label className="inline-flex cursor-pointer items-center space-x-3">
+					<Checkbox
+						data-testid="WalletEncryptionBanner__checkbox"
+						checked={checkboxChecked}
+						onChange={checkboxOnChange}
+						color="warning"
+					/>
+					<span className="text-sm font-normal leading-[21px] text-theme-secondary-900 dark:text-theme-dark-50">
+						{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.CHECKBOX")}
+					</span>
+				</label>
+			</div>
+		</div>
+	);
+};

--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
@@ -56,30 +56,32 @@ export const WalletEncryptionBanner = ({
 
 			<div
 				className={cn(
-					"flex flex-col gap-3 bg-theme-warning-50 transition-all duration-300 dark:bg-theme-dark-950",
+					"bg-theme-warning-50 transition-[max-height,opacity] duration-300 dark:bg-theme-dark-950",
 					{
-						"h-0 opacity-0": !toggleChecked,
-						"min-h-[120px] px-6 pb-5 pt-3 opacity-100": toggleChecked,
+						"max-h-0 opacity-0": !toggleChecked,
+						"max-h-[300px] opacity-100": toggleChecked,
 					},
 				)}
 			>
-				<p className="text-sm font-normal leading-[21px] text-theme-secondary-900 dark:text-theme-dark-50">
-					{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.WARNING")}
-				</p>
+				<div className="flex flex-col gap-3 px-6 pb-5 pt-3">
+					<p className="text-sm font-normal leading-[21px] text-theme-secondary-900 dark:text-theme-dark-50">
+						{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.WARNING")}
+					</p>
 
-				<hr className="border border-dashed border-theme-warning-300 dark:border-theme-dark-700" />
+					<hr className="border border-dashed border-theme-warning-300 dark:border-theme-dark-700" />
 
-				<label className="inline-flex cursor-pointer items-center space-x-3">
-					<Checkbox
-						data-testid="WalletEncryptionBanner__checkbox"
-						checked={checkboxChecked}
-						onChange={checkboxOnChange}
-						color="warning"
-					/>
-					<span className="text-sm font-normal leading-[21px] text-theme-secondary-900 dark:text-theme-dark-50">
-						{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.CHECKBOX")}
-					</span>
-				</label>
+					<label className="inline-flex cursor-pointer items-center space-x-3">
+						<Checkbox
+							data-testid="WalletEncryptionBanner__checkbox"
+							checked={checkboxChecked}
+							onChange={checkboxOnChange}
+							color="warning"
+						/>
+						<span className="text-sm font-normal leading-[21px] text-theme-secondary-900 dark:text-theme-dark-50">
+							{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.ENCRYPTION.CHECKBOX")}
+						</span>
+					</label>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/index.ts
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/index.ts
@@ -1,0 +1,1 @@
+export * from "./WalletEncryptionBanner";

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -136,10 +136,13 @@ export const translations = {
 
 		IMPORT_DETAIL_STEP: {
 			ENCRYPTION: {
+				CHECKBOX: "I understand and accept responsibility.",
 				DESCRIPTION:
-					"Set an encryption password to use in place of your mnemonic passphrase. Note that you must still record and keep your mnemonic passphrase safe as losing this will result in you losing all access to your funds.",
+					"Set an encryption password to replace your mnemonic passphrase when signing transactions and messages.",
 				NOT_AVAILABLE: "Encryption not available for this import type",
 				TITLE: "Use Wallet Encryption",
+				WARNING:
+					"You must still securely store your mnemonic passphrase. Losing it will result in permanent loss of access to your funds!",
 			},
 			MNEMONIC_TIP: {
 				GUIDELINES_1: "Ensure all words are in lowercase.",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[wallet encryption] implement updated design](https://app.clickup.com/t/86dw75w9m)

## Summary

- Wallet encryption toggle has been redesigned. A new `WalletEncryptionBanner` component has been created containing the new design, replacing both implementations in the `Create` and `Import` wallet flows.
- With this new toggle, a new `Accept Responsibility` checkbox has been introduced and registered into the forms, which is now required to continuing registered the wallets.
- Dark mode designs have also been updated for this component.
- Unit tests and translation files have been updated.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Screenshots

<img width="588" alt="image" src="https://github.com/user-attachments/assets/b5dc31c8-4ee3-4454-a8dc-b3c39a7ec473" />
<img width="581" alt="image" src="https://github.com/user-attachments/assets/cb2acd6f-14fe-433a-995b-1f054fe5956d" />


## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
