### PR TITLE
fix: remove comma from navbar

### DIFF
--- a/src/app/components/Layout/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/src/app/components/Layout/components/Page/__snapshots__/Page.test.tsx.snap
@@ -458,7 +458,6 @@ exports[`Page > should render with navigation context 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1165,7 +1164,6 @@ exports[`Page > should render with navigation context 2`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1872,7 +1870,6 @@ exports[`Page > should render with navigation context 3`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -2579,7 +2576,6 @@ exports[`Page > should render with sidebar = false 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -3282,7 +3278,6 @@ exports[`Page > should render with sidebar = true 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/app/components/NavigationBar/NavigationBar.blocks.tsx
+++ b/src/app/components/NavigationBar/NavigationBar.blocks.tsx
@@ -370,7 +370,6 @@ export const NavigationBarFull: React.FC<NavigationBarFullProperties> = ({
 											>
 												<Icon name="Received" size="lg" className="p-1" />
 											</Button>
-											´{" "}
 										</NavigationButtonWrapper>
 									</div>
 								</Tooltip>

--- a/src/app/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
+++ b/src/app/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
@@ -427,7 +427,6 @@ exports[`NavigationBar > should not render with title if variant is full 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -1149,7 +1148,6 @@ exports[`NavigationBar > should render full variant when profile restored is fal
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -1820,7 +1818,6 @@ exports[`NavigationBar > should render full variant when profile restored is tru
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -2492,7 +2489,6 @@ exports[`NavigationBar > should render in lg 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -3164,7 +3160,6 @@ exports[`NavigationBar > should render in md 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -3836,7 +3831,6 @@ exports[`NavigationBar > should render in sm 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -4508,7 +4502,6 @@ exports[`NavigationBar > should render in small screen variant 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -5180,7 +5173,6 @@ exports[`NavigationBar > should render in xs 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>
@@ -5852,7 +5844,6 @@ exports[`NavigationBar > should render with custom menu 1`] = `
                     </div>
                   </div>
                 </button>
-                ´ 
               </div>
             </div>
           </div>

--- a/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
+++ b/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
@@ -454,7 +454,6 @@ exports[`Contacts > should render compact on md screen 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1959,7 +1958,6 @@ exports[`Contacts > should render responsive with contacts 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -3201,7 +3199,6 @@ exports[`Contacts > should render with contacts 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -4706,7 +4703,6 @@ exports[`Contacts > should render without contacts 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -454,7 +454,6 @@ exports[`Dashboard > should render 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
+++ b/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
@@ -454,8 +454,6 @@ exports[`Exchange > should render empty 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´
-                   
                 </div>
               </div>
             </div>
@@ -1322,8 +1320,6 @@ exports[`Exchange > should render with exchanges 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´
-                   
                 </div>
               </div>
             </div>

--- a/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/message/pages/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`SignMessage > Sign with Wallet > should render (lg) 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1550,7 +1549,6 @@ exports[`SignMessage > Sign with Wallet > should render (xs) 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/message/pages/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/message/pages/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`VerifyMessage > should render (lg) 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1454,7 +1453,6 @@ exports[`VerifyMessage > should render (xs) 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/setting/pages/Export/__snapshots__/Export.test.tsx.snap
+++ b/src/domains/setting/pages/Export/__snapshots__/Export.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`Export Settings > should render export settings 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
+++ b/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
@@ -460,7 +460,6 @@ exports[`General Settings > should disable submit button when profile is not res
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -2985,7 +2984,6 @@ exports[`General Settings > should not update the uploaded avatar when removing 
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -5555,7 +5553,6 @@ exports[`General Settings > should render 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -8081,7 +8078,6 @@ exports[`General Settings > should update profile 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -10607,7 +10603,6 @@ exports[`General Settings > should update the avatar when removing focus from na
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -13132,7 +13127,6 @@ exports[`General Settings > should update the avatar when removing focus from na
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
+++ b/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
@@ -457,7 +457,6 @@ exports[`Password Settings > should render password settings 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1672,7 +1671,6 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/transaction/pages/SendValidatorResignation/__snapshots__/SendValidatorResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendValidatorResignation/__snapshots__/SendValidatorResignation.test.tsx.snap
@@ -333,7 +333,6 @@ exports[`SendValidatorResignation > Validator Resignation > should change fee 1`
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1670,7 +1669,6 @@ exports[`SendValidatorResignation > Validator Resignation > should render 1st st
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -2757,7 +2755,6 @@ exports[`SendValidatorResignation > Validator Resignation > should render 2nd st
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -3978,7 +3975,6 @@ exports[`SendValidatorResignation > Validator Resignation > should render 3rd st
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -4972,7 +4968,6 @@ exports[`SendValidatorResignation > Validator Resignation > should show error st
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>

--- a/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
+++ b/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
@@ -461,7 +461,6 @@ exports[`Votes > should filter current delegates 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -1824,7 +1823,6 @@ exports[`Votes > should open the create wallet side panel 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -2651,7 +2649,6 @@ exports[`Votes > should open the import wallet side panel 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -3485,7 +3482,6 @@ exports[`Votes > should render 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -11458,7 +11454,6 @@ exports[`Votes > should render and handle wallet current voting exception 1`] = 
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -19431,7 +19426,6 @@ exports[`Votes > should select a validator 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>
@@ -27665,7 +27659,6 @@ exports[`Votes > should trigger network connection warning 1`] = `
                       </div>
                     </div>
                   </button>
-                  ´ 
                 </div>
               </div>
             </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[navbar] random comma appearing just under navbar?](https://app.clickup.com/t/86dwfwdxe)

## Summary

- A random `´` character was being rendered below the navbar buttons and has now been removed from the codebase.
- Snapshots have been updated to support this change.

<img width="458" alt="image" src="https://github.com/user-attachments/assets/536d0138-7d3e-441b-a5f3-f0be3c252834" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
