### PR TITLE
fix: addresses panel mode selector in `xs` screen

### DIFF
--- a/src/domains/portfolio/components/AddressesSidePanel/AddressesSidePanel.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/AddressesSidePanel.tsx
@@ -308,7 +308,7 @@ export const AddressesSidePanel = ({
 			>
 				<TabList className="grid h-10 w-full grid-cols-2">
 					{tabOptions.map((option) => (
-						<Tab tabId={option.value} key={option.value}>
+						<Tab tabId={option.value} key={option.value} className="px-2.5 sm:px-3">
 							<span>{option.label}</span>
 						</Tab>
 					))}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dwt1amt

![image](https://github.com/user-attachments/assets/58f40fbe-c06c-4732-a1a5-83acf6a7fc45)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
