### PR TITLE
fix: unable to add recipients in multipayments

### DIFF
--- a/src/app/lib/sdk/network.ts
+++ b/src/app/lib/sdk/network.ts
@@ -305,7 +305,7 @@ export class Network {
 	 * @memberof Network
 	 */
 	public usesMemo(): boolean {
-		return get(this.#network, "validators.memo", false);
+		return get(this.#network, "transactions.memo", false);
 	}
 
 	/**
@@ -315,7 +315,7 @@ export class Network {
 	 * @memberof Network
 	 */
 	public usesUTXO(): boolean {
-		return get(this.#network, "validators.utxo", false);
+		return get(this.#network, "transactions.utxo", false);
 	}
 
 	/**
@@ -325,7 +325,7 @@ export class Network {
 	 * @memberof Network
 	 */
 	public usesLockedBalance(): boolean {
-		return get(this.#network, "validators.lockedBalance", false);
+		return get(this.#network, "transactions.lockedBalance", false);
 	}
 
 	/**
@@ -335,7 +335,7 @@ export class Network {
 	 * @memberof Network
 	 */
 	public multiPaymentRecipients(): number {
-		return get(this.#network, "validators.multiPaymentRecipients", 0);
+		return get(this.#network, "transactions.multiPaymentRecipients", 0);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[multipayment] can no longer add recipients](https://app.clickup.com/t/86dwn072d)

## Summary

- The properties in `network.ts` from the `lib` have been adjusted to match the correct property from the network, allowing users to add recipients again in multipayment transactions. Previously, this wasn't possible due to the `maxRecipients` having a value of 0.

<img width="739" alt="image" src="https://github.com/user-attachments/assets/33b79608-d5f0-448a-812f-be9a10e31d01" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
