### PR TITLE
refactor: onboarding tooltip for single address

### DIFF
--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -73,12 +73,12 @@ export const PortfolioHeader = ({
 	const { persist } = useEnvironmentContext();
 
 	const [showHint, setShowHint] = useState<boolean>(false);
-	const [hintHasShown, persistHintShown] = useLocalStorage<boolean | undefined>("multiple-addresses-hint", undefined);
+	const [hintHasShown, persistHintShown] = useLocalStorage<boolean | undefined>("single-address-hint", undefined);
 
 	useEffect(() => {
 		let id: NodeJS.Timeout;
-
-		if (hasFocus && hintHasShown === undefined && selectedWallets.length > 1) {
+		
+		if (hasFocus && hintHasShown === undefined && allWallets.length > 1 && mode === "single") {
 			id = setTimeout(() => {
 				setShowHint(true);
 			}, 1000);
@@ -87,7 +87,7 @@ export const PortfolioHeader = ({
 		return () => {
 			clearTimeout(id);
 		};
-	}, [hasFocus, hintHasShown, selectedWallets.length]);
+	}, [hasFocus, hintHasShown, mode, allWallets.length]);
 
 	const onDeleteAddress = async (address: string) => {
 		for (const wallet of profile.wallets().values()) {
@@ -117,7 +117,7 @@ export const PortfolioHeader = ({
 						content={
 							<div className="flex flex-col items-center px-[3px] pb-1.5 text-sm leading-5 sm:flex-row sm:space-x-4 sm:pb-px sm:pt-px">
 								<div className="mb-2 block sm:mb-0 sm:inline">
-									<Trans i18nKey="WALLETS.MULTIPLE_ADDRESSES_HINT" />
+									<Trans i18nKey="WALLETS.SINGLE_ADDRESS_HINT" />
 								</div>
 								<Button
 									size="xs"

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -77,7 +77,7 @@ export const PortfolioHeader = ({
 
 	useEffect(() => {
 		let id: NodeJS.Timeout;
-		
+
 		if (hasFocus && hintHasShown === undefined && allWallets.length > 1 && mode === "single") {
 			id = setTimeout(() => {
 				setShowHint(true);

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -116,7 +116,7 @@ export const PortfolioHeader = ({
 						interactive={true}
 						content={
 							<div className="flex flex-col items-center px-[3px] pb-1.5 text-sm leading-5 sm:flex-row sm:space-x-4 sm:pb-px sm:pt-px">
-								<div className="mb-2 block sm:mb-0 sm:inline">
+								<div className="mb-2 block max-w-96 sm:mb-0 sm:inline">
 									<Trans i18nKey="WALLETS.SINGLE_ADDRESS_HINT" />
 								</div>
 								<Button

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -85,8 +85,8 @@ export const translations = {
 		TITLE: "Wallet Update {{version}}",
 	},
 
-	MULTIPLE_ADDRESSES_HINT:
-		"Your address has been automatically added to <br/> the overview. You can select it here to make changes.",
+	SINGLE_ADDRESS_HINT:
+		"You're automatically viewing the latest created/imported address. You can select here to make changes",
 
 	PAGE_CREATE_WALLET: {
 		NETWORK_STEP: {

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -85,9 +85,6 @@ export const translations = {
 		TITLE: "Wallet Update {{version}}",
 	},
 
-	SINGLE_ADDRESS_HINT:
-		"You're automatically viewing the latest created/imported address. You can select here to make changes",
-
 	PAGE_CREATE_WALLET: {
 		NETWORK_STEP: {
 			GENERATION_ERROR:
@@ -275,6 +272,9 @@ export const translations = {
 	},
 
 	SIGNATURE: "Signature",
+
+	SINGLE_ADDRESS_HINT:
+		"You're automatically viewing the latest created/imported address. You can select here to make changes",
 
 	STATUS: {
 		ACTIVE: "Active",

--- a/src/domains/wallet/i18n.ts
+++ b/src/domains/wallet/i18n.ts
@@ -274,7 +274,7 @@ export const translations = {
 	SIGNATURE: "Signature",
 
 	SINGLE_ADDRESS_HINT:
-		"You're automatically viewing the latest created/imported address. You can select here to make changes",
+		"You're automatically viewing the latest created/imported address. You can select here to make changes.",
 
 	STATUS: {
 		ACTIVE: "Active",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] changes to onboarding tooltip](https://app.clickup.com/t/86dwm8ufz)

## Summary

- The hint tooltip has been refactored and will now appear when more than one wallet has been imported in single mode.
- Text for single address tooltip has been updated.

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/90c4a469-9f87-47c6-b8cb-b1ce8c643c4a" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
