### PR TITLE
chore: use knip to locate unused code & files with `pnpm unused`

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://unpkg.com/knip@5/schema.json",
+	"typescript": {
+		"config": ["tsconfig.json"]
+	},
+
+	"entry": ["src/main.tsx", "src/app/**/*.{ts,tsx}", "src/lib/index.ts", "!src/**/cucumber/**"],
+
+	"project": ["src/**/*.{ts,tsx}", "!src/**/cucumber/**"],
+
+	"ignore": ["src/generated/**", "**/cucumber/**", "**/e2e/**", "**/*.test.*", "dist/**"],
+
+	"ignoreDependencies": ["tippy.js", "slick-carousel", "assert"]
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"test:e2e:ci:firefox": "E2E_HOST='http://localhost:5001' gherkin-testcafe --config-file=.testcaferc.json firefox:headless -q attemptLimit=3,successThreshold=1",
 		"test:e2e:ci:edge": "E2E_HOST='http://localhost:5001' gherkin-testcafe --config-file=.testcaferc.json edge:headless -q attemptLimit=3,successThreshold=1",
 		"sdk:install-local": "node scripts/install-local-sdk.js",
-		"sdk:check-updates": "npx npm-check-updates \"/^@ardenthq.*$/\" -u"
+		"sdk:check-updates": "npx npm-check-updates \"/^@ardenthq.*$/\" -u",
+		"unused": "npx knip --config ./knip.json"
 	},
 	"dependencies": {
 		"@ardenthq/arkvault-crypto": "^0.0.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,10 @@
 		"useUnknownInCatchVariables": false,
 		"noImplicitAny": false,
 		"noFallthroughCasesInSwitch": true,
-		"types": ["vite-plugin-pwa/client", "vitest/globals"]
+		"types": ["vite-plugin-pwa/client", "vitest/globals"],
+		"paths": {
+			"@/*": ["./*"]
+		}
 	},
 	"exclude": [
 		"**/*.test.ts",
@@ -32,6 +35,5 @@
 		"src/setupTests.ts",
 		"dist/**/*"
 	],
-	"include": ["src", "public", "custom.d.ts", "global.d.ts"],
-	"extends": "./tsconfig.paths.json"
+	"include": ["src", "public", "custom.d.ts", "global.d.ts"]
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,7 +1,0 @@
-{
-	"compilerOptions": {
-		"paths": {
-			"@/*": ["./*"]
-		}
-	}
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,3 @@
-import OptimizationPersist from "vite-plugin-optimize-persist";
-import PkgConfig from "vite-plugin-package-config";
 import { VitePWA } from "vite-plugin-pwa";
 import { defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
@@ -76,8 +74,6 @@ export default defineConfig(async () => {
 			tailwindcss(),
 			react(),
 			svgrPlugin(),
-			PkgConfig(),
-			OptimizationPersist(),
 			VitePWA({
 				workbox: {
 					// Prevent from precaching html files. Caching index.html causes white-screen after each deployment.
@@ -177,5 +173,51 @@ export default defineConfig(async () => {
 				},
 			}),
 		],
+		optimizeDeps: {
+			include: [
+				"@ardenthq/arkvault-crypto",
+				"rollup-plugin-polyfill-node/polyfills/util",
+				"@faustbrian/node-haveibeenpwned",
+				"@ardenthq/arkvault-url",
+				"@tippyjs/react",
+				"assert",
+				"browser-fs-access",
+				"classnames",
+				"cross-fetch",
+				"downshift",
+				"focus-visible",
+				"framer-motion",
+				"i18next",
+				"locale-currency",
+				"multiformats",
+				"p-retry",
+				"qr-scanner",
+				"react",
+				"react-datepicker",
+				"react-dom",
+				"react-error-boundary",
+				"react-hook-form",
+				"react-i18next",
+				"react-idle-timer",
+				"react-linkify",
+				"react-loading-skeleton",
+				"react-qr-reader",
+				"react-resize-detector",
+				"react-responsive",
+				"react-router",
+				"react-router-dom",
+				"react-table",
+				"react-toastify",
+				"react-visibility-sensor",
+				"semver",
+				"socks-proxy-agent",
+				"string-hash",
+				"yup",
+				"react-zendesk",
+				"@ledgerhq/hw-app-eth",
+				"@ledgerhq/hw-transport-webhid",
+				"@ledgerhq/hw-transport-webusb",
+			],
+		},
 	};
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
A PoC using `knip` with an updated config to check whether it picks up the unused code & files correctly.

### Usage
Run `pnpm unused` to see the list of unused code, files, exports and dependencies
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
