### PR TITLE
fix: block height shown as nan

### DIFF
--- a/src/domains/transaction/components/TransactionDetail/TransactionDetails/TransactionDetails.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionDetails/TransactionDetails.tsx
@@ -44,7 +44,7 @@ export const TransactionDetails = ({
 	const timestamp = transaction.timestamp();
 
 	const { blockHeight } = useBlockHeight({
-		blockId: transaction.blockHash(),
+		blockHash: transaction.blockHash(),
 		network: transactionWallet.network(),
 	});
 

--- a/src/domains/transaction/hooks/use-block-height.ts
+++ b/src/domains/transaction/hooks/use-block-height.ts
@@ -12,7 +12,6 @@ export const useBlockHeight = ({
 }): { blockHeight?: string; isLoading: boolean } => {
 	const [blockHeight, setBlockHeight] = useState<string>();
 	const [isLoading, setIsLoading] = useState(false);
-	console.log({ blockHash });
 	useEffect(() => {
 		const client = new HttpClient(0);
 

--- a/src/domains/transaction/hooks/use-block-height.ts
+++ b/src/domains/transaction/hooks/use-block-height.ts
@@ -4,15 +4,15 @@ import { Networks } from "@ardenthq/sdk";
 import { Numeral } from "@/app/lib/intl";
 
 export const useBlockHeight = ({
-	blockId,
+	blockHash,
 	network,
 }: {
-	blockId?: string;
+	blockHash?: string;
 	network: Networks.Network;
 }): { blockHeight?: string; isLoading: boolean } => {
 	const [blockHeight, setBlockHeight] = useState<string>();
 	const [isLoading, setIsLoading] = useState(false);
-
+	console.log({ blockHash });
 	useEffect(() => {
 		const client = new HttpClient(0);
 
@@ -24,10 +24,10 @@ export const useBlockHeight = ({
 				const {
 					hosts: [api],
 				} = network.toObject();
-				const response = await client.get(`${api.host}/blocks/${blockId}`);
+				const response = await client.get(`${api.host}/blocks/${blockHash}`);
 				const { data } = response.json();
 
-				setBlockHeight(Numeral.make("en").format(data.height));
+				setBlockHeight(Numeral.make("en").format(data.number));
 			} catch {
 				//
 			}
@@ -35,10 +35,10 @@ export const useBlockHeight = ({
 			setIsLoading(false);
 		};
 
-		if (blockId) {
+		if (blockHash) {
 			fetchBlockHeight();
 		}
-	}, [blockId, network]);
+	}, [blockHash, network]);
 
 	return {
 		blockHeight,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx details] block height shows as NaN](https://app.clickup.com/t/86dwkdacv)

## Summary

- `blockId` prop has been renamed to `blockHash` in `useBlockHeight` hook.
- `data.height` has been updated to `data.number` in API response, to prevent `NaN` from appearing.


<img width="627" alt="image" src="https://github.com/user-attachments/assets/a878ed15-f403-42e5-a5f1-7b7794a266dc" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
