### PR TITLE
chore: use github.ref over head_ref for concurrency

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -12,7 +12,7 @@ jobs:
                 node-version: [20.12.2]
 
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}
+            group: ${{ github.ref }}-snapshots
             cancel-in-progress: true
 
         steps:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -12,7 +12,7 @@ jobs:
                 node-version: [20.12.2]
 
         concurrency:
-            group: ${{ github.head_ref }}-snapshots
+            group: ${{ github.workflow }}-${{ github.ref }}
             cancel-in-progress: true
 
         steps:
@@ -48,5 +48,5 @@ jobs:
 
             - uses: stefanzweifel/git-auto-commit-action@v4
               with:
-                commit_message: "chore: update snapshots"
-                branch: ${{ github.head_ref }}
+                  commit_message: "chore: update snapshots"
+                  branch: ${{ github.head_ref }}


### PR DESCRIPTION
this will make the reference unique per branch. Right now it will cancel any other snapshot workflows when triggered from the workflow dispatch button as head_ref does not work well with that. Instead `github.ref` should allow us to run them for multiple branches at the same time, while it still cancels the workflow when triggered more than once on the same branch