### PR TITLE
refactor: options dropdown styling

### DIFF
--- a/src/app/components/Dropdown/Dropdown.contracts.ts
+++ b/src/app/components/Dropdown/Dropdown.contracts.ts
@@ -25,6 +25,7 @@ export interface DropdownOptionGroup {
 	hasDivider?: boolean;
 	options: DropdownOption[];
 	onSelect?: OnSelectProperties;
+	variant?: DropdownVariantType;
 }
 
 export interface OptionsProperties {

--- a/src/app/components/Dropdown/Dropdown.helpers.tsx
+++ b/src/app/components/Dropdown/Dropdown.helpers.tsx
@@ -27,7 +27,14 @@ const renderIcon = (option: DropdownOption) => {
 const isOptionGroup = (options: DropdownOption[] | DropdownOptionGroup[]) =>
 	options.length > 0 && options[0].key !== undefined;
 
-const renderOptionGroup = ({ key, hasDivider, title, options, onSelect }: DropdownOptionGroup) => {
+const renderOptionGroup = ({
+	key,
+	hasDivider,
+	title,
+	options,
+	onSelect,
+	variant,
+}: DropdownOptionGroup & { variant?: string }) => {
 	if (options.length === 0 || !onSelect) {
 		return;
 	}
@@ -45,7 +52,7 @@ const renderOptionGroup = ({ key, hasDivider, title, options, onSelect }: Dropdo
 						{title}
 					</li>
 				)}
-				{renderOptions({ key, onSelect, options })}
+				{renderOptions({ key, onSelect, options, variant })}
 			</ul>
 		</div>
 	);
@@ -70,7 +77,7 @@ export const renderOptions = ({ options, key, onSelect, variant }: OptionsProper
 		return (
 			<div>
 				{(options as DropdownOptionGroup[]).map((optionGroup: DropdownOptionGroup) =>
-					renderOptionGroup({ ...optionGroup, onSelect }),
+					renderOptionGroup({ ...optionGroup, onSelect, variant }),
 				)}
 			</div>
 		);
@@ -94,16 +101,25 @@ export const renderOptions = ({ options, key, onSelect, variant }: OptionsProper
 					}}
 				>
 					{option.iconPosition === "start" && renderIcon(option)}
-					<span>
+					<span className="flex w-full items-center justify-between">
 						{option.element}
-						{option.label}
+						<span>{option.label}</span>
 						{option.secondaryLabel && (
-							<span className="ml-1 text-theme-secondary-500 dark:text-theme-secondary-600">
+							<span className="ml-1 pr-4 text-theme-secondary-500 dark:text-theme-secondary-600">
 								{renderSecondaryLabel(option.secondaryLabel, !!option.active)}
 							</span>
 						)}
 					</span>
 					{option.iconPosition !== "start" && renderIcon(option)}
+					<div className="h-4 w-4">
+						{option.active && variant === "options" && (
+							<Icon
+								name={"CheckmarkDouble"}
+								size="md"
+								className="text-theme-primary-600 dark:text-theme-secondary-200"
+							/>
+						)}
+					</div>
 				</DropdownItem>
 			))}
 		</ul>

--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -125,6 +125,7 @@ export const Dropdown: FC<DropdownProperties> = ({
 						className={twMerge(
 							"z-40 w-full sm:w-auto",
 							classNames({
+								"min-w-52": variant === "options",
 								"px-5 sm:px-0": variant !== "navbar",
 								"rounded-none sm:mt-2": variant === "navbar",
 							}),
@@ -136,7 +137,13 @@ export const Dropdown: FC<DropdownProperties> = ({
 					>
 						<Wrapper
 							variant={options && variant === undefined ? "options" : variant}
-							className="dropdown-body overflow-hidden rounded bg-white p-1 shadow-xl outline-none dark:bg-theme-dark-900"
+							className={cn(
+								"dropdown-body overflow-hidden bg-white p-1 shadow-xl outline-none dark:bg-theme-dark-900",
+								{
+									rounded: variant !== "options",
+									"rounded-xl": variant === "options",
+								},
+							)}
 						>
 							{top}
 							{options?.length && renderOptions({ onSelect: onSelectOption, options, variant })}

--- a/src/app/components/Dropdown/DropdownItem.tsx
+++ b/src/app/components/Dropdown/DropdownItem.tsx
@@ -11,12 +11,14 @@ export const DropdownItem = ({
 	<li
 		{...props}
 		className={twMerge(
-			"mx-1 my-1 flex items-center space-x-2 whitespace-nowrap rounded px-5 py-4 text-left text-base font-semibold transition-colors-shadow duration-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400",
+			"flex items-center whitespace-nowrap text-left text-base font-semibold transition-colors-shadow duration-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400",
 			cn({
 				"bg-theme-secondary-200 text-theme-primary-600 dark:bg-theme-dark-950 dark:text-theme-dark-50":
 					isActive,
 				"cursor-pointer text-theme-secondary-700 hover:bg-theme-secondary-200 hover:text-theme-secondary-900 dark:text-theme-dark-200 hover:dark:bg-theme-secondary-900":
 					!isActive,
+				"mx-1 my-1 space-x-2 rounded px-5 py-4": variant !== "options",
+				"my-0.5 justify-between rounded-lg px-5 py-[14px]": variant === "options",
 				"rounded-lg": !isActive && variant !== "navbar",
 				"sm:rounded-lg": !isActive && variant === "navbar",
 			}),

--- a/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/CsvSettings.tsx
+++ b/src/domains/transaction/components/TransactionExportModal/TransactionExportForm/CsvSettings.tsx
@@ -24,6 +24,7 @@ const SelectDelimiter = ({ value, onSelect }: { value: CsvDelimiter; onSelect?: 
 	return (
 		<FormField name="delimiter">
 			<Dropdown
+				variant="options"
 				data-testid="TransactionExportForm--delimiter-options"
 				wrapperClass="z-50"
 				options={delimiterOptions.options}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] update dropdown design](https://app.clickup.com/t/86dwb57je)

## Summary

- Support for `variant` prop has been added for the dropdown render helpers.
- Styles have been updated for `options` variant in the dropdown `Wrapper` and `Item` components.
- The double check icon is now displayed for the selected option in this variant of the dropdown.

## Screenshots

<img width="314" alt="image" src="https://github.com/user-attachments/assets/58e99a0f-0281-4b09-a7db-f31104b5a3f9" />

<img width="308" alt="image" src="https://github.com/user-attachments/assets/07a89322-3a49-4a01-8395-38da06dd6c5d" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
