### PR TITLE
refactor: close sidepanel on switching in single view mode

### DIFF
--- a/src/domains/portfolio/components/AddressesSidePanel/AddressesSidePanel.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/AddressesSidePanel.tsx
@@ -133,6 +133,9 @@ export const AddressesSidePanel = ({
 		if (activeMode === AddressViewSelection.single) {
 			setSelectedAddresses([address]);
 			await setSingleSelectedAddress([address]);
+
+			onOpenChange(false);
+			onClose([address]);
 		} else {
 			if (selectedAddresses.includes(address)) {
 				const newSelection = selectedAddresses.filter((a) => a !== address);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[sidepanel] close automatically when switching address in single view](https://app.clickup.com/t/86dwfk3h2)

## Summary

- Sidepanel will now close when switching addresses in single view mode 

<!-- What changes are being made? -->

https://github.com/user-attachments/assets/ff36af82-5ed5-466b-83dd-ece6a5bef1d2



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
