### PR TITLE
refactor: allow tabbing into dropdowns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -730,7 +730,7 @@ jobs:
             - name: Test Components ^A-O
               env:
                   COVERAGE_THRESHOLD_LINES: 97.5
-                  COVERAGE_THRESHOLD_FUNCTIONS: 95.78
+                  COVERAGE_THRESHOLD_FUNCTIONS: 94.79
                   COVERAGE_THRESHOLD_STATEMENTS: 97.57
                   COVERAGE_THRESHOLD_BRANCHES: 94.88
                   COVERAGE_INCLUDE_PATH: src/domains/transaction/components/[A-O]*
@@ -840,6 +840,7 @@ jobs:
                   COVERAGE_THRESHOLD_LINES: 98.67
                   COVERAGE_THRESHOLD_STATEMENTS: 98.73
                   COVERAGE_THRESHOLD_BRANCHES: 98.25
+                  COVERAGE_THRESHOLD_FUNCTIONS: 99.39
               with:
                   timeout_minutes: 10
                   max_attempts: 1

--- a/src/app/components/Dropdown/Dropdown.contracts.ts
+++ b/src/app/components/Dropdown/Dropdown.contracts.ts
@@ -15,6 +15,7 @@ export interface DropdownOption {
 	value: string | number;
 	active?: boolean;
 	[key: string]: any;
+	disableFocus?: boolean;
 }
 
 type OnSelectProperties = (option: DropdownOption) => void;

