### PR TITLE
fix: tooltip position for input warnings

### DIFF
--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -207,15 +207,15 @@ export const Input = React.forwardRef<InputElement, InputProperties>(
 						>
 							{isInvalidValue && (
 								<div className={cn({ "pr-3": addons?.end })}>
-								<Tooltip content={errorMessageValue} size="sm">
-									<span data-errortext={errorMessageValue} data-testid="Input__error">
-										<Icon
-											name="CircleExclamationMark"
-											className={cn("text-theme-danger-500")}
-											size="lg"
-										/>
-									</span>
-								</Tooltip>
+									<Tooltip content={errorMessageValue} size="sm">
+										<span data-errortext={errorMessageValue} data-testid="Input__error">
+											<Icon
+												name="CircleExclamationMark"
+												className={cn("text-theme-danger-500")}
+												size="lg"
+											/>
+										</span>
+									</Tooltip>
 								</div>
 							)}
 

--- a/src/app/components/Input/Input.tsx
+++ b/src/app/components/Input/Input.tsx
@@ -206,17 +206,17 @@ export const Input = React.forwardRef<InputElement, InputProperties>(
 							)}
 						>
 							{isInvalidValue && (
+								<div className={cn({ "pr-3": addons?.end })}>
 								<Tooltip content={errorMessageValue} size="sm">
 									<span data-errortext={errorMessageValue} data-testid="Input__error">
 										<Icon
 											name="CircleExclamationMark"
-											className={cn("text-theme-danger-500", {
-												"pr-3": addons?.end,
-											})}
+											className={cn("text-theme-danger-500")}
 											size="lg"
 										/>
 									</span>
 								</Tooltip>
+								</div>
 							)}
 
 							{isValid && (

--- a/src/app/components/Input/__snapshots__/Input.test.tsx.snap
+++ b/src/app/components/Input/__snapshots__/Input.test.tsx.snap
@@ -81,51 +81,55 @@ exports[`Input > should render invalid 1`] = `
       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
       data-testid="Input__addon-end"
     >
-      <span
-        data-errortext="Field invalid"
-        data-testid="Input__error"
+      <div
+        class=""
       >
-        <div
-          class="text-theme-danger-500"
+        <span
+          data-errortext="Field invalid"
+          data-testid="Input__error"
         >
           <div
-            style="height: 20px; width: 20px;"
+            class="text-theme-danger-500"
           >
-            <svg
-              id="circle-exclamation-mark"
-              style="height: 100%; width: 100%;"
-              viewBox="0 0 20 20"
-              x="0"
-              xml:space="preserve"
-              xmlns="http://www.w3.org/2000/svg"
-              y="0"
+            <div
+              style="height: 20px; width: 20px;"
             >
-              <g
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+              <svg
+                id="circle-exclamation-mark"
+                style="height: 100%; width: 100%;"
+                viewBox="0 0 20 20"
+                x="0"
+                xml:space="preserve"
+                xmlns="http://www.w3.org/2000/svg"
+                y="0"
               >
-                <circle
-                  cx="10"
-                  cy="10"
-                  r="9"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 10.5v-5"
-                  stroke-linecap="round"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 14h0"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </g>
-            </svg>
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <circle
+                    cx="10"
+                    cy="10"
+                    r="9"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 10.5v-5"
+                    stroke-linecap="round"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 14h0"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </g>
+              </svg>
+            </div>
           </div>
-        </div>
-      </span>
+        </span>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -153,51 +157,55 @@ exports[`Input > should render invalid and disabled 1`] = `
       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
       data-testid="Input__addon-end"
     >
-      <span
-        data-errortext="Field invalid and disabled"
-        data-testid="Input__error"
+      <div
+        class=""
       >
-        <div
-          class="text-theme-danger-500"
+        <span
+          data-errortext="Field invalid and disabled"
+          data-testid="Input__error"
         >
           <div
-            style="height: 20px; width: 20px;"
+            class="text-theme-danger-500"
           >
-            <svg
-              id="circle-exclamation-mark"
-              style="height: 100%; width: 100%;"
-              viewBox="0 0 20 20"
-              x="0"
-              xml:space="preserve"
-              xmlns="http://www.w3.org/2000/svg"
-              y="0"
+            <div
+              style="height: 20px; width: 20px;"
             >
-              <g
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+              <svg
+                id="circle-exclamation-mark"
+                style="height: 100%; width: 100%;"
+                viewBox="0 0 20 20"
+                x="0"
+                xml:space="preserve"
+                xmlns="http://www.w3.org/2000/svg"
+                y="0"
               >
-                <circle
-                  cx="10"
-                  cy="10"
-                  r="9"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 10.5v-5"
-                  stroke-linecap="round"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 14h0"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </g>
-            </svg>
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <circle
+                    cx="10"
+                    cy="10"
+                    r="9"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 10.5v-5"
+                    stroke-linecap="round"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 14h0"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </g>
+              </svg>
+            </div>
           </div>
-        </div>
-      </span>
+        </span>
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/app/components/Input/__snapshots__/InputCounter.test.tsx.snap
+++ b/src/app/components/Input/__snapshots__/InputCounter.test.tsx.snap
@@ -61,50 +61,54 @@ exports[`InputCounter > should render with invalid state 1`] = `
       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
       data-testid="Input__addon-end"
     >
-      <span
-        data-testid="Input__error"
+      <div
+        class="pr-3"
       >
-        <div
-          class="text-theme-danger-500 pr-3"
+        <span
+          data-testid="Input__error"
         >
           <div
-            style="height: 20px; width: 20px;"
+            class="text-theme-danger-500"
           >
-            <svg
-              id="circle-exclamation-mark"
-              style="height: 100%; width: 100%;"
-              viewBox="0 0 20 20"
-              x="0"
-              xml:space="preserve"
-              xmlns="http://www.w3.org/2000/svg"
-              y="0"
+            <div
+              style="height: 20px; width: 20px;"
             >
-              <g
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+              <svg
+                id="circle-exclamation-mark"
+                style="height: 100%; width: 100%;"
+                viewBox="0 0 20 20"
+                x="0"
+                xml:space="preserve"
+                xmlns="http://www.w3.org/2000/svg"
+                y="0"
               >
-                <circle
-                  cx="10"
-                  cy="10"
-                  r="9"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 10.5v-5"
-                  stroke-linecap="round"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 14h0"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </g>
-            </svg>
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <circle
+                    cx="10"
+                    cy="10"
+                    r="9"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 10.5v-5"
+                    stroke-linecap="round"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 14h0"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </g>
+              </svg>
+            </div>
           </div>
-        </div>
-      </span>
+        </span>
+      </div>
       <div
         class="pl-3"
       >

--- a/src/app/components/Input/__snapshots__/InputPassword.test.tsx.snap
+++ b/src/app/components/Input/__snapshots__/InputPassword.test.tsx.snap
@@ -90,51 +90,55 @@ exports[`InputPassword > should render as a password isInvalid 1`] = `
       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
       data-testid="Input__addon-end"
     >
-      <span
-        data-errortext="Error message for password"
-        data-testid="Input__error"
+      <div
+        class="pr-3"
       >
-        <div
-          class="text-theme-danger-500 pr-3"
+        <span
+          data-errortext="Error message for password"
+          data-testid="Input__error"
         >
           <div
-            style="height: 20px; width: 20px;"
+            class="text-theme-danger-500"
           >
-            <svg
-              id="circle-exclamation-mark"
-              style="height: 100%; width: 100%;"
-              viewBox="0 0 20 20"
-              x="0"
-              xml:space="preserve"
-              xmlns="http://www.w3.org/2000/svg"
-              y="0"
+            <div
+              style="height: 20px; width: 20px;"
             >
-              <g
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+              <svg
+                id="circle-exclamation-mark"
+                style="height: 100%; width: 100%;"
+                viewBox="0 0 20 20"
+                x="0"
+                xml:space="preserve"
+                xmlns="http://www.w3.org/2000/svg"
+                y="0"
               >
-                <circle
-                  cx="10"
-                  cy="10"
-                  r="9"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 10.5v-5"
-                  stroke-linecap="round"
-                  stroke-miterlimit="10"
-                />
-                <path
-                  d="M10 14h0"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </g>
-            </svg>
+                <g
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <circle
+                    cx="10"
+                    cy="10"
+                    r="9"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 10.5v-5"
+                    stroke-linecap="round"
+                    stroke-miterlimit="10"
+                  />
+                  <path
+                    d="M10 14h0"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </g>
+              </svg>
+            </div>
           </div>
-        </div>
-      </span>
+        </span>
+      </div>
       <div
         class="pl-3"
       >

--- a/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
+++ b/src/app/components/PasswordValidation/__snapshots__/PasswordValidation.test.tsx.snap
@@ -32,50 +32,54 @@ exports[`PasswordValidation > should render password rules 1`] = `
         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
         data-testid="Input__addon-end"
       >
-        <span
-          data-testid="Input__error"
+        <div
+          class="pr-3"
         >
-          <div
-            class="text-theme-danger-500 pr-3"
+          <span
+            data-testid="Input__error"
           >
             <div
-              style="height: 20px; width: 20px;"
+              class="text-theme-danger-500"
             >
-              <svg
-                id="circle-exclamation-mark"
-                style="height: 100%; width: 100%;"
-                viewBox="0 0 20 20"
-                x="0"
-                xml:space="preserve"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0"
+              <div
+                style="height: 20px; width: 20px;"
               >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
+                <svg
+                  id="circle-exclamation-mark"
+                  style="height: 100%; width: 100%;"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
                 >
-                  <circle
-                    cx="10"
-                    cy="10"
-                    r="9"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 10.5v-5"
-                    stroke-linecap="round"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 14h0"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <circle
+                      cx="10"
+                      cy="10"
+                      r="9"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 10.5v-5"
+                      stroke-linecap="round"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 14h0"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                </svg>
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
         <div
           class="pl-3"
         >
@@ -304,51 +308,55 @@ exports[`PasswordValidation > should render password rules 1`] = `
         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
         data-testid="Input__addon-end"
       >
-        <span
-          data-errortext="Passwords do not match."
-          data-testid="Input__error"
+        <div
+          class="pr-3"
         >
-          <div
-            class="text-theme-danger-500 pr-3"
+          <span
+            data-errortext="Passwords do not match."
+            data-testid="Input__error"
           >
             <div
-              style="height: 20px; width: 20px;"
+              class="text-theme-danger-500"
             >
-              <svg
-                id="circle-exclamation-mark"
-                style="height: 100%; width: 100%;"
-                viewBox="0 0 20 20"
-                x="0"
-                xml:space="preserve"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0"
+              <div
+                style="height: 20px; width: 20px;"
               >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
+                <svg
+                  id="circle-exclamation-mark"
+                  style="height: 100%; width: 100%;"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
                 >
-                  <circle
-                    cx="10"
-                    cy="10"
-                    r="9"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 10.5v-5"
-                    stroke-linecap="round"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 14h0"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <circle
+                      cx="10"
+                      cy="10"
+                      r="9"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 10.5v-5"
+                      stroke-linecap="round"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 14h0"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                </svg>
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
         <div
           class="pl-3"
         >

--- a/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
+++ b/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
@@ -261,50 +261,54 @@ exports[`SelectDropdown > should render invalid option base 1`] = `
         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
         data-testid="Input__addon-end"
       >
-        <span
-          data-testid="Input__error"
+        <div
+          class=""
         >
-          <div
-            class="text-theme-danger-500"
+          <span
+            data-testid="Input__error"
           >
             <div
-              style="height: 20px; width: 20px;"
+              class="text-theme-danger-500"
             >
-              <svg
-                id="circle-exclamation-mark"
-                style="height: 100%; width: 100%;"
-                viewBox="0 0 20 20"
-                x="0"
-                xml:space="preserve"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0"
+              <div
+                style="height: 20px; width: 20px;"
               >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
+                <svg
+                  id="circle-exclamation-mark"
+                  style="height: 100%; width: 100%;"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
                 >
-                  <circle
-                    cx="10"
-                    cy="10"
-                    r="9"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 10.5v-5"
-                    stroke-linecap="round"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 14h0"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <circle
+                      cx="10"
+                      cy="10"
+                      r="9"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 10.5v-5"
+                      stroke-linecap="round"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 14h0"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                </svg>
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
       </div>
     </div>
     <div
@@ -345,50 +349,54 @@ exports[`SelectDropdown > should render invalid option base 1`] = `
               class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
               data-testid="Input__addon-end"
             >
-              <span
-                data-testid="Input__error"
+              <div
+                class="pr-3"
               >
-                <div
-                  class="text-theme-danger-500 pr-3"
+                <span
+                  data-testid="Input__error"
                 >
                   <div
-                    style="height: 20px; width: 20px;"
+                    class="text-theme-danger-500"
                   >
-                    <svg
-                      id="circle-exclamation-mark"
-                      style="height: 100%; width: 100%;"
-                      viewBox="0 0 20 20"
-                      x="0"
-                      xml:space="preserve"
-                      xmlns="http://www.w3.org/2000/svg"
-                      y="0"
+                    <div
+                      style="height: 20px; width: 20px;"
                     >
-                      <g
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
+                      <svg
+                        id="circle-exclamation-mark"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
                       >
-                        <circle
-                          cx="10"
-                          cy="10"
-                          r="9"
-                          stroke-miterlimit="10"
-                        />
-                        <path
-                          d="M10 10.5v-5"
-                          stroke-linecap="round"
-                          stroke-miterlimit="10"
-                        />
-                        <path
-                          d="M10 14h0"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                        />
-                      </g>
-                    </svg>
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                        >
+                          <circle
+                            cx="10"
+                            cy="10"
+                            r="9"
+                            stroke-miterlimit="10"
+                          />
+                          <path
+                            d="M10 10.5v-5"
+                            stroke-linecap="round"
+                            stroke-miterlimit="10"
+                          />
+                          <path
+                            d="M10 14h0"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          />
+                        </g>
+                      </svg>
+                    </div>
                   </div>
-                </div>
-              </span>
+                </span>
+              </div>
               <div
                 class="pl-3"
               >
@@ -472,50 +480,54 @@ exports[`SelectDropdown > should render invalid option group 1`] = `
         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
         data-testid="Input__addon-end"
       >
-        <span
-          data-testid="Input__error"
+        <div
+          class=""
         >
-          <div
-            class="text-theme-danger-500"
+          <span
+            data-testid="Input__error"
           >
             <div
-              style="height: 20px; width: 20px;"
+              class="text-theme-danger-500"
             >
-              <svg
-                id="circle-exclamation-mark"
-                style="height: 100%; width: 100%;"
-                viewBox="0 0 20 20"
-                x="0"
-                xml:space="preserve"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0"
+              <div
+                style="height: 20px; width: 20px;"
               >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
+                <svg
+                  id="circle-exclamation-mark"
+                  style="height: 100%; width: 100%;"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
                 >
-                  <circle
-                    cx="10"
-                    cy="10"
-                    r="9"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 10.5v-5"
-                    stroke-linecap="round"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 14h0"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <circle
+                      cx="10"
+                      cy="10"
+                      r="9"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 10.5v-5"
+                      stroke-linecap="round"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 14h0"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                </svg>
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
       </div>
     </div>
     <div
@@ -556,50 +568,54 @@ exports[`SelectDropdown > should render invalid option group 1`] = `
               class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
               data-testid="Input__addon-end"
             >
-              <span
-                data-testid="Input__error"
+              <div
+                class="pr-3"
               >
-                <div
-                  class="text-theme-danger-500 pr-3"
+                <span
+                  data-testid="Input__error"
                 >
                   <div
-                    style="height: 20px; width: 20px;"
+                    class="text-theme-danger-500"
                   >
-                    <svg
-                      id="circle-exclamation-mark"
-                      style="height: 100%; width: 100%;"
-                      viewBox="0 0 20 20"
-                      x="0"
-                      xml:space="preserve"
-                      xmlns="http://www.w3.org/2000/svg"
-                      y="0"
+                    <div
+                      style="height: 20px; width: 20px;"
                     >
-                      <g
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
+                      <svg
+                        id="circle-exclamation-mark"
+                        style="height: 100%; width: 100%;"
+                        viewBox="0 0 20 20"
+                        x="0"
+                        xml:space="preserve"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
                       >
-                        <circle
-                          cx="10"
-                          cy="10"
-                          r="9"
-                          stroke-miterlimit="10"
-                        />
-                        <path
-                          d="M10 10.5v-5"
-                          stroke-linecap="round"
-                          stroke-miterlimit="10"
-                        />
-                        <path
-                          d="M10 14h0"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                        />
-                      </g>
-                    </svg>
+                        <g
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                        >
+                          <circle
+                            cx="10"
+                            cy="10"
+                            r="9"
+                            stroke-miterlimit="10"
+                          />
+                          <path
+                            d="M10 10.5v-5"
+                            stroke-linecap="round"
+                            stroke-miterlimit="10"
+                          />
+                          <path
+                            d="M10 14h0"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          />
+                        </g>
+                      </svg>
+                    </div>
                   </div>
-                </div>
-              </span>
+                </span>
+              </div>
               <div
                 class="pl-3"
               >

--- a/src/app/components/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/app/components/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -80,50 +80,54 @@ exports[`TextArea > should render as invalid 1`] = `
         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x absolute right-0 bottom-full mb-2 text-theme-danger-500"
         data-testid="Input__addon-end"
       >
-        <span
-          data-testid="Input__error"
+        <div
+          class=""
         >
-          <div
-            class="text-theme-danger-500"
+          <span
+            data-testid="Input__error"
           >
             <div
-              style="height: 20px; width: 20px;"
+              class="text-theme-danger-500"
             >
-              <svg
-                id="circle-exclamation-mark"
-                style="height: 100%; width: 100%;"
-                viewBox="0 0 20 20"
-                x="0"
-                xml:space="preserve"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0"
+              <div
+                style="height: 20px; width: 20px;"
               >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
+                <svg
+                  id="circle-exclamation-mark"
+                  style="height: 100%; width: 100%;"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
                 >
-                  <circle
-                    cx="10"
-                    cy="10"
-                    r="9"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 10.5v-5"
-                    stroke-linecap="round"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 14h0"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <circle
+                      cx="10"
+                      cy="10"
+                      r="9"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 10.5v-5"
+                      stroke-linecap="round"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 14h0"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                </svg>
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/domains/profile/components/SelectAddress/__snapshots__/SelectAddress.test.tsx.snap
+++ b/src/domains/profile/components/SelectAddress/__snapshots__/SelectAddress.test.tsx.snap
@@ -203,50 +203,54 @@ exports[`SelectAddress > should render invalid 1`] = `
         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
         data-testid="Input__addon-end"
       >
-        <span
-          data-testid="Input__error"
+        <div
+          class="pr-3"
         >
-          <div
-            class="text-theme-danger-500 pr-3"
+          <span
+            data-testid="Input__error"
           >
             <div
-              style="height: 20px; width: 20px;"
+              class="text-theme-danger-500"
             >
-              <svg
-                id="circle-exclamation-mark"
-                style="height: 100%; width: 100%;"
-                viewBox="0 0 20 20"
-                x="0"
-                xml:space="preserve"
-                xmlns="http://www.w3.org/2000/svg"
-                y="0"
+              <div
+                style="height: 20px; width: 20px;"
               >
-                <g
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
+                <svg
+                  id="circle-exclamation-mark"
+                  style="height: 100%; width: 100%;"
+                  viewBox="0 0 20 20"
+                  x="0"
+                  xml:space="preserve"
+                  xmlns="http://www.w3.org/2000/svg"
+                  y="0"
                 >
-                  <circle
-                    cx="10"
-                    cy="10"
-                    r="9"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 10.5v-5"
-                    stroke-linecap="round"
-                    stroke-miterlimit="10"
-                  />
-                  <path
-                    d="M10 14h0"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </g>
-              </svg>
+                  <g
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <circle
+                      cx="10"
+                      cy="10"
+                      r="9"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 10.5v-5"
+                      stroke-linecap="round"
+                      stroke-miterlimit="10"
+                    />
+                    <path
+                      d="M10 14h0"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </g>
+                </svg>
+              </div>
             </div>
-          </div>
-        </span>
+          </span>
+        </div>
         <div
           class="pl-3"
         >

--- a/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
+++ b/src/domains/profile/components/SelectRecipient/__snapshots__/SelectRecipient.test.tsx.snap
@@ -291,50 +291,54 @@ exports[`SelectRecipient > should render invalid 1`] = `
             class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
             data-testid="Input__addon-end"
           >
-            <span
-              data-testid="Input__error"
+            <div
+              class=""
             >
-              <div
-                class="text-theme-danger-500"
+              <span
+                data-testid="Input__error"
               >
                 <div
-                  style="height: 20px; width: 20px;"
+                  class="text-theme-danger-500"
                 >
-                  <svg
-                    id="circle-exclamation-mark"
-                    style="height: 100%; width: 100%;"
-                    viewBox="0 0 20 20"
-                    x="0"
-                    xml:space="preserve"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
+                  <div
+                    style="height: 20px; width: 20px;"
                   >
-                    <g
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
+                    <svg
+                      id="circle-exclamation-mark"
+                      style="height: 100%; width: 100%;"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
                     >
-                      <circle
-                        cx="10"
-                        cy="10"
-                        r="9"
-                        stroke-miterlimit="10"
-                      />
-                      <path
-                        d="M10 10.5v-5"
-                        stroke-linecap="round"
-                        stroke-miterlimit="10"
-                      />
-                      <path
-                        d="M10 14h0"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </g>
-                  </svg>
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <circle
+                          cx="10"
+                          cy="10"
+                          r="9"
+                          stroke-miterlimit="10"
+                        />
+                        <path
+                          d="M10 10.5v-5"
+                          stroke-linecap="round"
+                          stroke-miterlimit="10"
+                        />
+                        <path
+                          d="M10 14h0"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
+                      </g>
+                    </svg>
+                  </div>
                 </div>
-              </div>
-            </span>
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -382,50 +386,54 @@ exports[`SelectRecipient > should render invalid 1`] = `
                   class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                   data-testid="Input__addon-end"
                 >
-                  <span
-                    data-testid="Input__error"
+                  <div
+                    class="pr-3"
                   >
-                    <div
-                      class="text-theme-danger-500 pr-3"
+                    <span
+                      data-testid="Input__error"
                     >
                       <div
-                        style="height: 20px; width: 20px;"
+                        class="text-theme-danger-500"
                       >
-                        <svg
-                          id="circle-exclamation-mark"
-                          style="height: 100%; width: 100%;"
-                          viewBox="0 0 20 20"
-                          x="0"
-                          xml:space="preserve"
-                          xmlns="http://www.w3.org/2000/svg"
-                          y="0"
+                        <div
+                          style="height: 20px; width: 20px;"
                         >
-                          <g
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
+                          <svg
+                            id="circle-exclamation-mark"
+                            style="height: 100%; width: 100%;"
+                            viewBox="0 0 20 20"
+                            x="0"
+                            xml:space="preserve"
+                            xmlns="http://www.w3.org/2000/svg"
+                            y="0"
                           >
-                            <circle
-                              cx="10"
-                              cy="10"
-                              r="9"
-                              stroke-miterlimit="10"
-                            />
-                            <path
-                              d="M10 10.5v-5"
-                              stroke-linecap="round"
-                              stroke-miterlimit="10"
-                            />
-                            <path
-                              d="M10 14h0"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                            />
-                          </g>
-                        </svg>
+                            <g
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                            >
+                              <circle
+                                cx="10"
+                                cy="10"
+                                r="9"
+                                stroke-miterlimit="10"
+                              />
+                              <path
+                                d="M10 10.5v-5"
+                                stroke-linecap="round"
+                                stroke-miterlimit="10"
+                              />
+                              <path
+                                d="M10 14h0"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                              />
+                            </g>
+                          </svg>
+                        </div>
                       </div>
-                    </div>
-                  </span>
+                    </span>
+                  </div>
                   <div
                     class="pl-3"
                   >

--- a/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
+++ b/src/domains/setting/pages/General/__snapshots__/General.test.tsx.snap
@@ -13984,51 +13984,55 @@ exports[`General Settings > should update the avatar when removing focus from na
                                 class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                                 data-testid="Input__addon-end"
                               >
-                                <span
-                                  data-errortext="Profile Name required."
-                                  data-testid="Input__error"
+                                <div
+                                  class=""
                                 >
-                                  <div
-                                    class="text-theme-danger-500"
+                                  <span
+                                    data-errortext="Profile Name required."
+                                    data-testid="Input__error"
                                   >
                                     <div
-                                      style="height: 20px; width: 20px;"
+                                      class="text-theme-danger-500"
                                     >
-                                      <svg
-                                        id="circle-exclamation-mark"
-                                        style="height: 100%; width: 100%;"
-                                        viewBox="0 0 20 20"
-                                        x="0"
-                                        xml:space="preserve"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        y="0"
+                                      <div
+                                        style="height: 20px; width: 20px;"
                                       >
-                                        <g
-                                          fill="none"
-                                          stroke="currentColor"
-                                          stroke-width="2"
+                                        <svg
+                                          id="circle-exclamation-mark"
+                                          style="height: 100%; width: 100%;"
+                                          viewBox="0 0 20 20"
+                                          x="0"
+                                          xml:space="preserve"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                          y="0"
                                         >
-                                          <circle
-                                            cx="10"
-                                            cy="10"
-                                            r="9"
-                                            stroke-miterlimit="10"
-                                          />
-                                          <path
-                                            d="M10 10.5v-5"
-                                            stroke-linecap="round"
-                                            stroke-miterlimit="10"
-                                          />
-                                          <path
-                                            d="M10 14h0"
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                          />
-                                        </g>
-                                      </svg>
+                                          <g
+                                            fill="none"
+                                            stroke="currentColor"
+                                            stroke-width="2"
+                                          >
+                                            <circle
+                                              cx="10"
+                                              cy="10"
+                                              r="9"
+                                              stroke-miterlimit="10"
+                                            />
+                                            <path
+                                              d="M10 10.5v-5"
+                                              stroke-linecap="round"
+                                              stroke-miterlimit="10"
+                                            />
+                                            <path
+                                              d="M10 14h0"
+                                              stroke-linecap="round"
+                                              stroke-linejoin="round"
+                                            />
+                                          </g>
+                                        </svg>
+                                      </div>
                                     </div>
-                                  </div>
-                                </span>
+                                  </span>
+                                </div>
                               </div>
                             </div>
                           </fieldset>

--- a/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
+++ b/src/domains/setting/pages/Password/__snapshots__/Password.test.tsx.snap
@@ -2256,50 +2256,54 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                               class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                               data-testid="Input__addon-end"
                             >
-                              <span
-                                data-testid="Input__error"
+                              <div
+                                class="pr-3"
                               >
-                                <div
-                                  class="text-theme-danger-500 pr-3"
+                                <span
+                                  data-testid="Input__error"
                                 >
                                   <div
-                                    style="height: 20px; width: 20px;"
+                                    class="text-theme-danger-500"
                                   >
-                                    <svg
-                                      id="circle-exclamation-mark"
-                                      style="height: 100%; width: 100%;"
-                                      viewBox="0 0 20 20"
-                                      x="0"
-                                      xml:space="preserve"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                      y="0"
+                                    <div
+                                      style="height: 20px; width: 20px;"
                                     >
-                                      <g
-                                        fill="none"
-                                        stroke="currentColor"
-                                        stroke-width="2"
+                                      <svg
+                                        id="circle-exclamation-mark"
+                                        style="height: 100%; width: 100%;"
+                                        viewBox="0 0 20 20"
+                                        x="0"
+                                        xml:space="preserve"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        y="0"
                                       >
-                                        <circle
-                                          cx="10"
-                                          cy="10"
-                                          r="9"
-                                          stroke-miterlimit="10"
-                                        />
-                                        <path
-                                          d="M10 10.5v-5"
-                                          stroke-linecap="round"
-                                          stroke-miterlimit="10"
-                                        />
-                                        <path
-                                          d="M10 14h0"
-                                          stroke-linecap="round"
-                                          stroke-linejoin="round"
-                                        />
-                                      </g>
-                                    </svg>
+                                        <g
+                                          fill="none"
+                                          stroke="currentColor"
+                                          stroke-width="2"
+                                        >
+                                          <circle
+                                            cx="10"
+                                            cy="10"
+                                            r="9"
+                                            stroke-miterlimit="10"
+                                          />
+                                          <path
+                                            d="M10 10.5v-5"
+                                            stroke-linecap="round"
+                                            stroke-miterlimit="10"
+                                          />
+                                          <path
+                                            d="M10 14h0"
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </div>
                                   </div>
-                                </div>
-                              </span>
+                                </span>
+                              </div>
                               <div
                                 class="pl-3"
                               >
@@ -2615,51 +2619,55 @@ exports[`Password Settings > should trigger password confirmation mismatch error
                               class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                               data-testid="Input__addon-end"
                             >
-                              <span
-                                data-errortext="Passwords do not match."
-                                data-testid="Input__error"
+                              <div
+                                class="pr-3"
                               >
-                                <div
-                                  class="text-theme-danger-500 pr-3"
+                                <span
+                                  data-errortext="Passwords do not match."
+                                  data-testid="Input__error"
                                 >
                                   <div
-                                    style="height: 20px; width: 20px;"
+                                    class="text-theme-danger-500"
                                   >
-                                    <svg
-                                      id="circle-exclamation-mark"
-                                      style="height: 100%; width: 100%;"
-                                      viewBox="0 0 20 20"
-                                      x="0"
-                                      xml:space="preserve"
-                                      xmlns="http://www.w3.org/2000/svg"
-                                      y="0"
+                                    <div
+                                      style="height: 20px; width: 20px;"
                                     >
-                                      <g
-                                        fill="none"
-                                        stroke="currentColor"
-                                        stroke-width="2"
+                                      <svg
+                                        id="circle-exclamation-mark"
+                                        style="height: 100%; width: 100%;"
+                                        viewBox="0 0 20 20"
+                                        x="0"
+                                        xml:space="preserve"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        y="0"
                                       >
-                                        <circle
-                                          cx="10"
-                                          cy="10"
-                                          r="9"
-                                          stroke-miterlimit="10"
-                                        />
-                                        <path
-                                          d="M10 10.5v-5"
-                                          stroke-linecap="round"
-                                          stroke-miterlimit="10"
-                                        />
-                                        <path
-                                          d="M10 14h0"
-                                          stroke-linecap="round"
-                                          stroke-linejoin="round"
-                                        />
-                                      </g>
-                                    </svg>
+                                        <g
+                                          fill="none"
+                                          stroke="currentColor"
+                                          stroke-width="2"
+                                        >
+                                          <circle
+                                            cx="10"
+                                            cy="10"
+                                            r="9"
+                                            stroke-miterlimit="10"
+                                          />
+                                          <path
+                                            d="M10 10.5v-5"
+                                            stroke-linecap="round"
+                                            stroke-miterlimit="10"
+                                          />
+                                          <path
+                                            d="M10 14h0"
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                          />
+                                        </g>
+                                      </svg>
+                                    </div>
                                   </div>
-                                </div>
-                              </span>
+                                </span>
+                              </div>
                               <div
                                 class="pl-3"
                               >

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -2504,51 +2504,55 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
                     class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                     data-testid="Input__addon-end"
                   >
-                    <span
-                      data-errortext="The balance is too low."
-                      data-testid="Input__error"
+                    <div
+                      class=""
                     >
-                      <div
-                        class="text-theme-danger-500"
+                      <span
+                        data-errortext="The balance is too low."
+                        data-testid="Input__error"
                       >
                         <div
-                          style="height: 20px; width: 20px;"
+                          class="text-theme-danger-500"
                         >
-                          <svg
-                            id="circle-exclamation-mark"
-                            style="height: 100%; width: 100%;"
-                            viewBox="0 0 20 20"
-                            x="0"
-                            xml:space="preserve"
-                            xmlns="http://www.w3.org/2000/svg"
-                            y="0"
+                          <div
+                            style="height: 20px; width: 20px;"
                           >
-                            <g
-                              fill="none"
-                              stroke="currentColor"
-                              stroke-width="2"
+                            <svg
+                              id="circle-exclamation-mark"
+                              style="height: 100%; width: 100%;"
+                              viewBox="0 0 20 20"
+                              x="0"
+                              xml:space="preserve"
+                              xmlns="http://www.w3.org/2000/svg"
+                              y="0"
                             >
-                              <circle
-                                cx="10"
-                                cy="10"
-                                r="9"
-                                stroke-miterlimit="10"
-                              />
-                              <path
-                                d="M10 10.5v-5"
-                                stroke-linecap="round"
-                                stroke-miterlimit="10"
-                              />
-                              <path
-                                d="M10 14h0"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                              />
-                            </g>
-                          </svg>
+                              <g
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                              >
+                                <circle
+                                  cx="10"
+                                  cy="10"
+                                  r="9"
+                                  stroke-miterlimit="10"
+                                />
+                                <path
+                                  d="M10 10.5v-5"
+                                  stroke-linecap="round"
+                                  stroke-miterlimit="10"
+                                />
+                                <path
+                                  d="M10 14h0"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                />
+                              </g>
+                            </svg>
+                          </div>
                         </div>
-                      </div>
-                    </span>
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
@@ -60,51 +60,55 @@ exports[`AuthenticationStep (message) > should request mnemonic if wallet was im
           class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
           data-testid="Input__addon-end"
         >
-          <span
-            data-errortext="This mnemonic does not correspond to your wallet"
-            data-testid="Input__error"
+          <div
+            class="pr-3"
           >
-            <div
-              class="text-theme-danger-500 pr-3"
+            <span
+              data-errortext="This mnemonic does not correspond to your wallet"
+              data-testid="Input__error"
             >
               <div
-                style="height: 20px; width: 20px;"
+                class="text-theme-danger-500"
               >
-                <svg
-                  id="circle-exclamation-mark"
-                  style="height: 100%; width: 100%;"
-                  viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  style="height: 20px; width: 20px;"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
+                  <svg
+                    id="circle-exclamation-mark"
+                    style="height: 100%; width: 100%;"
+                    viewBox="0 0 20 20"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
                   >
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="9"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 10.5v-5"
-                      stroke-linecap="round"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 14h0"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                </svg>
+                    <g
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <circle
+                        cx="10"
+                        cy="10"
+                        r="9"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 10.5v-5"
+                        stroke-linecap="round"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 14h0"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </g>
+                  </svg>
+                </div>
               </div>
-            </div>
-          </span>
+            </span>
+          </div>
           <div
             class="pl-3"
           >
@@ -215,51 +219,55 @@ exports[`AuthenticationStep (message) > should request mnemonic if wallet was im
           class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
           data-testid="Input__addon-end"
         >
-          <span
-            data-errortext="This mnemonic does not correspond to your wallet"
-            data-testid="Input__error"
+          <div
+            class="pr-3"
           >
-            <div
-              class="text-theme-danger-500 pr-3"
+            <span
+              data-errortext="This mnemonic does not correspond to your wallet"
+              data-testid="Input__error"
             >
               <div
-                style="height: 20px; width: 20px;"
+                class="text-theme-danger-500"
               >
-                <svg
-                  id="circle-exclamation-mark"
-                  style="height: 100%; width: 100%;"
-                  viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  style="height: 20px; width: 20px;"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
+                  <svg
+                    id="circle-exclamation-mark"
+                    style="height: 100%; width: 100%;"
+                    viewBox="0 0 20 20"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
                   >
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="9"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 10.5v-5"
-                      stroke-linecap="round"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 14h0"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                </svg>
+                    <g
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <circle
+                        cx="10"
+                        cy="10"
+                        r="9"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 10.5v-5"
+                        stroke-linecap="round"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 14h0"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </g>
+                  </svg>
+                </div>
               </div>
-            </div>
-          </span>
+            </span>
+          </div>
           <div
             class="pl-3"
           >
@@ -1162,51 +1170,55 @@ exports[`AuthenticationStep (transaction) > should request mnemonic if wallet wa
           class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
           data-testid="Input__addon-end"
         >
-          <span
-            data-errortext="This mnemonic does not correspond to your wallet"
-            data-testid="Input__error"
+          <div
+            class="pr-3"
           >
-            <div
-              class="text-theme-danger-500 pr-3"
+            <span
+              data-errortext="This mnemonic does not correspond to your wallet"
+              data-testid="Input__error"
             >
               <div
-                style="height: 20px; width: 20px;"
+                class="text-theme-danger-500"
               >
-                <svg
-                  id="circle-exclamation-mark"
-                  style="height: 100%; width: 100%;"
-                  viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  style="height: 20px; width: 20px;"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
+                  <svg
+                    id="circle-exclamation-mark"
+                    style="height: 100%; width: 100%;"
+                    viewBox="0 0 20 20"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
                   >
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="9"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 10.5v-5"
-                      stroke-linecap="round"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 14h0"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                </svg>
+                    <g
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <circle
+                        cx="10"
+                        cy="10"
+                        r="9"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 10.5v-5"
+                        stroke-linecap="round"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 14h0"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </g>
+                  </svg>
+                </div>
               </div>
-            </div>
-          </span>
+            </span>
+          </div>
           <div
             class="pl-3"
           >
@@ -1317,51 +1329,55 @@ exports[`AuthenticationStep (transaction) > should request mnemonic if wallet wa
           class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
           data-testid="Input__addon-end"
         >
-          <span
-            data-errortext="This mnemonic does not correspond to your wallet"
-            data-testid="Input__error"
+          <div
+            class="pr-3"
           >
-            <div
-              class="text-theme-danger-500 pr-3"
+            <span
+              data-errortext="This mnemonic does not correspond to your wallet"
+              data-testid="Input__error"
             >
               <div
-                style="height: 20px; width: 20px;"
+                class="text-theme-danger-500"
               >
-                <svg
-                  id="circle-exclamation-mark"
-                  style="height: 100%; width: 100%;"
-                  viewBox="0 0 20 20"
-                  x="0"
-                  xml:space="preserve"
-                  xmlns="http://www.w3.org/2000/svg"
-                  y="0"
+                <div
+                  style="height: 20px; width: 20px;"
                 >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
+                  <svg
+                    id="circle-exclamation-mark"
+                    style="height: 100%; width: 100%;"
+                    viewBox="0 0 20 20"
+                    x="0"
+                    xml:space="preserve"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
                   >
-                    <circle
-                      cx="10"
-                      cy="10"
-                      r="9"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 10.5v-5"
-                      stroke-linecap="round"
-                      stroke-miterlimit="10"
-                    />
-                    <path
-                      d="M10 14h0"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                </svg>
+                    <g
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <circle
+                        cx="10"
+                        cy="10"
+                        r="9"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 10.5v-5"
+                        stroke-linecap="round"
+                        stroke-miterlimit="10"
+                      />
+                      <path
+                        d="M10 14h0"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </g>
+                  </svg>
+                </div>
               </div>
-            </div>
-          </span>
+            </span>
+          </div>
           <div
             class="pl-3"
           >

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -761,51 +761,55 @@ exports[`SendVote > should show error if wrong mnemonic 1`] = `
                         class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                         data-testid="Input__addon-end"
                       >
-                        <span
-                          data-errortext="This mnemonic does not correspond to your wallet"
-                          data-testid="Input__error"
+                        <div
+                          class="pr-3"
                         >
-                          <div
-                            class="text-theme-danger-500 pr-3"
+                          <span
+                            data-errortext="This mnemonic does not correspond to your wallet"
+                            data-testid="Input__error"
                           >
                             <div
-                              style="height: 20px; width: 20px;"
+                              class="text-theme-danger-500"
                             >
-                              <svg
-                                id="circle-exclamation-mark"
-                                style="height: 100%; width: 100%;"
-                                viewBox="0 0 20 20"
-                                x="0"
-                                xml:space="preserve"
-                                xmlns="http://www.w3.org/2000/svg"
-                                y="0"
+                              <div
+                                style="height: 20px; width: 20px;"
                               >
-                                <g
-                                  fill="none"
-                                  stroke="currentColor"
-                                  stroke-width="2"
+                                <svg
+                                  id="circle-exclamation-mark"
+                                  style="height: 100%; width: 100%;"
+                                  viewBox="0 0 20 20"
+                                  x="0"
+                                  xml:space="preserve"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  y="0"
                                 >
-                                  <circle
-                                    cx="10"
-                                    cy="10"
-                                    r="9"
-                                    stroke-miterlimit="10"
-                                  />
-                                  <path
-                                    d="M10 10.5v-5"
-                                    stroke-linecap="round"
-                                    stroke-miterlimit="10"
-                                  />
-                                  <path
-                                    d="M10 14h0"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                  />
-                                </g>
-                              </svg>
+                                  <g
+                                    fill="none"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                  >
+                                    <circle
+                                      cx="10"
+                                      cy="10"
+                                      r="9"
+                                      stroke-miterlimit="10"
+                                    />
+                                    <path
+                                      d="M10 10.5v-5"
+                                      stroke-linecap="round"
+                                      stroke-miterlimit="10"
+                                    />
+                                    <path
+                                      d="M10 14h0"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                    />
+                                  </g>
+                                </svg>
+                              </div>
                             </div>
-                          </div>
-                        </span>
+                          </span>
+                        </div>
                         <div
                           class="pl-3"
                         >

--- a/src/domains/wallet/components/EncryptPasswordStep/__snapshots__/EncryptPasswordStep.test.tsx.snap
+++ b/src/domains/wallet/components/EncryptPasswordStep/__snapshots__/EncryptPasswordStep.test.tsx.snap
@@ -96,50 +96,54 @@ exports[`EncryptPasswordStep > should trigger password confirmation validation w
             class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
             data-testid="Input__addon-end"
           >
-            <span
-              data-testid="Input__error"
+            <div
+              class="pr-3"
             >
-              <div
-                class="text-theme-danger-500 pr-3"
+              <span
+                data-testid="Input__error"
               >
                 <div
-                  style="height: 20px; width: 20px;"
+                  class="text-theme-danger-500"
                 >
-                  <svg
-                    id="circle-exclamation-mark"
-                    style="height: 100%; width: 100%;"
-                    viewBox="0 0 20 20"
-                    x="0"
-                    xml:space="preserve"
-                    xmlns="http://www.w3.org/2000/svg"
-                    y="0"
+                  <div
+                    style="height: 20px; width: 20px;"
                   >
-                    <g
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
+                    <svg
+                      id="circle-exclamation-mark"
+                      style="height: 100%; width: 100%;"
+                      viewBox="0 0 20 20"
+                      x="0"
+                      xml:space="preserve"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
                     >
-                      <circle
-                        cx="10"
-                        cy="10"
-                        r="9"
-                        stroke-miterlimit="10"
-                      />
-                      <path
-                        d="M10 10.5v-5"
-                        stroke-linecap="round"
-                        stroke-miterlimit="10"
-                      />
-                      <path
-                        d="M10 14h0"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                      />
-                    </g>
-                  </svg>
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <circle
+                          cx="10"
+                          cy="10"
+                          r="9"
+                          stroke-miterlimit="10"
+                        />
+                        <path
+                          d="M10 10.5v-5"
+                          stroke-linecap="round"
+                          stroke-miterlimit="10"
+                        />
+                        <path
+                          d="M10 14h0"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        />
+                      </g>
+                    </svg>
+                  </div>
                 </div>
-              </div>
-            </span>
+              </span>
+            </div>
             <div
               class="pl-3"
             >

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -251,51 +251,55 @@ exports[`UpdateWalletName > should show an error message for duplicate name 1`] 
                       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                       data-testid="Input__addon-end"
                     >
-                      <span
-                        data-errortext="The name 'Mainsail Wallet 2' is already assigned to another wallet."
-                        data-testid="Input__error"
+                      <div
+                        class=""
                       >
-                        <div
-                          class="text-theme-danger-500"
+                        <span
+                          data-errortext="The name 'Mainsail Wallet 2' is already assigned to another wallet."
+                          data-testid="Input__error"
                         >
                           <div
-                            style="height: 20px; width: 20px;"
+                            class="text-theme-danger-500"
                           >
-                            <svg
-                              id="circle-exclamation-mark"
-                              style="height: 100%; width: 100%;"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
+                            <div
+                              style="height: 20px; width: 20px;"
                             >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
+                              <svg
+                                id="circle-exclamation-mark"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
                               >
-                                <circle
-                                  cx="10"
-                                  cy="10"
-                                  r="9"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 10.5v-5"
-                                  stroke-linecap="round"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 14h0"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                />
-                              </g>
-                            </svg>
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                >
+                                  <circle
+                                    cx="10"
+                                    cy="10"
+                                    r="9"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 10.5v-5"
+                                    stroke-linecap="round"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 14h0"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
                           </div>
-                        </div>
-                      </span>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -444,51 +448,55 @@ exports[`UpdateWalletName > should show an error message for duplicate name 2`] 
                       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                       data-testid="Input__addon-end"
                     >
-                      <span
-                        data-errortext="The name 'mainsail wallet 2' is already assigned to another wallet."
-                        data-testid="Input__error"
+                      <div
+                        class=""
                       >
-                        <div
-                          class="text-theme-danger-500"
+                        <span
+                          data-errortext="The name 'mainsail wallet 2' is already assigned to another wallet."
+                          data-testid="Input__error"
                         >
                           <div
-                            style="height: 20px; width: 20px;"
+                            class="text-theme-danger-500"
                           >
-                            <svg
-                              id="circle-exclamation-mark"
-                              style="height: 100%; width: 100%;"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
+                            <div
+                              style="height: 20px; width: 20px;"
                             >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
+                              <svg
+                                id="circle-exclamation-mark"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
                               >
-                                <circle
-                                  cx="10"
-                                  cy="10"
-                                  r="9"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 10.5v-5"
-                                  stroke-linecap="round"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 14h0"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                />
-                              </g>
-                            </svg>
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                >
+                                  <circle
+                                    cx="10"
+                                    cy="10"
+                                    r="9"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 10.5v-5"
+                                    stroke-linecap="round"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 14h0"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
                           </div>
-                        </div>
-                      </span>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -637,51 +645,55 @@ exports[`UpdateWalletName > should show an error message for duplicate name 3`] 
                       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                       data-testid="Input__addon-end"
                     >
-                      <span
-                        data-errortext="The name 'Mainsail Wallet 2' is already assigned to another wallet."
-                        data-testid="Input__error"
+                      <div
+                        class=""
                       >
-                        <div
-                          class="text-theme-danger-500"
+                        <span
+                          data-errortext="The name 'Mainsail Wallet 2' is already assigned to another wallet."
+                          data-testid="Input__error"
                         >
                           <div
-                            style="height: 20px; width: 20px;"
+                            class="text-theme-danger-500"
                           >
-                            <svg
-                              id="circle-exclamation-mark"
-                              style="height: 100%; width: 100%;"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
+                            <div
+                              style="height: 20px; width: 20px;"
                             >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
+                              <svg
+                                id="circle-exclamation-mark"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
                               >
-                                <circle
-                                  cx="10"
-                                  cy="10"
-                                  r="9"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 10.5v-5"
-                                  stroke-linecap="round"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 14h0"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                />
-                              </g>
-                            </svg>
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                >
+                                  <circle
+                                    cx="10"
+                                    cy="10"
+                                    r="9"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 10.5v-5"
+                                    stroke-linecap="round"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 14h0"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
                           </div>
-                        </div>
-                      </span>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -830,51 +842,55 @@ exports[`UpdateWalletName > should show an error message for duplicate name 4`] 
                       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                       data-testid="Input__addon-end"
                     >
-                      <span
-                        data-errortext="The name 'Mainsail Wallet 2' is already assigned to another wallet."
-                        data-testid="Input__error"
+                      <div
+                        class=""
                       >
-                        <div
-                          class="text-theme-danger-500"
+                        <span
+                          data-errortext="The name 'Mainsail Wallet 2' is already assigned to another wallet."
+                          data-testid="Input__error"
                         >
                           <div
-                            style="height: 20px; width: 20px;"
+                            class="text-theme-danger-500"
                           >
-                            <svg
-                              id="circle-exclamation-mark"
-                              style="height: 100%; width: 100%;"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
+                            <div
+                              style="height: 20px; width: 20px;"
                             >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
+                              <svg
+                                id="circle-exclamation-mark"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
                               >
-                                <circle
-                                  cx="10"
-                                  cy="10"
-                                  r="9"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 10.5v-5"
-                                  stroke-linecap="round"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 14h0"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                />
-                              </g>
-                            </svg>
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                >
+                                  <circle
+                                    cx="10"
+                                    cy="10"
+                                    r="9"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 10.5v-5"
+                                    stroke-linecap="round"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 14h0"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
                           </div>
-                        </div>
-                      </span>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1023,51 +1039,55 @@ exports[`UpdateWalletName > should show error message when name consists only of
                       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                       data-testid="Input__addon-end"
                     >
-                      <span
-                        data-errortext="WALLETS.VALIDATION.ALIAS_REQUIRED"
-                        data-testid="Input__error"
+                      <div
+                        class=""
                       >
-                        <div
-                          class="text-theme-danger-500"
+                        <span
+                          data-errortext="WALLETS.VALIDATION.ALIAS_REQUIRED"
+                          data-testid="Input__error"
                         >
                           <div
-                            style="height: 20px; width: 20px;"
+                            class="text-theme-danger-500"
                           >
-                            <svg
-                              id="circle-exclamation-mark"
-                              style="height: 100%; width: 100%;"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
+                            <div
+                              style="height: 20px; width: 20px;"
                             >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
+                              <svg
+                                id="circle-exclamation-mark"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
                               >
-                                <circle
-                                  cx="10"
-                                  cy="10"
-                                  r="9"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 10.5v-5"
-                                  stroke-linecap="round"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 14h0"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                />
-                              </g>
-                            </svg>
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                >
+                                  <circle
+                                    cx="10"
+                                    cy="10"
+                                    r="9"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 10.5v-5"
+                                    stroke-linecap="round"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 14h0"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
                           </div>
-                        </div>
-                      </span>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1216,51 +1236,55 @@ exports[`UpdateWalletName > should show error message when name exceeds 42 chara
                       class="divide-theme-secondary-300 dark:divide-theme-secondary-800 flex items-center divide-x text-theme-danger-500"
                       data-testid="Input__addon-end"
                     >
-                      <span
-                        data-errortext="Wallet Name should have at most 42 characters."
-                        data-testid="Input__error"
+                      <div
+                        class=""
                       >
-                        <div
-                          class="text-theme-danger-500"
+                        <span
+                          data-errortext="Wallet Name should have at most 42 characters."
+                          data-testid="Input__error"
                         >
                           <div
-                            style="height: 20px; width: 20px;"
+                            class="text-theme-danger-500"
                           >
-                            <svg
-                              id="circle-exclamation-mark"
-                              style="height: 100%; width: 100%;"
-                              viewBox="0 0 20 20"
-                              x="0"
-                              xml:space="preserve"
-                              xmlns="http://www.w3.org/2000/svg"
-                              y="0"
+                            <div
+                              style="height: 20px; width: 20px;"
                             >
-                              <g
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
+                              <svg
+                                id="circle-exclamation-mark"
+                                style="height: 100%; width: 100%;"
+                                viewBox="0 0 20 20"
+                                x="0"
+                                xml:space="preserve"
+                                xmlns="http://www.w3.org/2000/svg"
+                                y="0"
                               >
-                                <circle
-                                  cx="10"
-                                  cy="10"
-                                  r="9"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 10.5v-5"
-                                  stroke-linecap="round"
-                                  stroke-miterlimit="10"
-                                />
-                                <path
-                                  d="M10 14h0"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                />
-                              </g>
-                            </svg>
+                                <g
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                >
+                                  <circle
+                                    cx="10"
+                                    cy="10"
+                                    r="9"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 10.5v-5"
+                                    stroke-linecap="round"
+                                    stroke-miterlimit="10"
+                                  />
+                                  <path
+                                    d="M10 14h0"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                  />
+                                </g>
+                              </svg>
+                            </div>
                           </div>
-                        </div>
-                      </span>
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] error tooltip not aligned correctly](https://app.clickup.com/t/86dwx4bpq)

## Summary

- Padding right applied to the icon has been moved out to a parent container that also wraps the tooltip.
- Tooltip position has been fixed and will now appear centered with the input warning icon.

<img width="605" alt="image" src="https://github.com/user-attachments/assets/ab536c93-88be-45a6-871a-a343a54d3307" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
