### PR TITLE
fix: onboarding message z ordering

### DIFF
--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -69,8 +69,8 @@ export const SidePanel = ({
 			<FloatingPortal>
 				{isMounted && (
 					<>
-						<div className="fixed inset-0 z-[10000] bg-[#212225] bg-opacity-10 backdrop-blur-xl dark:bg-[#101627] dark:bg-opacity-10" />
-						<FloatingOverlay className="z-[10001] transition-opacity duration-300" lockScroll>
+						<div className="fixed inset-0 z-40 bg-[#212225] bg-opacity-10 backdrop-blur-xl dark:bg-[#101627] dark:bg-opacity-10" />
+						<FloatingOverlay className="z-50 transition-opacity duration-300" lockScroll>
 							<FloatingFocusManager context={context}>
 								<div
 									data-testid={dataTestId}

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -712,7 +712,7 @@ exports[`Dashboard > should render 1`] = `
               class="flex flex-col gap-3 bg-theme-primary-100 px-2 pb-2 pt-3 dark:bg-theme-dark-950 sm:gap-2 md:rounded-xl"
             >
               <div
-                class="flex w-full flex-row items-center justify-between px-4"
+                class="z-30 flex w-full flex-row items-center justify-between px-4"
               >
                 <div
                   aria-expanded="false"

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -95,10 +95,11 @@ export const PortfolioHeader = ({
 	return (
 		<header data-testid="WalletHeader" className="lg:container md:px-10 md:pt-8">
 			<div className="flex flex-col gap-3 bg-theme-primary-100 px-2 pb-2 pt-3 dark:bg-theme-dark-950 sm:gap-2 md:rounded-xl">
-				<div className="flex w-full flex-row items-center justify-between px-4">
+				<div className="z-30 flex w-full flex-row items-center justify-between px-4">
 					<Tooltip
 						visible={showHint}
 						interactive={true}
+
 						content={
 							<div className="flex flex-col items-center px-[3px] pb-1.5 text-sm leading-5 sm:flex-row sm:space-x-4 sm:pb-px sm:pt-px">
 								<div className="mb-2 block sm:mb-0 sm:inline">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dw9yxv3

I think for this specific issue we should apply a local solution because there are not many tooltips with `Got It` button. Since `tippy` appends its root to the parent element I only had to reduce parent's `z-index` to `30`, that will cancel out tippy's `z-index: 9999`.  

[Screencast from 2025-03-20 02-13-34.webm](https://github.com/user-attachments/assets/9adbee04-3cda-428f-a4ed-7e2128fba0d1)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