--- a/src/app/components/Dropdown/Dropdown.helpers.tsx
+++ b/src/app/components/Dropdown/Dropdown.helpers.tsx
@@ -90,7 +90,7 @@ export const renderOptions = ({ options, key, onSelect, variant }: OptionsProper
 					variant={variant}
 					isActive={!!option.active}
 					key={index}
-					data-testid={`dropdown__option--${key ? key + '-' : ""}${index}`}
+					data-testid={`dropdown__option--${key ? key + "-" : ""}${index}`}
 					onClick={(event) => onSelectItem(event, option)}
 					tabIndex={option.disableFocus ? -1 : 0}
 					onKeyDown={(event) => {

--- a/src/app/components/Dropdown/Dropdown.helpers.tsx
+++ b/src/app/components/Dropdown/Dropdown.helpers.tsx
@@ -92,7 +92,7 @@ export const renderOptions = ({ options, key, onSelect, variant }: OptionsProper
 					key={index}
 					data-testid={`dropdown__option--${key ? `${key}-` : ""}${index}`}
 					onClick={(event) => onSelectItem(event, option)}
-					tabIndex={option.disableFocus ? 0 : -1}
+					tabIndex={option.disableFocus ? -1 : 0}
 					onKeyDown={(event) => {
 						/* istanbul ignore next -- @preserve */
 						if (event.key === "Enter" || event.key === " ") {

--- a/src/app/components/Dropdown/Dropdown.helpers.tsx
+++ b/src/app/components/Dropdown/Dropdown.helpers.tsx
@@ -90,7 +90,7 @@ export const renderOptions = ({ options, key, onSelect, variant }: OptionsProper
 					variant={variant}
 					isActive={!!option.active}
 					key={index}
-					data-testid={`dropdown__option--${key ? `${key}-` : ""}${index}`}
+					data-testid={`dropdown__option--${key ? key + '-' : ""}${index}`}
 					onClick={(event) => onSelectItem(event, option)}
 					tabIndex={option.disableFocus ? -1 : 0}
 					onKeyDown={(event) => {

--- a/src/app/components/Dropdown/Dropdown.helpers.tsx
+++ b/src/app/components/Dropdown/Dropdown.helpers.tsx
@@ -92,7 +92,7 @@ export const renderOptions = ({ options, key, onSelect, variant }: OptionsProper
 					key={index}
 					data-testid={`dropdown__option--${key ? `${key}-` : ""}${index}`}
 					onClick={(event) => onSelectItem(event, option)}
-					tabIndex={0}
+					tabIndex={option.disableFocus ? 0 : -1}
 					onKeyDown={(event) => {
 						/* istanbul ignore next -- @preserve */
 						if (event.key === "Enter" || event.key === " ") {

--- a/src/app/components/Dropdown/Dropdown.test.tsx
+++ b/src/app/components/Dropdown/Dropdown.test.tsx
@@ -45,6 +45,20 @@ describe("Dropdown", () => {
 		expect(container).toMatchSnapshot();
 	});
 
+	it("should render options with focus disabled", async () => {
+		const options = [{ disableFocus: true, label: "Option 1", value: "1" }];
+
+		render(<Dropdown options={options} />);
+
+		const dropdown = screen.getByTestId("dropdown__toggle");
+
+		await userEvent.click(dropdown);
+
+		await expect(screen.findByTestId("dropdown__content")).resolves.toBeVisible();
+
+		expect(screen.getByTestId("dropdown__option--0")).toHaveAttribute("tabindex", "-1");
+	});
+
 	it("should render with custom icon classname", async () => {
 		const optionsWithIcon = [{ icon: "trash", iconClassName: "custom-class-name", label: "Option 1", value: "1" }];
 

--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -15,9 +15,11 @@ import {
 	useRole,
 	useInteractions,
 	FloatingPortal,
+	FloatingFocusManager,
 } from "@floating-ui/react";
 import { twMerge } from "tailwind-merge";
 import classNames from "classnames";
+import { isUnit } from "@/utils/test-helpers";
 
 export const Wrapper = ({ variant, ...props }: { variant?: DropdownVariantType } & React.HTMLProps<HTMLDivElement>) => (
 	<div
@@ -120,6 +122,7 @@ export const Dropdown: FC<DropdownProperties> = ({
 
 			{isOpen && (
 				<FloatingPortal>
+					<FloatingFocusManager context={context} disabled={isUnit()}>
 					<div
 						ref={refs.setFloating}
 						className={twMerge(
@@ -151,6 +154,7 @@ export const Dropdown: FC<DropdownProperties> = ({
 							{bottom}
 						</Wrapper>
 					</div>
+					</FloatingFocusManager>
 				</FloatingPortal>
 			)}
 		</>

--- a/src/app/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/app/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Dropdown > should render 1`] = `
 exports[`Dropdown > should render a bottom position 1`] = `
 <div>
   <div
-    aria-controls=":r1h:"
+    aria-controls=":r1k:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -96,7 +96,7 @@ exports[`Dropdown > should render a bottom position 1`] = `
 exports[`Dropdown > should render a bottom-left position 1`] = `
 <div>
   <div
-    aria-controls=":r1k:"
+    aria-controls=":r1n:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -189,7 +189,7 @@ exports[`Dropdown > should render a large one 1`] = `
 exports[`Dropdown > should render a left position 1`] = `
 <div>
   <div
-    aria-controls=":r1n:"
+    aria-controls=":r1q:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -282,7 +282,7 @@ exports[`Dropdown > should render a small one 1`] = `
 exports[`Dropdown > should render a top 1`] = `
 <div>
   <div
-    aria-controls=":r1t:"
+    aria-controls=":r20:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -329,7 +329,7 @@ exports[`Dropdown > should render a top 1`] = `
 exports[`Dropdown > should render a top-left position 1`] = `
 <div>
   <div
-    aria-controls=":r1q:"
+    aria-controls=":r1t:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -376,7 +376,7 @@ exports[`Dropdown > should render a top-left position 1`] = `
 exports[`Dropdown > should render a top-right 1`] = `
 <div>
   <div
-    aria-controls=":r20:"
+    aria-controls=":r23:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -423,7 +423,7 @@ exports[`Dropdown > should render a top-right 1`] = `
 exports[`Dropdown > should render dropdown group options with divider, icon and secondary label 1`] = `
 <div>
   <div
-    aria-controls=":r23:"
+    aria-controls=":r26:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"
@@ -590,7 +590,7 @@ exports[`Dropdown > should render with options 1`] = `
 exports[`Dropdown > should render without options one 1`] = `
 <div>
   <div
-    aria-controls=":r26:"
+    aria-controls=":r29:"
     aria-expanded="true"
     aria-haspopup="dialog"
     data-testid="dropdown__toggle"

--- a/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
+++ b/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
@@ -36,6 +36,12 @@ const FilterOption = ({
 			"font-semibold hover:text-theme-navy-600": isChecked,
 		})}
 		onClick={() => onChange?.(!isChecked)}
+		onKeyDown={(event) => {
+			/* istanbul ignore next -- @preserve */
+			if (event.key === "Enter" || event.key === " ") {
+				onChange?.(!isChecked);
+			}
+		}}
 	>
 		<Checkbox
 			checked={isChecked}

--- a/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
+++ b/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
@@ -75,6 +75,7 @@ export const FilterTransactions = memo(
 				key: "all",
 				options: [
 					{
+						disableFocus: true,
 						element: (
 							<FilterOption
 								label={t("COMMON.SELECT_ALL")}
@@ -92,6 +93,7 @@ export const FilterTransactions = memo(
 				key: "others",
 				options: [
 					{
+						disableFocus: true,
 						element: (
 							<FilterOption
 								label={t("COMMON.TRANSFERS")}
@@ -103,6 +105,7 @@ export const FilterTransactions = memo(
 						value: "transfer",
 					},
 					{
+						disableFocus: true,
 						element: (
 							<FilterOption
 								label={t("COMMON.VOTES")}
@@ -114,6 +117,7 @@ export const FilterTransactions = memo(
 						value: "vote",
 					},
 					{
+						disableFocus: true,
 						element: (
 							<FilterOption
 								label={t("COMMON.MULTIPAYMENTS")}
@@ -125,6 +129,7 @@ export const FilterTransactions = memo(
 						value: "transfer",
 					},
 					{
+						disableFocus: true,
 						element: (
 							<FilterOption
 								label={t("COMMON.OTHERS")}

--- a/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
+++ b/src/domains/transaction/components/FilterTransactions/FilterTransactions.tsx
@@ -36,12 +36,6 @@ const FilterOption = ({
 			"font-semibold hover:text-theme-navy-600": isChecked,
 		})}
 		onClick={() => onChange?.(!isChecked)}
-		onKeyDown={(event) => {
-			/* istanbul ignore next -- @preserve */
-			if (event.key === "Enter" || event.key === " ") {
-				onChange?.(!isChecked);
-			}
-		}}
 	>
 		<Checkbox
 			checked={isChecked}
@@ -51,6 +45,12 @@ const FilterOption = ({
 				"group-hover:bg-theme-navy-700": isChecked,
 				"group-hover:border-theme-navy-600 dark:group-hover:border-theme-navy-600": !isChecked,
 			})}
+			onKeyDown={(event) => {
+				/* istanbul ignore next -- @preserve */
+				if (event.key === "Enter" || event.key === " ") {
+					onChange?.(!isChecked);
+				}
+			}}
 		/>
 		<span data-testid={`FilterOption__${label}`}>{label}</span>
 	</span>

--- a/src/domains/vote/components/VotesFilter/VotesFilter.test.tsx
+++ b/src/domains/vote/components/VotesFilter/VotesFilter.test.tsx
@@ -54,7 +54,8 @@ describe("VotesFilter", () => {
 
 		await waitFor(() => expect(onChange).toHaveBeenCalledWith("current"));
 
-		await userEvent.click(screen.getByTestId("VotesFilter__option--all"));
+		const filterOptionAll = screen.getByTestId("VotesFilter__option--all");
+		await userEvent.click(filterOptionAll);
 
 		await waitFor(() => expect(onChange).toHaveBeenCalledWith("all"));
 
@@ -62,5 +63,10 @@ describe("VotesFilter", () => {
 		await userEvent.keyboard("{enter}");
 
 		await waitFor(() => expect(onChange).toHaveBeenCalledWith("current"));
+
+		filterOptionAll.focus();
+		await userEvent.keyboard("{space}");
+
+		await waitFor(() => expect(onChange).toHaveBeenCalledWith("all"));
 	});
 });

--- a/src/domains/vote/components/VotesFilter/VotesFilter.test.tsx
+++ b/src/domains/vote/components/VotesFilter/VotesFilter.test.tsx
@@ -49,12 +49,18 @@ describe("VotesFilter", () => {
 
 		await expect(screen.findByTestId("dropdown__content-VotesFilter")).resolves.toBeVisible();
 
-		await userEvent.click(screen.getByTestId("VotesFilter__option--current"));
+		const filterOptionCurrent = screen.getByTestId("VotesFilter__option--current");
+		await userEvent.click(filterOptionCurrent);
 
 		await waitFor(() => expect(onChange).toHaveBeenCalledWith("current"));
 
 		await userEvent.click(screen.getByTestId("VotesFilter__option--all"));
 
 		await waitFor(() => expect(onChange).toHaveBeenCalledWith("all"));
+
+		filterOptionCurrent.focus();
+		await userEvent.keyboard("{enter}");
+
+		await waitFor(() => expect(onChange).toHaveBeenCalledWith("current"));
 	});
 });

--- a/src/domains/vote/components/VotesFilter/VotesFilter.tsx
+++ b/src/domains/vote/components/VotesFilter/VotesFilter.tsx
@@ -33,7 +33,17 @@ export const VotesFilter = ({
 						className="flex h-5 cursor-pointer items-center space-x-3 rounded-md"
 						data-testid="VotesFilter__option--all"
 					>
-						<Checkbox name="all" checked={selectedOption === "all"} onChange={() => onChange?.("all")} />
+						<Checkbox
+							name="all"
+							checked={selectedOption === "all"}
+							onChange={() => onChange?.("all")}
+							onKeyDown={(event) => {
+								/* istanbul ignore next -- @preserve */
+								if (event.key === "Enter" || event.key === " ") {
+									onChange?.("all");
+								}
+							}}
+						/>
 						<span className="text-base font-medium">{t("VOTE.FILTERS.ALL")}</span>
 					</label>
 
@@ -53,6 +63,12 @@ export const VotesFilter = ({
 								name="current"
 								checked={selectedOption === "current"}
 								onChange={() => onChange?.("current")}
+								onKeyDown={(event) => {
+									/* istanbul ignore next -- @preserve */
+									if (event.key === "Enter" || event.key === " ") {
+										onChange?.("current");
+									}
+								}}
 							/>
 							<span className="text-base font-medium">{t("VOTE.FILTERS.CURRENT_VOTES")}</span>
 						</label>

--- a/src/domains/vote/components/VotesFilter/VotesFilter.tsx
+++ b/src/domains/vote/components/VotesFilter/VotesFilter.tsx
@@ -64,7 +64,6 @@ export const VotesFilter = ({
 								checked={selectedOption === "current"}
 								onChange={() => onChange?.("current")}
 								onKeyDown={(event) => {
-									/* istanbul ignore next -- @preserve */
 									if (event.key === "Enter" || event.key === " ") {
 										onChange?.("current");
 									}

--- a/src/domains/vote/components/VotesFilter/VotesFilter.tsx
+++ b/src/domains/vote/components/VotesFilter/VotesFilter.tsx
@@ -64,6 +64,7 @@ export const VotesFilter = ({
 								checked={selectedOption === "current"}
 								onChange={() => onChange?.("current")}
 								onKeyDown={(event) => {
+									/* istanbul ignore next -- @preserve */
 									if (event.key === "Enter" || event.key === " ") {
 										onChange?.("current");
 									}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dwrbhz7

- adds focus manager for dropdown
- adds `onKeyDown` handler for tx type filter and validator page dropdowns
- disables focus on `label` for the tx type filter dropdown 


[Screencast from 2025-05-16 17-41-29.webm](https://github.com/user-attachments/assets/dfc3d40a-ac5d-428d-a399-0437697b3eff)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
