### PR TITLE
refactor: accessibility for import wallet

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/MethodStep.tsx
+++ b/src/domains/portfolio/components/ImportWallet/MethodStep.tsx
@@ -32,10 +32,9 @@ export const MethodStep = ({ network, onSelect }: { network: Networks.Network; o
 };
 
 const Option = ({ option, onSelect }: { option: ImportOption; onSelect: (option: ImportOption) => void }) => (
-	<div
+	<button
 		onClick={() => onSelect(option)}
-		tabIndex={0}
-		className="group cursor-pointer space-y-2 rounded-lg border border-theme-primary-200 p-4 hover:bg-theme-primary-200 dark:border-theme-dark-700 dark:hover:bg-theme-dark-700 sm:p-6"
+		className="group flex w-full cursor-pointer flex-col items-start space-y-2 rounded-lg border border-theme-primary-200 p-4 hover:bg-theme-primary-200 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-primary-400 dark:border-theme-dark-700 dark:hover:bg-theme-dark-700 sm:p-6"
 	>
 		<div className="flex items-center space-x-2">
 			{option.icon && (
@@ -52,5 +51,5 @@ const Option = ({ option, onSelect }: { option: ImportOption; onSelect: (option:
 				{option.description}
 			</div>
 		)}
-	</div>
+	</button>
 );


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[a11y] allow to select import method with tab and enter](https://app.clickup.com/t/86dwrbgnf)

## Summary

- `Option` component in `MethodStep` has been refactored to be a `button` component that includes class names for customizing the focus state styles.

<img width="580" alt="image" src="https://github.com/user-attachments/assets/fbaaf271-8521-40ce-8af4-5d3311614dab" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
