### PR TITLE
fix: reset import state when closing side panel

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -87,6 +87,7 @@ export const ImportAddressesSidePanel = ({
 		}
 
 		setActiveTab(Step.MethodStep);
+		setImportedWallet(undefined);
 		form.reset();
 	}, [open]);
 
@@ -161,7 +162,7 @@ export const ImportAddressesSidePanel = ({
 			return history.push(`/profiles/${activeProfile.id()}/dashboard`);
 		}
 
-		if (activeTab === Step.EncryptPasswordStep) {
+		if (activeTab === Step.EncryptPasswordStep && importedWallet) {
 			forgetImportedWallets(importedWallet);
 		}
 
@@ -310,10 +311,12 @@ export const ImportAddressesSidePanel = ({
 							</TabPanel>
 
 							<TabPanel tabId={Step.SummaryStep}>
-								<SuccessStep
-									importedWallet={importedWallet}
-									onClickEditAlias={() => setIsEditAliasModalOpen(true)}
-								/>
+								{importedWallet && (
+									<SuccessStep
+										importedWallet={importedWallet}
+										onClickEditAlias={() => setIsEditAliasModalOpen(true)}
+									/>
+								)}
 							</TabPanel>
 						</div>
 					</Tabs>


### PR DESCRIPTION
Alternative of https://github.com/ArdentHQ/arkvault/pull/1096 to reset the imported wallet state when closing the side panel 

Task: https://app.clickup.com/t/86dwa3crp

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
