### PR TITLE
refactor: manage button hover state

### DIFF
--- a/src/domains/portfolio/components/AddressesSidePanel/AddressesSidePanel.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/AddressesSidePanel.tsx
@@ -197,10 +197,10 @@ export const AddressesSidePanel = ({
 							<Button
 								data-testid="ManageAddresses"
 								size="icon"
-								variant="transparent"
+								variant="primary-transparent"
 								onClick={() => setDeleteMode(true)}
 								className={cn(
-									"p-2 py-0 text-sm leading-[18px] text-theme-primary-600 dark:text-theme-primary-400 sm:text-base sm:leading-5",
+									"p-2 py-[3px] text-sm leading-[18px] text-theme-primary-600 dark:text-theme-primary-400 sm:text-base sm:leading-5",
 									{
 										"ring ring-theme-primary-400 ring-offset-4 ring-offset-theme-secondary-100 dark:ring-theme-primary-800 dark:ring-offset-theme-dark-950 sm:ring-offset-transparent dark:sm:ring-offset-transparent":
 											showManageHint,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Side Panel] "Manage" button should have hover state](https://app.clickup.com/t/86dw8ffxj)

## Summary

- Button variant for "Manage" button has been changed to `primary-transparent`.
- Padding has been adjusted to match the designs.

<img width="203" alt="image" src="https://github.com/user-attachments/assets/726e55ba-babe-4e8f-abe1-b651764259b1" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
