### PR TITLE
fix: sign message button hover state

### DIFF
--- a/src/domains/message/pages/SignMessage/SignMessage.tsx
+++ b/src/domains/message/pages/SignMessage/SignMessage.tsx
@@ -256,9 +256,10 @@ export const SignMessage: React.VFC = () => {
 										data={JSON.stringify(signedMessage)}
 										data-testid="SignMessage__copy-button"
 										wrapperClassName="flex-1 md:flex-none"
+										buttonClassName="bg-theme-primary-600 text-center text-base font-semibold text-white hover:bg-theme-primary-700"
 									>
 										<div
-											className="relative inline-flex items-center space-x-3 rounded bg-theme-primary-600 text-center text-base font-semibold text-white hover:bg-theme-primary-700"
+											className="relative inline-flex items-center space-x-3 rounded"
 											data-testid="SignMessage__back-to-wallet-button"
 										>
 											<Icon name="Copy" />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[message] incorrect button hover state](https://app.clickup.com/t/86dwkt20u)

## Summary

- Class names applied to the div wrapper have been moved to the button class name container in `Clipboard` button variant.

<img width="441" alt="image" src="https://github.com/user-attachments/assets/80379413-32b3-4c56-88e6-740b7df1ea02" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
