### PR TITLE
fix: increase gas limit for multipayments

### DIFF
--- a/src/domains/transaction/components/FeeField/FeeField.tsx
+++ b/src/domains/transaction/components/FeeField/FeeField.tsx
@@ -50,22 +50,18 @@ export const FeeField: React.FC<Properties> = ({ type, network, profile, ...prop
 	useEffect(() => {
 		const recalculateFee = async () => {
 			setIsLoadingFee(true);
-	
+
 			const transactionFees = await calculate({
 				coin: network.coin(),
 				data,
 				network: network.id(),
 				type,
 			});
-	
+
 			/* istanbul ignore else -- @preserve */
 			const isMultiPayment = type === "multiPayment";
-			const recipientsCount = isMultiPayment && Array.isArray(data?.payments)
-				? data.payments.length
-				: 1;
-			const defaultGasLimit = isMultiPayment
-				? GasLimit.multiPayment * recipientsCount
-				: GasLimit[type];
+			const recipientsCount = isMultiPayment && Array.isArray(data?.payments) ? data.payments.length : 1;
+			const defaultGasLimit = isMultiPayment ? GasLimit.multiPayment * recipientsCount : GasLimit[type];
 
 			if (getValues("gasPrice") === undefined) {
 				setValue("gasPrice", transactionFees.avg, { shouldDirty: true, shouldValidate: true });
@@ -75,10 +71,9 @@ export const FeeField: React.FC<Properties> = ({ type, network, profile, ...prop
 			setValue("fees", transactionFees, { shouldDirty: true, shouldValidate: true });
 			setIsLoadingFee(false);
 		};
-	
+
 		void recalculateFee();
 	}, [calculate, data, getValues, network.id(), setValue, type]);
-	
 
 	return (
 		<InputFee

--- a/src/domains/transaction/components/FeeField/FeeField.tsx
+++ b/src/domains/transaction/components/FeeField/FeeField.tsx
@@ -24,7 +24,7 @@ interface Properties {
 export const GasLimit: Record<Properties["type"], number> = {
 	delegateRegistration: 500_000,
 	delegateResignation: 150_000,
-	multiPayment: 24_000,
+	multiPayment: 21_000,
 	multiSignature: 21_000,
 	transfer: 21_000,
 	usernameRegistration: 200_000,
@@ -50,30 +50,35 @@ export const FeeField: React.FC<Properties> = ({ type, network, profile, ...prop
 	useEffect(() => {
 		const recalculateFee = async () => {
 			setIsLoadingFee(true);
-
+	
 			const transactionFees = await calculate({
 				coin: network.coin(),
 				data,
 				network: network.id(),
 				type,
 			});
-
+	
 			/* istanbul ignore else -- @preserve */
+			const isMultiPayment = type === "multiPayment";
+			const recipientsCount = isMultiPayment && Array.isArray(data?.payments)
+				? data.payments.length
+				: 1;
+			const defaultGasLimit = isMultiPayment
+				? GasLimit.multiPayment * recipientsCount
+				: GasLimit[type];
+
 			if (getValues("gasPrice") === undefined) {
 				setValue("gasPrice", transactionFees.avg, { shouldDirty: true, shouldValidate: true });
 			}
 
-			if (getValues("gasLimit") === undefined) {
-				setValue("gasLimit", GasLimit[type], { shouldDirty: true, shouldValidate: true });
-			}
-
+			setValue("gasLimit", defaultGasLimit, { shouldDirty: true, shouldValidate: true });
 			setValue("fees", transactionFees, { shouldDirty: true, shouldValidate: true });
-
 			setIsLoadingFee(false);
 		};
-
+	
 		void recalculateFee();
 	}, [calculate, data, getValues, network.id(), setValue, type]);
+	
 
 	return (
 		<InputFee
@@ -83,7 +88,11 @@ export const FeeField: React.FC<Properties> = ({ type, network, profile, ...prop
 			loading={!fees || isLoadingFee}
 			gasPrice={gasPrice}
 			gasLimit={gasLimit}
-			defaultGasLimit={GasLimit[type]}
+			defaultGasLimit={
+				type === "multiPayment" && Array.isArray(data?.payments)
+					? GasLimit.multiPayment * data.payments.length
+					: GasLimit[type]
+			}
 			minGasPrice={MIN_GAS_PRICE}
 			gasPriceStep={1}
 			network={network}

--- a/src/domains/transaction/components/FeeField/FeeField.tsx
+++ b/src/domains/transaction/components/FeeField/FeeField.tsx
@@ -24,7 +24,7 @@ interface Properties {
 export const GasLimit: Record<Properties["type"], number> = {
 	delegateRegistration: 500_000,
 	delegateResignation: 150_000,
-	multiPayment: 21_000,
+	multiPayment: 24_000,
 	multiSignature: 21_000,
 	transfer: 21_000,
 	usernameRegistration: 200_000,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[multipay] transactions fail by default](https://app.clickup.com/t/86dwh10p8)

## Summary

- Multipayment transactions constantly started failing providing errors related to the gas limit being lower than expected for the pre-verification of the transaction. This amount, fluctuated betweek 22000 and 23000, reason why in this PR, I am increasing the default gas limit for multipayments to 24 000.

![image](https://github.com/user-attachments/assets/f403520e-847d-40df-bf75-1f858f1a9a4b)

![image](https://github.com/user-attachments/assets/5c55f561-9452-475c-a5e2-89bd2f71f73d)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
