### PR TITLE
fix: wallet encryption disappear

### DIFF
--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
@@ -25,7 +25,7 @@ export const WalletEncryptionBanner = ({
 		<div
 			className={cn("flex w-full flex-col rounded-xl border", {
 				"border-theme-secondary-300 dark:border-theme-dark-700": !toggleChecked,
-				"border-theme-warning-300 dark:border-theme-warning-700 overflow-hidden": toggleChecked,
+				"overflow-hidden border-theme-warning-300 dark:border-theme-warning-700": toggleChecked,
 			})}
 		>
 			<div className="flex flex-row justify-between px-6 py-4">

--- a/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
+++ b/src/domains/wallet/components/WalletEncryptionBanner.tsx/WalletEncryptionBanner.tsx
@@ -23,9 +23,9 @@ export const WalletEncryptionBanner = ({
 
 	return (
 		<div
-			className={cn("flex w-full flex-col overflow-hidden rounded-xl border", {
+			className={cn("flex w-full flex-col rounded-xl border", {
 				"border-theme-secondary-300 dark:border-theme-dark-700": !toggleChecked,
-				"border-theme-warning-300 dark:border-theme-warning-700": toggleChecked,
+				"border-theme-warning-300 dark:border-theme-warning-700 overflow-hidden": toggleChecked,
 			})}
 		>
 			<div className="flex flex-row justify-between px-6 py-4">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[side panel] can make wallet encryption disappear](https://app.clickup.com/t/86dwhfjtf)

## Summary

- `overflow-hidden` class name is being applied only when wallet encryption toggle is enabled, this will prevent the issue when tabbing inside the wallet encryption banner.

<!-- What changes are being made? -->

https://github.com/user-attachments/assets/cfd8e58f-0e40-4cf9-89ee-ce1ce5d84b4b



<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
