### PR TITLE
refactor: address switch button hover state

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -746,35 +746,42 @@ exports[`Dashboard > should render 1`] = `
                           </span>
                         </span>
                       </div>
-                      <div
-                        class="text-theme-dark-200 text-theme-secondary-700"
+                      <button
+                        class="p-3 relative items-center inline-flex justify-center font-semibold leading-tight text-center transition-colors-shadow duration-100 ease-linear outline-none rounded focus:outline-none focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed hover:text-theme-primary-700 hover:dark:text-theme-dark-50 hover:bg-theme-primary-200 hover:dark:bg-theme-dark-700 text-theme-secondary-700 dark:text-theme-dark-200 h-6 w-6"
+                        type="button"
                       >
                         <div
-                          style="height: 26px; width: 26px;"
+                          class="flex items-center space-x-2"
                         >
-                          <svg
-                            fill="none"
-                            style="height: 100%; width: 100%;"
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M14.4016 14.3984L12.1146 16.7502C12.0998 16.7655 12.0822 16.7776 12.0628 16.7859C12.0434 16.7942 12.0226 16.7984 12.0016 16.7984C11.9806 16.7984 11.9598 16.7942 11.9404 16.7859C11.921 16.7776 11.9033 16.7655 11.8885 16.7502L9.60156 14.3984"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="1.6"
-                            />
-                            <path
-                              d="M9.60234 9.60156L11.8893 7.24978C11.9041 7.23449 11.9217 7.22237 11.9411 7.21409C11.9605 7.20582 11.9813 7.20156 12.0023 7.20156C12.0233 7.20156 12.0441 7.20582 12.0635 7.21409C12.0829 7.22237 12.1006 7.23449 12.1154 7.24978L14.4023 9.60156"
-                              stroke="currentColor"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="1.6"
-                            />
-                          </svg>
+                          <div>
+                            <div
+                              style="height: 26px; width: 26px;"
+                            >
+                              <svg
+                                fill="none"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14.4016 14.3984L12.1146 16.7502C12.0998 16.7655 12.0822 16.7776 12.0628 16.7859C12.0434 16.7942 12.0226 16.7984 12.0016 16.7984C11.9806 16.7984 11.9598 16.7942 11.9404 16.7859C11.921 16.7776 11.9033 16.7655 11.8885 16.7502L9.60156 14.3984"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="1.6"
+                                />
+                                <path
+                                  d="M9.60234 9.60156L11.8893 7.24978C11.9041 7.23449 11.9217 7.22237 11.9411 7.21409C11.9605 7.20582 11.9813 7.20156 12.0023 7.20156C12.0233 7.20156 12.0441 7.20582 12.0635 7.21409C12.0829 7.22237 12.1006 7.23449 12.1154 7.24978L14.4023 9.60156"
+                                  stroke="currentColor"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="1.6"
+                                />
+                              </svg>
+                            </div>
+                          </div>
                         </div>
-                      </div>
+                      </button>
                     </div>
                   </div>
                 </div>

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -139,12 +139,14 @@ export const PortfolioHeader = ({
 							>
 								<div className="flex items-center gap-1">
 									<ViewingAddressInfo wallets={selectedWallets} profile={profile} />
-									<Icon
-										name="DoubleChevron"
-										width={26}
-										height={26}
-										className="text-theme-dark-200 text-theme-secondary-700"
-									/>
+									<Button variant="primary-transparent" size="icon" className="h-6 w-6">
+										<Icon
+											name="DoubleChevron"
+											width={26}
+											height={26}
+											className="dark:text-theme-dark-200 text-theme-secondary-700"
+										/>
+									</Button>
 								</div>
 							</div>
 						</div>

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -144,7 +144,6 @@ export const PortfolioHeader = ({
 											name="DoubleChevron"
 											width={26}
 											height={26}
-											className="dark:text-theme-dark-200 text-theme-secondary-700"
 										/>
 									</Button>
 								</div>

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -140,11 +140,7 @@ export const PortfolioHeader = ({
 								<div className="flex items-center gap-1">
 									<ViewingAddressInfo wallets={selectedWallets} profile={profile} />
 									<Button variant="primary-transparent" size="icon" className="h-6 w-6">
-										<Icon
-											name="DoubleChevron"
-											width={26}
-											height={26}
-										/>
+										<Icon name="DoubleChevron" width={26} height={26} />
 									</Button>
 								</div>
 							</div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[portfolio] add hover state to address switch button](https://app.clickup.com/t/86dw7624m)

## Summary

- Address switch button has been refactored to now support the `primary-transparent` button styles.

<img width="145" alt="image" src="https://github.com/user-attachments/assets/50681d15-0502-4a3a-be74-cc126f7b1cd6" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
