### PR TITLE
fix: sync on import for votes page

### DIFF
--- a/src/domains/vote/pages/Votes/Votes.tsx
+++ b/src/domains/vote/pages/Votes/Votes.tsx
@@ -105,6 +105,17 @@ export const Votes: FC = () => {
 	}, [votes, setVoteFilter]);
 
 	useEffect(() => {
+		const syncVotes = async () => {
+			if (selectedWallet) {
+				await env.delegates().sync(activeProfile, selectedWallet.coinId(), selectedWallet.networkId());
+				await selectedWallet.synchroniser().votes();
+			}
+		};
+
+		void syncVotes();
+	}, [selectedWallet, env, activeProfile]);
+
+	useEffect(() => {
 		const { hasErroredNetworks } = getErroredNetworks(activeProfile);
 		if (!hasErroredNetworks) {
 			return;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[votes] sync issue](https://app.clickup.com/t/86dwcvhvh)

## Summary

- Votes are now synced when updating the profile and selected wallet from the votes page.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
