### PR TITLE
tests: update `message` domain tests to use `Mainsail` network

### DIFF
--- a/src/tests/fixtures/coins/mainsail/devnet/wallets/0x125b484e51Ad990b5b3140931f3BD8eAee85Db23.json
+++ b/src/tests/fixtures/coins/mainsail/devnet/wallets/0x125b484e51Ad990b5b3140931f3BD8eAee85Db23.json
@@ -1,0 +1,12 @@
+{
+	"data": {
+		"address": "0x125b484e51Ad990b5b3140931f3BD8eAee85Db23",
+		"publicKey": "02727d83862b9d429b91a0d06920d860c252893a25ec337fb30da87b119985c182",
+		"balance": "999893645145814000",
+		"nonce": "1",
+		"attributes": {
+
+		},
+		"updated_at": "292469"
+	}
+}

--- a/src/tests/fixtures/coins/mainsail/devnet/wallets/0x659A76be283644AEc2003aa8ba26485047fd1BFB.json
+++ b/src/tests/fixtures/coins/mainsail/devnet/wallets/0x659A76be283644AEc2003aa8ba26485047fd1BFB.json
@@ -1,0 +1,12 @@
+{
+	"data": {
+		"address": "0x659A76be283644AEc2003aa8ba26485047fd1BFB",
+		"publicKey": "0311b11b0dea8851d49af7c673d7032e37ee12307f9bbd379b64bbdac6ca302e84",
+		"balance": "19892164047230000",
+		"nonce": "1",
+		"attributes": {
+
+		},
+		"updated_at": "248548"
+	}
+}

--- a/src/tests/mocks/handlers/mainsail.devnet.ts
+++ b/src/tests/mocks/handlers/mainsail.devnet.ts
@@ -15,7 +15,11 @@ const endpoints = [
 	// { path: "/transactions/fees", data: require("../../fixtures/coins/mainsail/devnet/transaction-fees.json") },
 ];
 
-const wallets = ["0xcd15953dD076e56Dc6a5bc46Da23308Ff3158EE6"];
+const wallets = [
+	"0xcd15953dD076e56Dc6a5bc46Da23308Ff3158EE6",
+	"0x659A76be283644AEc2003aa8ba26485047fd1BFB",
+	"0x125b484e51Ad990b5b3140931f3BD8eAee85Db23"
+];
 
 export const mainsailDevnetHandlers = [
 	...endpoints.map((endpoint) =>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
