### PR TITLE
refactor: move send all button

### DIFF
--- a/src/domains/transaction/components/AddRecipient/AddRecipient.test.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.test.tsx
@@ -217,10 +217,17 @@ describe("AddRecipient", () => {
 	it("should set available amount in mobile", async () => {
 		renderWithFormProvider(<AddRecipient profile={profile} wallet={wallet} recipients={[]} onChange={vi.fn()} />);
 
-		await userEvent.click(screen.getByTestId("AddRecipient__send-all_mobile"));
+
 
 		await waitFor(() => expect(screen.getByTestId("AddRecipient__amount")).toHaveValue(`${wallet.balance()}`));
 	});
+
+	it("should show divider only if single recipient and sender has balance", async () => {
+		renderWithFormProvider(<AddRecipient profile={profile} wallet={wallet} recipients={[]} onChange={vi.fn()} />);
+
+		await waitFor(() => expect(screen.getByTestId("AddRecipient__divider")).toBeInTheDocument());
+	});
+
 
 	it("should show zero amount if wallet has zero or insufficient balance", async () => {
 		const emptyProfile = await env.profiles().create("Empty");

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.test.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.test.tsx
@@ -217,17 +217,14 @@ describe("AddRecipient", () => {
 	it("should set available amount in mobile", async () => {
 		renderWithFormProvider(<AddRecipient profile={profile} wallet={wallet} recipients={[]} onChange={vi.fn()} />);
 
-
-
 		await waitFor(() => expect(screen.getByTestId("AddRecipient__amount")).toHaveValue(`${wallet.balance()}`));
 	});
 
 	it("should show divider only if single recipient and sender has balance", async () => {
 		renderWithFormProvider(<AddRecipient profile={profile} wallet={wallet} recipients={[]} onChange={vi.fn()} />);
 
-		await waitFor(() => expect(screen.getByTestId("AddRecipient__divider")).toBeInTheDocument());
+		expect(screen.getByTestId("AddRecipient__divider")).toBeInTheDocument();
 	});
-
 
 	it("should show zero amount if wallet has zero or insufficient balance", async () => {
 		const emptyProfile = await env.profiles().create("Empty");

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -354,33 +354,34 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 					<FormField name="amount">
 						<FormLabel>
 							<span className="items-centers flex w-full justify-between">
-								<span>
-									<span>{t("COMMON.AMOUNT")}</span>
-									{isSenderFilled && !!remainingNetBalance && (
+								<span>{t("COMMON.AMOUNT")}</span>
+								<div className="flex flex-row items-center gap-2">
+									{isSenderFilled && !!remainingBalance && (
 										<span
 											data-testid="AddRecipient__available"
-											className="ml-1 text-theme-secondary-500"
+											className="text-theme-secondary-700 dark:text-theme-dark-200" 
 										>
-											(<Amount value={+remainingNetBalance} ticker={ticker} showTicker={false} />)
+											{t("COMMON.BALANCE")}: <Amount value={+remainingBalance} ticker={ticker} showTicker={true} />
 										</span>
 									)}
-								</span>
-								{isSingle && (
-									<span className="inline-flex sm:hidden">
-										<Button
-											type="button"
-											variant="transparent"
-											disabled={!isSenderFilled}
-											className="p-0 text-sm text-theme-navy-600"
-											onClick={() => {
-												setValue("isSendAllSelected", !getValues("isSendAllSelected"));
-											}}
-											data-testid="AddRecipient__send-all_mobile"
-										>
-											{t("TRANSACTION.SEND_ALL")}
-										</Button>
-									</span>
-								)}
+									{isSenderFilled && !!remainingBalance && isSingle && <div className="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700" data-testid="AddRecipient__divider"/>}
+									{isSingle && (
+										<span className="inline-flex">
+											<Button
+												type="button"
+												variant="transparent"
+												disabled={!isSenderFilled}
+												className="p-0 text-sm text-theme-navy-600"
+												onClick={() => {
+													setValue("isSendAllSelected", !getValues("isSendAllSelected"));
+												}}
+												data-testid="AddRecipient__send-all"
+											>
+												{t("TRANSACTION.SEND_ALL")}
+											</Button>
+										</span>
+									)}
+								</div>
 							</span>
 						</FormLabel>
 
@@ -404,24 +405,6 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 									}}
 								/>
 							</div>
-
-							{isSingle && (
-								<div className="hidden sm:inline-flex">
-									<InputButtonStyled
-										type="button"
-										disabled={!isSenderFilled}
-										className={cn({
-											active: getValues("isSendAllSelected"),
-										})}
-										onClick={() => {
-											setValue("isSendAllSelected", !getValues("isSendAllSelected"));
-										}}
-										data-testid="AddRecipient__send-all"
-									>
-										{t("TRANSACTION.SEND_ALL")}
-									</InputButtonStyled>
-								</div>
-							)}
 						</div>
 					</FormField>
 					{!isSingle && (

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -353,9 +353,9 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 									{isSenderFilled && !!remainingBalance && (
 										<div
 											data-testid="AddRecipient__available"
-											className="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
+											className="hidden text-theme-secondary-700 dark:text-theme-dark-200 sm:flex"
 										>
-											<span className="hidden sm:inline pr-1">{t("COMMON.BALANCE")}:</span>
+											<span className="hidden pr-1 sm:inline">{t("COMMON.BALANCE")}:</span>
 											<Amount value={+remainingBalance} ticker={ticker} showTicker={true} />
 										</div>
 									)}

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -343,20 +343,25 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 					<FormField name="amount">
 						<FormLabel>
 							<span className="items-centers flex w-full justify-between">
-								<span>{t("COMMON.AMOUNT")}</span>
+								<div className="flex flex-row items-center gap-1.5">
+									<span>{t("COMMON.AMOUNT")}</span>
+									<span className="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden">
+										(<Amount value={+remainingBalance} ticker={ticker} showTicker={false} />)
+									</span>
+								</div>
 								<div className="flex flex-row items-center gap-2">
 									{isSenderFilled && !!remainingBalance && (
-										<span
+										<div
 											data-testid="AddRecipient__available"
-											className="text-theme-secondary-700 dark:text-theme-dark-200"
+											className="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
 										>
-											{t("COMMON.BALANCE")}:{" "}
+											<span className="hidden sm:inline pr-1">{t("COMMON.BALANCE")}:</span>
 											<Amount value={+remainingBalance} ticker={ticker} showTicker={true} />
-										</span>
+										</div>
 									)}
 									{isSenderFilled && !!remainingBalance && isSingle && (
 										<div
-											className="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+											className="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
 											data-testid="AddRecipient__divider"
 										/>
 									)}

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -1,5 +1,4 @@
 import { Contracts } from "@ardenthq/sdk-profiles";
-import cn from "classnames";
 import React, { useCallback, useEffect, useMemo, useRef, useState, VFC } from "react";
 import { BigNumber } from "@ardenthq/sdk-helpers";
 import { useFormContext } from "react-hook-form";
@@ -19,7 +18,6 @@ import { useValidation, WalletAliasResult } from "@/app/hooks";
 import { useExchangeRate } from "@/app/hooks/use-exchange-rate";
 import { SelectRecipient } from "@/domains/profile/components/SelectRecipient";
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
-import { twMerge } from "tailwind-merge";
 import { calculateGasFee } from "@/domains/transaction/components/InputFee/InputFee";
 import { GasLimit, MIN_GAS_PRICE } from "@/domains/transaction/components/FeeField/FeeField";
 
@@ -58,15 +56,6 @@ const TransferType = ({ isSingle, disableMultiple, onChange, maxRecipients }: To
 		</div>
 	);
 };
-
-const InputButtonStyled = ({ ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-	<button
-		{...props}
-		className={twMerge(
-			"input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700",
-		)}
-	/>
-);
 
 export const AddRecipient: VFC<AddRecipientProperties> = ({
 	disableMultiPaymentOption,
@@ -359,12 +348,18 @@ export const AddRecipient: VFC<AddRecipientProperties> = ({
 									{isSenderFilled && !!remainingBalance && (
 										<span
 											data-testid="AddRecipient__available"
-											className="text-theme-secondary-700 dark:text-theme-dark-200" 
+											className="text-theme-secondary-700 dark:text-theme-dark-200"
 										>
-											{t("COMMON.BALANCE")}: <Amount value={+remainingBalance} ticker={ticker} showTicker={true} />
+											{t("COMMON.BALANCE")}:{" "}
+											<Amount value={+remainingBalance} ticker={ticker} showTicker={true} />
 										</span>
 									)}
-									{isSenderFilled && !!remainingBalance && isSingle && <div className="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700" data-testid="AddRecipient__divider"/>}
+									{isSenderFilled && !!remainingBalance && isSingle && (
+										<div
+											className="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+											data-testid="AddRecipient__divider"
+										/>
+									)}
 									{isSingle && (
 										<span className="inline-flex">
 											<Button

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -225,38 +225,44 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
+                Amount
+              </span>
+              <div
+                class="flex flex-row items-center gap-2"
+              >
                 <span
-                  class="ml-1 text-theme-secondary-500"
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
                   data-testid="AddRecipient__available"
                 >
-                  (
+                  Balance
+                  : 
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
-                    11.999895
+                    12 DARK
                   </span>
-                  )
                 </span>
-              </span>
-              <span
-                class="inline-flex sm:hidden"
-              >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <div
+                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  data-testid="AddRecipient__divider"
+                />
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -301,17 +307,6 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>
@@ -546,38 +541,44 @@ exports[`AddRecipient > should render 1`] = `
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
+                Amount
+              </span>
+              <div
+                class="flex flex-row items-center gap-2"
+              >
                 <span
-                  class="ml-1 text-theme-secondary-500"
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
                   data-testid="AddRecipient__available"
                 >
-                  (
+                  Balance
+                  : 
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
-                    33.75079301
+                    33.75089801 DARK
                   </span>
-                  )
                 </span>
-              </span>
-              <span
-                class="inline-flex sm:hidden"
-              >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <div
+                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  data-testid="AddRecipient__divider"
+                />
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -607,17 +608,6 @@ exports[`AddRecipient > should render 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>
@@ -852,38 +842,44 @@ exports[`AddRecipient > should render with empty array of recipients as default 
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
+                Amount
+              </span>
+              <div
+                class="flex flex-row items-center gap-2"
+              >
                 <span
-                  class="ml-1 text-theme-secondary-500"
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
                   data-testid="AddRecipient__available"
                 >
-                  (
+                  Balance
+                  : 
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
-                    33.75079301
+                    33.75089801 DARK
                   </span>
-                  )
                 </span>
-              </span>
-              <span
-                class="inline-flex sm:hidden"
-              >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <div
+                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  data-testid="AddRecipient__divider"
+                />
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -913,17 +909,6 @@ exports[`AddRecipient > should render with empty array of recipients as default 
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>
@@ -1158,38 +1143,44 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
+                Amount
+              </span>
+              <div
+                class="flex flex-row items-center gap-2"
+              >
                 <span
-                  class="ml-1 text-theme-secondary-500"
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
                   data-testid="AddRecipient__available"
                 >
-                  (
+                  Balance
+                  : 
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
-                    33.75079301
+                    33.75089801 DARK
                   </span>
-                  )
                 </span>
-              </span>
-              <span
-                class="inline-flex sm:hidden"
-              >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <div
+                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  data-testid="AddRecipient__divider"
+                />
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -1219,17 +1210,6 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>
@@ -1464,38 +1444,44 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
+                Amount
+              </span>
+              <div
+                class="flex flex-row items-center gap-2"
+              >
                 <span
-                  class="ml-1 text-theme-secondary-500"
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
                   data-testid="AddRecipient__available"
                 >
-                  (
+                  Balance
+                  : 
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
-                    33.75079301
+                    33.75089801 DARK
                   </span>
-                  )
                 </span>
-              </span>
-              <span
-                class="inline-flex sm:hidden"
-              >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <div
+                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  data-testid="AddRecipient__divider"
+                />
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -1525,17 +1511,6 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>
@@ -1702,38 +1677,44 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
+                Amount
+              </span>
+              <div
+                class="flex flex-row items-center gap-2"
+              >
                 <span
-                  class="ml-1 text-theme-secondary-500"
+                  class="text-theme-secondary-700 dark:text-theme-dark-200"
                   data-testid="AddRecipient__available"
                 >
-                  (
+                  Balance
+                  : 
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
-                    33.75079301
+                    33.75089801 DARK
                   </span>
-                  )
                 </span>
-              </span>
-              <span
-                class="inline-flex sm:hidden"
-              >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <div
+                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  data-testid="AddRecipient__divider"
+                />
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -1763,17 +1744,6 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>
@@ -2008,38 +1978,27 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
               class="items-centers flex w-full justify-between"
             >
               <span>
-                <span>
-                  Amount
-                </span>
-                <span
-                  class="ml-1 text-theme-secondary-500"
-                  data-testid="AddRecipient__available"
-                >
-                  (
-                  <span
-                    class="whitespace-nowrap"
-                    data-testid="Amount"
-                  >
-                    0
-                  </span>
-                  )
-                </span>
+                Amount
               </span>
-              <span
-                class="inline-flex sm:hidden"
+              <div
+                class="flex flex-row items-center gap-2"
               >
-                <button
-                  class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
-                  data-testid="AddRecipient__send-all_mobile"
-                  type="button"
+                <span
+                  class="inline-flex"
                 >
-                  <div
-                    class="flex items-center space-x-2"
+                  <button
+                    class="space-x-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none p-0 text-sm text-theme-navy-600"
+                    data-testid="AddRecipient__send-all"
+                    type="button"
                   >
-                    Send All
-                  </div>
-                </button>
-              </span>
+                    <div
+                      class="flex items-center space-x-2"
+                    >
+                      Send All
+                    </div>
+                  </button>
+                </span>
+              </div>
             </span>
           </label>
           <div
@@ -2120,17 +2079,6 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="hidden sm:inline-flex"
-            >
-              <button
-                class="input-button flex h-full items-center rounded border-2 border-theme-primary-100 px-5 font-semibold text-theme-secondary-700 transition-colors duration-300 hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-700 focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:border disabled:border-theme-secondary-300 disabled:text-theme-secondary-500 dark:border-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:border-theme-secondary-800 dark:hover:bg-theme-secondary-800 dark:hover:text-white disabled:dark:border-theme-secondary-700 disabled:dark:text-theme-secondary-700"
-                data-testid="AddRecipient__send-all"
-                type="button"
-              >
-                Send All
-              </button>
             </div>
           </div>
         </fieldset>

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -235,7 +235,8 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
                   data-testid="AddRecipient__available"
                 >
                   Balance
-                  : 
+                  :
+                   
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
@@ -244,7 +245,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
                   </span>
                 </span>
                 <div
-                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -551,7 +552,8 @@ exports[`AddRecipient > should render 1`] = `
                   data-testid="AddRecipient__available"
                 >
                   Balance
-                  : 
+                  :
+                   
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
@@ -560,7 +562,7 @@ exports[`AddRecipient > should render 1`] = `
                   </span>
                 </span>
                 <div
-                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -852,7 +854,8 @@ exports[`AddRecipient > should render with empty array of recipients as default 
                   data-testid="AddRecipient__available"
                 >
                   Balance
-                  : 
+                  :
+                   
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
@@ -861,7 +864,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
                   </span>
                 </span>
                 <div
-                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1153,7 +1156,8 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
                   data-testid="AddRecipient__available"
                 >
                   Balance
-                  : 
+                  :
+                   
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
@@ -1162,7 +1166,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
                   </span>
                 </span>
                 <div
-                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1454,7 +1458,8 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
                   data-testid="AddRecipient__available"
                 >
                   Balance
-                  : 
+                  :
+                   
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
@@ -1463,7 +1468,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
                   </span>
                 </span>
                 <div
-                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1687,7 +1692,8 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
                   data-testid="AddRecipient__available"
                 >
                   Balance
-                  : 
+                  :
+                   
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
@@ -1696,7 +1702,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
                   </span>
                 </span>
                 <div
-                  class="w-px h-3 bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
                   data-testid="AddRecipient__divider"
                 />
                 <span

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -224,28 +224,47 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    12
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >
-                <span
-                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
                   data-testid="AddRecipient__available"
                 >
-                  Balance
-                  :
-                   
+                  <span
+                    class="hidden sm:inline pr-1"
+                  >
+                    Balance
+                    :
+                  </span>
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
                     12 DARK
                   </span>
-                </span>
+                </div>
                 <div
-                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -541,28 +560,47 @@ exports[`AddRecipient > should render 1`] = `
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    33.75089801
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >
-                <span
-                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
                   data-testid="AddRecipient__available"
                 >
-                  Balance
-                  :
-                   
+                  <span
+                    class="hidden sm:inline pr-1"
+                  >
+                    Balance
+                    :
+                  </span>
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
                     33.75089801 DARK
                   </span>
-                </span>
+                </div>
                 <div
-                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -843,28 +881,47 @@ exports[`AddRecipient > should render with empty array of recipients as default 
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    33.75089801
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >
-                <span
-                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
                   data-testid="AddRecipient__available"
                 >
-                  Balance
-                  :
-                   
+                  <span
+                    class="hidden sm:inline pr-1"
+                  >
+                    Balance
+                    :
+                  </span>
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
                     33.75089801 DARK
                   </span>
-                </span>
+                </div>
                 <div
-                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1145,28 +1202,47 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    33.75089801
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >
-                <span
-                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
                   data-testid="AddRecipient__available"
                 >
-                  Balance
-                  :
-                   
+                  <span
+                    class="hidden sm:inline pr-1"
+                  >
+                    Balance
+                    :
+                  </span>
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
                     33.75089801 DARK
                   </span>
-                </span>
+                </div>
                 <div
-                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1447,28 +1523,47 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    33.75089801
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >
-                <span
-                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
                   data-testid="AddRecipient__available"
                 >
-                  Balance
-                  :
-                   
+                  <span
+                    class="hidden sm:inline pr-1"
+                  >
+                    Balance
+                    :
+                  </span>
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
                     33.75089801 DARK
                   </span>
-                </span>
+                </div>
                 <div
-                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1681,28 +1776,47 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    33.75089801
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >
-                <span
-                  class="text-theme-secondary-700 dark:text-theme-dark-200"
+                <div
+                  class="text-theme-secondary-700 dark:text-theme-dark-200 hidden sm:flex"
                   data-testid="AddRecipient__available"
                 >
-                  Balance
-                  :
-                   
+                  <span
+                    class="hidden sm:inline pr-1"
+                  >
+                    Balance
+                    :
+                  </span>
                   <span
                     class="whitespace-nowrap"
                     data-testid="Amount"
                   >
                     33.75089801 DARK
                   </span>
-                </span>
+                </div>
                 <div
-                  class="h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700"
+                  class="hidden h-3 w-px bg-theme-secondary-300 dark:bg-theme-dark-700 sm:flex"
                   data-testid="AddRecipient__divider"
                 />
                 <span
@@ -1983,9 +2097,25 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
             <span
               class="items-centers flex w-full justify-between"
             >
-              <span>
-                Amount
-              </span>
+              <div
+                class="flex flex-row items-center gap-1.5"
+              >
+                <span>
+                  Amount
+                </span>
+                <span
+                  class="text-sm text-theme-secondary-700 dark:text-theme-dark-200 sm:hidden"
+                >
+                  (
+                  <span
+                    class="whitespace-nowrap"
+                    data-testid="Amount"
+                  >
+                    0
+                  </span>
+                  )
+                </span>
+              </div>
               <div
                 class="flex flex-row items-center gap-2"
               >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[send form] move "Send All" button](https://app.clickup.com/t/86dw77cxq)

## Summary

- "Send All" button has been moved to the other side of the "Amount" label.
- Also, the selected wallet balance has been moved to respect the designs.
- This has also been updated in dark mode to support the design changes.
- New unit tests to support these changes.
- Snapshots have been updated.

## Screenshots

- Single transfer:
<img width="831" alt="image" src="https://github.com/user-attachments/assets/e5bcfe51-b47c-4118-9c40-d946aaa0a33a" />

- Multiple transfer:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/4ccac018-7841-48ab-8b2b-5666795fb6df" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
