### PR TITLE
test: increase coverage for `src/app/libs/helpers`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -965,10 +965,10 @@ jobs:
         runs-on: ubuntu-latest
         env:
             COVERAGE_INCLUDE_PATH: src/app/lib
-            COVERAGE_THRESHOLD_LINES: 30.99
-            COVERAGE_THRESHOLD_BRANCHES: 22.77
-            COVERAGE_THRESHOLD_FUNCTIONS: 25.5
-            COVERAGE_THRESHOLD_STATEMENTS: 31.3
+            COVERAGE_THRESHOLD_LINES: 32.32
+            COVERAGE_THRESHOLD_BRANCHES: 26.35
+            COVERAGE_THRESHOLD_FUNCTIONS: 26.45
+            COVERAGE_THRESHOLD_STATEMENTS: 32.67
         strategy:
             matrix:
                 node-version:

--- a/src/app/lib/helpers/fast-sort.test.ts
+++ b/src/app/lib/helpers/fast-sort.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createNewSortInstance, inPlaceSort, sort } from "./fast-sort";
 
@@ -14,32 +14,32 @@ const users = [
 ];
 
 describe("sort", () => {
-	test("should not sort in place by default", () => {
+	it("should not sort in place by default", () => {
 		const arr = [...unsorted];
 		sort(arr).asc();
 		expect(arr).toEqual(unsorted);
 	});
 
 	describe("asc", () => {
-		test("should sort a flat array of numbers in ascending order", () => {
+		it("should sort a flat array of numbers in ascending order", () => {
 			expect(sort(unsorted).asc()).toEqual(sortedAsc);
 		});
 
-		test("should work with sortBy being true", () => {
+		it("should work with sortBy being true", () => {
 			expect(sort(unsorted).asc(true as any)).toEqual(sortedAsc);
 		});
 
-		test("should sort an array of objects by a string property", () => {
+		it("should sort an array of objects by a string property", () => {
 			const sortedByAge = sort(users).asc("age");
 			expect(sortedByAge.map((u) => u.age)).toEqual([25, 25, 30, 30]);
 		});
 
-		test("should sort an array of objects by a function property", () => {
+		it("should sort an array of objects by a function property", () => {
 			const sortedByScore = sort(users).asc((u) => u.score);
 			expect(sortedByScore.map((u) => u.score)).toEqual([70, 80, 90, 90]);
 		});
 
-		test("should sort by multiple properties (string array)", () => {
+		it("should sort by multiple properties (string array)", () => {
 			const users2 = [
 				{ name: "C", age: 30, score: 80 },
 				{ name: "B", age: 25, score: 90 },
@@ -49,7 +49,7 @@ describe("sort", () => {
 			expect(sorted2.map((u) => u.name)).toEqual(["B", "A", "C"]);
 		});
 
-		test("should sort by multiple properties (function array)", () => {
+		it("should sort by multiple properties (function array)", () => {
 			const users2 = [
 				{ name: "C", age: 30, score: 80 },
 				{ name: "B", age: 25, score: 90 },
@@ -59,7 +59,7 @@ describe("sort", () => {
 			expect(sorted.map((u) => u.name)).toEqual(["B", "A", "C"]);
 		});
 
-		test("should sort by multiple properties (mixed string/function array)", () => {
+		it("should sort by multiple properties (mixed string/function array)", () => {
 			const users2 = [
 				{ name: "C", age: 30, score: 80 },
 				{ name: "B", age: 25, score: 90 },
@@ -69,7 +69,7 @@ describe("sort", () => {
 			expect(sorted.map((u) => u.name)).toEqual(["B", "A", "C"]);
 		});
 
-		test("should handle null values", () => {
+		it("should handle null values", () => {
 			const arr = [1, null, 3, undefined, 2]; // undefined is treated as null by `== null`
 			const sortedArr = sort(arr).asc();
 			expect(sortedArr).toEqual([1, 2, 3, null, undefined]); // nulls are pushed to the end
@@ -77,20 +77,20 @@ describe("sort", () => {
 	});
 
 	describe("desc", () => {
-		test("should sort a flat array of numbers in descending order", () => {
+		it("should sort a flat array of numbers in descending order", () => {
 			expect(sort(unsorted).desc()).toEqual(sortedDesc);
 		});
 
-		test("should work with sortBy being true", () => {
+		it("should work with sortBy being true", () => {
 			expect(sort(unsorted).desc(true as any)).toEqual(sortedDesc);
 		});
 
-		test("should sort an array of objects by a string property in descending order", () => {
+		it("should sort an array of objects by a string property in descending order", () => {
 			const sortedByAge = sort(users).desc("age");
 			expect(sortedByAge.map((u) => u.age)).toEqual([30, 30, 25, 25]);
 		});
 
-		test("should sort by multiple properties descending", () => {
+		it("should sort by multiple properties descending", () => {
 			const users2 = [
 				{ name: "C", age: 30, score: 80 },
 				{ name: "B", age: 25, score: 90 },
@@ -100,7 +100,7 @@ describe("sort", () => {
 			expect(sorted.map((u) => u.name)).toEqual(["C", "A", "B"]); // age desc, then score desc
 		});
 
-		test("should handle null values", () => {
+		it("should handle null values", () => {
 			const arr = [1, null, 3, undefined, 2];
 			const sortedArr = sort(arr).desc();
 			expect(sortedArr).toEqual([3, 2, 1, null, undefined]);
@@ -108,7 +108,7 @@ describe("sort", () => {
 	});
 
 	describe("by", () => {
-		test("should sort by multiple properties with mixed order", () => {
+		it("should sort by multiple properties with mixed order", () => {
 			const users2 = [
 				{ name: "C", age: 30, score: 80 },
 				{ name: "B", age: 25, score: 90 },
@@ -118,7 +118,7 @@ describe("sort", () => {
 			expect(sorted.map((u) => u.name)).toEqual(["B", "C", "A"]);
 		});
 
-		test("should sort with function sorters", () => {
+		it("should sort with function sorters", () => {
 			const users2 = [
 				{ name: "C", age: 30, score: 80 },
 				{ name: "B", age: 25, score: 90 },
@@ -128,12 +128,12 @@ describe("sort", () => {
 			expect(sorted.map((u) => u.name)).toEqual(["B", "C", "A"]);
 		});
 
-		test("should handle a single object sorter", () => {
+		it("should handle a single object sorter", () => {
 			const sorted = sort(users).by({ asc: "age" });
 			expect(sorted.map((u) => u.age)).toEqual([25, 25, 30, 30]);
 		});
 
-		test("should sort by multiple properties with a comparer", () => {
+		it("should sort by multiple properties with a comparer", () => {
 			const customComparer = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
 			const sorted = sort(users).by([{ asc: "age" }, { desc: "score", comparer: customComparer }]);
 			const johnIndex = sorted.findIndex((u) => u.name === "John");
@@ -143,29 +143,29 @@ describe("sort", () => {
 	});
 
 	describe("Error handling", () => {
-		test("should throw error for nested properties in string syntax", () => {
+		it("should throw error for nested properties in string syntax", () => {
 			expect(() => sort(users).asc("profile.age" as any)).toThrow(
 				"String syntax not allowed for nested properties.",
 			);
 		});
 
-		test("should throw error for ambiguous object sorter", () => {
+		it("should throw error for ambiguous object sorter", () => {
 			expect(() => sort(users).by({ asc: "age", desc: "score" } as any)).toThrow(
 				"Ambiguous object with `asc` and `desc` config properties",
 			);
 		});
 
-		test("should throw error for invalid object sorter", () => {
+		it("should throw error for invalid object sorter", () => {
 			expect(() => sort(users).by({} as any)).toThrow("Expected `asc` or `desc` property");
 		});
 
-		test("should throw error for null sorter object", () => {
+		it("should throw error for null sorter object", () => {
 			expect(() => sort(users).by(null as any)).toThrow("Expected `asc` or `desc` property");
 		});
 	});
 
 	describe("Custom Comparer", () => {
-		test("should use custom comparer with asc", () => {
+		it("should use custom comparer with asc", () => {
 			const customComparer = (a, b) => {
 				const lenA = a ? a.length : 0;
 				const lenB = b ? b.length : 0;
@@ -181,7 +181,7 @@ describe("sort", () => {
 			expect(sortedAsc).toEqual(["kiwi", "pear", "apple", "banana"]);
 		});
 
-		test("should use custom comparer with object sorter", () => {
+		it("should use custom comparer with object sorter", () => {
 			const customComparer = (a, b) => String(a).localeCompare(String(b));
 			const data = [{ val: "c" }, { val: "b" }, { val: "a" }];
 			const sortedData = sort(data).by({ asc: "val", comparer: customComparer });
@@ -189,37 +189,37 @@ describe("sort", () => {
 		});
 	});
 
-	test("should handle empty array", () => {
+	it("should handle empty array", () => {
 		expect(sort([]).asc()).toEqual([]);
 		expect(sort([]).desc()).toEqual([]);
 		expect(sort([]).by({ asc: "a" })).toEqual([]);
 	});
 
-	test("should handle non-array input", () => {
+	it("should handle non-array input", () => {
 		const input: any = { a: 1 };
 		expect(sort(input).asc()).toBe(input);
 	});
 
-	test("should unpack single sortBy from array", () => {
+	it("should unpack single sortBy from array", () => {
 		const sorted = sort(users).asc(["age"]);
 		expect(sorted.map((u) => u.age)).toEqual([25, 25, 30, 30]);
 	});
 });
 
 describe("inPlaceSort", () => {
-	test("should sort in place", () => {
+	it("should sort in place", () => {
 		const arr = [...unsorted];
 		inPlaceSort(arr).asc();
 		expect(arr).toEqual(sortedAsc);
 	});
 
-	test("should sort in place with desc", () => {
+	it("should sort in place with desc", () => {
 		const arr = [...unsorted];
 		inPlaceSort(arr).desc();
 		expect(arr).toEqual(sortedDesc);
 	});
 
-	test("should sort in place with by", () => {
+	it("should sort in place with by", () => {
 		const users2 = [
 			{ name: "C", age: 30, score: 80 },
 			{ name: "B", age: 25, score: 90 },
@@ -234,14 +234,14 @@ describe("inPlaceSort", () => {
 		expect(users2).toEqual(expected);
 	});
 
-	test("should handle non-array input", () => {
+	it("should handle non-array input", () => {
 		const input: any = { a: 1 };
 		expect(inPlaceSort(input).asc()).toBe(input);
 	});
 });
 
 describe("multiPropertySorter with nulls", () => {
-	test("should handle null values correctly in multi-property sort", () => {
+	it("should handle null values correctly in multi-property sort", () => {
 		const data = [
 			{ a: 1, b: 3 },
 			{ a: null, b: 1 },
@@ -258,7 +258,7 @@ describe("multiPropertySorter with nulls", () => {
 		]);
 	});
 
-	test("should handle equal null values in multi-property sort", () => {
+	it("should handle equal null values in multi-property sort", () => {
 		const data = [
 			{ a: 1, b: 3 },
 			{ a: 1, b: null },

--- a/src/app/lib/helpers/fast-sort.test.ts
+++ b/src/app/lib/helpers/fast-sort.test.ts
@@ -13,6 +13,30 @@ const users = [
 	{ name: "Alice", age: 25, score: 90 },
 ];
 
+const basicComparer = (a: number, b: number): number => {
+	if (a < b) {
+		return -1;
+	}
+	if (a > b) {
+		return 1;
+	}
+	return 0;
+};
+
+const lengthComparer = (a: string, b: string): number => {
+	const lenA = a?.length ?? 0;
+	const lenB = b?.length ?? 0;
+	if (lenA < lenB) {
+		return -1;
+	}
+	if (lenA > lenB) {
+		return 1;
+	}
+	return 0;
+};
+
+const localeComparer = (a: any, b: any): number => String(a).localeCompare(String(b));
+
 describe("sort", () => {
 	it("should not sort in place by default", () => {
 		const arr = [...unsorted];
@@ -74,6 +98,13 @@ describe("sort", () => {
 			const sortedArr = sort(arr).asc();
 			expect(sortedArr).toEqual([1, 2, 3, null, undefined]); // nulls are pushed to the end
 		});
+
+		it("should sort by multiple properties with a comparer", () => {
+			const sorted = sort(users).by([{ asc: "age" }, { desc: "score", comparer: basicComparer }]);
+			const johnIndex = sorted.findIndex((u) => u.name === "John");
+			const doeIndex = sorted.findIndex((u) => u.name === "Doe");
+			expect(johnIndex).toBeLessThan(doeIndex);
+		});
 	});
 
 	describe("desc", () => {
@@ -134,8 +165,7 @@ describe("sort", () => {
 		});
 
 		it("should sort by multiple properties with a comparer", () => {
-			const customComparer = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
-			const sorted = sort(users).by([{ asc: "age" }, { desc: "score", comparer: customComparer }]);
+			const sorted = sort(users).by([{ asc: "age" }, { desc: "score", comparer: basicComparer }]);
 			const johnIndex = sorted.findIndex((u) => u.name === "John");
 			const doeIndex = sorted.findIndex((u) => u.name === "Doe");
 			expect(johnIndex).toBeLessThan(doeIndex);
@@ -166,15 +196,7 @@ describe("sort", () => {
 
 	describe("Custom Comparer", () => {
 		it("should use custom comparer with asc", () => {
-			const customComparer = (a, b) => {
-				const lenA = a ? a.length : 0;
-				const lenB = b ? b.length : 0;
-				if (lenA < lenB) return -1;
-				if (lenA > lenB) return 1;
-				return 0;
-			};
-
-			const sorter = createNewSortInstance({ comparer: customComparer });
+			const sorter = createNewSortInstance({ comparer: lengthComparer });
 			const strArr = ["apple", "banana", "kiwi", "pear"]; // 5, 6, 4, 4
 
 			const sortedAsc = sorter(strArr).asc();
@@ -182,9 +204,8 @@ describe("sort", () => {
 		});
 
 		it("should use custom comparer with object sorter", () => {
-			const customComparer = (a, b) => String(a).localeCompare(String(b));
 			const data = [{ val: "c" }, { val: "b" }, { val: "a" }];
-			const sortedData = sort(data).by({ asc: "val", comparer: customComparer });
+			const sortedData = sort(data).by({ asc: "val", comparer: localeComparer });
 			expect(sortedData.map((d) => d.val)).toEqual(["a", "b", "c"]);
 		});
 	});

--- a/src/app/lib/helpers/fast-sort.test.ts
+++ b/src/app/lib/helpers/fast-sort.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from "vitest";
+
+import { createNewSortInstance, inPlaceSort, sort } from "./fast-sort";
+
+const unsorted = [3, 1, 4, 1, 5, 9, 2, 6];
+const sortedAsc = [1, 1, 2, 3, 4, 5, 6, 9];
+const sortedDesc = [9, 6, 5, 4, 3, 2, 1, 1];
+
+const users = [
+	{ name: "John", age: 30, score: 80 },
+	{ name: "Jane", age: 25, score: 90 },
+	{ name: "Doe", age: 30, score: 70 },
+	{ name: "Alice", age: 25, score: 90 },
+];
+
+describe("sort", () => {
+	test("should not sort in place by default", () => {
+		const arr = [...unsorted];
+		sort(arr).asc();
+		expect(arr).toEqual(unsorted);
+	});
+
+	describe("asc", () => {
+		test("should sort a flat array of numbers in ascending order", () => {
+			expect(sort(unsorted).asc()).toEqual(sortedAsc);
+		});
+
+		test("should work with sortBy being true", () => {
+			expect(sort(unsorted).asc(true as any)).toEqual(sortedAsc);
+		});
+
+		test("should sort an array of objects by a string property", () => {
+			const sortedByAge = sort(users).asc("age");
+			expect(sortedByAge.map((u) => u.age)).toEqual([25, 25, 30, 30]);
+		});
+
+		test("should sort an array of objects by a function property", () => {
+			const sortedByScore = sort(users).asc((u) => u.score);
+			expect(sortedByScore.map((u) => u.score)).toEqual([70, 80, 90, 90]);
+		});
+
+		test("should sort by multiple properties (string array)", () => {
+			const users2 = [
+				{ name: "C", age: 30, score: 80 },
+				{ name: "B", age: 25, score: 90 },
+				{ name: "A", age: 30, score: 70 },
+			];
+			const sorted2 = sort(users2).asc(["age", "score"]);
+			expect(sorted2.map((u) => u.name)).toEqual(["B", "A", "C"]);
+		});
+
+		test("should sort by multiple properties (function array)", () => {
+			const users2 = [
+				{ name: "C", age: 30, score: 80 },
+				{ name: "B", age: 25, score: 90 },
+				{ name: "A", age: 30, score: 70 },
+			];
+			const sorted = sort(users2).asc([(u) => u.age, (u) => u.score]);
+			expect(sorted.map((u) => u.name)).toEqual(["B", "A", "C"]);
+		});
+
+		test("should sort by multiple properties (mixed string/function array)", () => {
+			const users2 = [
+				{ name: "C", age: 30, score: 80 },
+				{ name: "B", age: 25, score: 90 },
+				{ name: "A", age: 30, score: 70 },
+			];
+			const sorted = sort(users2).asc(["age", (u) => u.score]);
+			expect(sorted.map((u) => u.name)).toEqual(["B", "A", "C"]);
+		});
+
+		test("should handle null values", () => {
+			const arr = [1, null, 3, undefined, 2]; // undefined is treated as null by `== null`
+			const sortedArr = sort(arr).asc();
+			expect(sortedArr).toEqual([1, 2, 3, null, undefined]); // nulls are pushed to the end
+		});
+	});
+
+	describe("desc", () => {
+		test("should sort a flat array of numbers in descending order", () => {
+			expect(sort(unsorted).desc()).toEqual(sortedDesc);
+		});
+
+		test("should work with sortBy being true", () => {
+			expect(sort(unsorted).desc(true as any)).toEqual(sortedDesc);
+		});
+
+		test("should sort an array of objects by a string property in descending order", () => {
+			const sortedByAge = sort(users).desc("age");
+			expect(sortedByAge.map((u) => u.age)).toEqual([30, 30, 25, 25]);
+		});
+
+		test("should sort by multiple properties descending", () => {
+			const users2 = [
+				{ name: "C", age: 30, score: 80 },
+				{ name: "B", age: 25, score: 90 },
+				{ name: "A", age: 30, score: 70 },
+			];
+			const sorted = sort(users2).desc(["age", "score"]);
+			expect(sorted.map((u) => u.name)).toEqual(["C", "A", "B"]); // age desc, then score desc
+		});
+
+		test("should handle null values", () => {
+			const arr = [1, null, 3, undefined, 2];
+			const sortedArr = sort(arr).desc();
+			expect(sortedArr).toEqual([3, 2, 1, null, undefined]);
+		});
+	});
+
+	describe("by", () => {
+		test("should sort by multiple properties with mixed order", () => {
+			const users2 = [
+				{ name: "C", age: 30, score: 80 },
+				{ name: "B", age: 25, score: 90 },
+				{ name: "A", age: 30, score: 70 },
+			];
+			const sorted = sort(users2).by([{ asc: "age" }, { desc: "score" }]);
+			expect(sorted.map((u) => u.name)).toEqual(["B", "C", "A"]);
+		});
+
+		test("should sort with function sorters", () => {
+			const users2 = [
+				{ name: "C", age: 30, score: 80 },
+				{ name: "B", age: 25, score: 90 },
+				{ name: "A", age: 30, score: 70 },
+			];
+			const sorted = sort(users2).by([{ asc: (u) => u.age }, { desc: (u) => u.score }]);
+			expect(sorted.map((u) => u.name)).toEqual(["B", "C", "A"]);
+		});
+
+		test("should handle a single object sorter", () => {
+			const sorted = sort(users).by({ asc: "age" });
+			expect(sorted.map((u) => u.age)).toEqual([25, 25, 30, 30]);
+		});
+
+		test("should sort by multiple properties with a comparer", () => {
+			const customComparer = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+			const sorted = sort(users).by([{ asc: "age" }, { desc: "score", comparer: customComparer }]);
+			const johnIndex = sorted.findIndex((u) => u.name === "John");
+			const doeIndex = sorted.findIndex((u) => u.name === "Doe");
+			expect(johnIndex).toBeLessThan(doeIndex);
+		});
+	});
+
+	describe("Error handling", () => {
+		test("should throw error for nested properties in string syntax", () => {
+			expect(() => sort(users).asc("profile.age" as any)).toThrow(
+				"String syntax not allowed for nested properties.",
+			);
+		});
+
+		test("should throw error for ambiguous object sorter", () => {
+			expect(() => sort(users).by({ asc: "age", desc: "score" } as any)).toThrow(
+				"Ambiguous object with `asc` and `desc` config properties",
+			);
+		});
+
+		test("should throw error for invalid object sorter", () => {
+			expect(() => sort(users).by({} as any)).toThrow("Expected `asc` or `desc` property");
+		});
+
+		test("should throw error for null sorter object", () => {
+			expect(() => sort(users).by(null as any)).toThrow("Expected `asc` or `desc` property");
+		});
+	});
+
+	describe("Custom Comparer", () => {
+		test("should use custom comparer with asc", () => {
+			const customComparer = (a, b) => {
+				const lenA = a ? a.length : 0;
+				const lenB = b ? b.length : 0;
+				if (lenA < lenB) return -1;
+				if (lenA > lenB) return 1;
+				return 0;
+			};
+
+			const sorter = createNewSortInstance({ comparer: customComparer });
+			const strArr = ["apple", "banana", "kiwi", "pear"]; // 5, 6, 4, 4
+
+			const sortedAsc = sorter(strArr).asc();
+			expect(sortedAsc).toEqual(["kiwi", "pear", "apple", "banana"]);
+		});
+
+		test("should use custom comparer with object sorter", () => {
+			const customComparer = (a, b) => String(a).localeCompare(String(b));
+			const data = [{ val: "c" }, { val: "b" }, { val: "a" }];
+			const sortedData = sort(data).by({ asc: "val", comparer: customComparer });
+			expect(sortedData.map((d) => d.val)).toEqual(["a", "b", "c"]);
+		});
+	});
+
+	test("should handle empty array", () => {
+		expect(sort([]).asc()).toEqual([]);
+		expect(sort([]).desc()).toEqual([]);
+		expect(sort([]).by({ asc: "a" })).toEqual([]);
+	});
+
+	test("should handle non-array input", () => {
+		const input: any = { a: 1 };
+		expect(sort(input).asc()).toBe(input);
+	});
+
+	test("should unpack single sortBy from array", () => {
+		const sorted = sort(users).asc(["age"]);
+		expect(sorted.map((u) => u.age)).toEqual([25, 25, 30, 30]);
+	});
+});
+
+describe("inPlaceSort", () => {
+	test("should sort in place", () => {
+		const arr = [...unsorted];
+		inPlaceSort(arr).asc();
+		expect(arr).toEqual(sortedAsc);
+	});
+
+	test("should sort in place with desc", () => {
+		const arr = [...unsorted];
+		inPlaceSort(arr).desc();
+		expect(arr).toEqual(sortedDesc);
+	});
+
+	test("should sort in place with by", () => {
+		const users2 = [
+			{ name: "C", age: 30, score: 80 },
+			{ name: "B", age: 25, score: 90 },
+			{ name: "A", age: 30, score: 70 },
+		];
+		const expected = [
+			{ name: "B", age: 25, score: 90 },
+			{ name: "C", age: 30, score: 80 },
+			{ name: "A", age: 30, score: 70 },
+		];
+		inPlaceSort(users2).by([{ asc: (u) => u.age }, { desc: (u) => u.score }]);
+		expect(users2).toEqual(expected);
+	});
+
+	test("should handle non-array input", () => {
+		const input: any = { a: 1 };
+		expect(inPlaceSort(input).asc()).toBe(input);
+	});
+});
+
+describe("multiPropertySorter with nulls", () => {
+	test("should handle null values correctly in multi-property sort", () => {
+		const data = [
+			{ a: 1, b: 3 },
+			{ a: null, b: 1 },
+			{ a: 1, b: 2 },
+			{ a: null, b: 4 },
+		];
+
+		const sorted = sort(data).asc(["a", "b"]);
+		expect(sorted).toEqual([
+			{ a: 1, b: 2 },
+			{ a: 1, b: 3 },
+			{ a: null, b: 1 },
+			{ a: null, b: 4 },
+		]);
+	});
+
+	test("should handle equal null values in multi-property sort", () => {
+		const data = [
+			{ a: 1, b: 3 },
+			{ a: 1, b: null },
+			{ a: 1, b: 2 },
+			{ a: 1, b: null },
+		];
+
+		const sorted = sort(data).asc(["a", "b"]);
+
+		expect(sorted).toEqual([
+			{ a: 1, b: 2 },
+			{ a: 1, b: 3 },
+			{ a: 1, b: null },
+			{ a: 1, b: null },
+		]);
+	});
+});

--- a/src/app/lib/helpers/filter.test.ts
+++ b/src/app/lib/helpers/filter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { filter } from "./filter";
+
+describe("filter", () => {
+	it("should filter an array based on the predicate", () => {
+		const array = [
+			{ a: 1, active: true },
+			{ a: 2, active: false },
+			{ a: 3, active: true },
+		];
+		const result = filter(array, (item: { active: boolean }) => item.active);
+		expect(result).toEqual([
+			{ a: 1, active: true },
+			{ a: 3, active: true },
+		]);
+	});
+
+	it("should filter an object based on the predicate", () => {
+		const object = {
+			a: { value: 1, active: true },
+			b: { value: 2, active: false },
+			c: { value: 3, active: true },
+		};
+		const result = filter(object, (item: { active: boolean }) => item.active);
+		expect(result).toEqual({
+			a: { value: 1, active: true },
+			c: { value: 3, active: true },
+		});
+	});
+
+	it("should pass (value, index, array) to the iteratee for arrays", () => {
+		const array = ["a", "b"];
+		const args: any[] = [];
+		filter(array, (...rest) => {
+			args.push(rest);
+			return true;
+		});
+
+		expect(args).toEqual([
+			["a", 0, array],
+			["b", 1, array],
+		]);
+	});
+
+	it("should pass (value, key, object) to the iteratee for objects", () => {
+		const object = { a: 1, b: 2 };
+		const args: any[] = [];
+		filter(object, (...rest) => {
+			args.push(rest);
+			return true;
+		});
+
+		expect(args).toEqual([
+			[1, "a", object],
+			[2, "b", object],
+		]);
+	});
+});

--- a/src/app/lib/helpers/has.test.ts
+++ b/src/app/lib/helpers/has.test.ts
@@ -3,11 +3,19 @@ import { has } from "./has";
 
 describe("has", () => {
 	it("should return false if the target is not an object", () => {
+		expect(has(null, "a.b.c")).toBe(false);
+		expect(has(undefined, "a.b.c")).toBe(false);
+		expect(has(1, "a.b.c")).toBe(false);
+		expect(has("string", "a.b.c")).toBe(false);
 		expect(has([], "a.b.c")).toBe(false);
 	});
 
 	it("should return false if the path is not a string", () => {
-		expect(has({}, "123")).toBe(false);
+		expect(has({}, null as any)).toBe(false);
+		expect(has({}, undefined as any)).toBe(false);
+		expect(has({}, 123 as any)).toBe(false);
+		expect(has({}, [] as any)).toBe(false);
+		expect(has({}, {} as any)).toBe(false);
 	});
 
 	it("should not do anything if the object is not an object", () => {

--- a/src/app/lib/helpers/index-of.test.ts
+++ b/src/app/lib/helpers/index-of.test.ts
@@ -9,5 +9,6 @@ describe("indexOf", () => {
 		expect(indexOf([1, 2, 1, 2], 2, 2)).toBe(3);
 		expect(indexOf([1, 2, 1, 2], 3)).toBe(-1);
 		expect(indexOf([], 0, -1)).toBe(-1);
+		expect(indexOf([1, 2, 3, 4, 5, 1, 2, 3], 1, -3)).toBe(5);
 	});
 });

--- a/src/app/lib/helpers/slice.test.ts
+++ b/src/app/lib/helpers/slice.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { slice } from "./slice";
+
+describe("slice", () => {
+	const array = [1, 2, 3, 4, 5];
+
+	it("should slice a portion of the array", () => {
+		expect(slice(array, 1, 4)).toEqual([2, 3, 4]);
+	});
+
+	it("should work with a negative start index", () => {
+		expect(slice(array, -2, 5)).toEqual([4, 5]);
+	});
+
+	it("should work with a negative end index", () => {
+		expect(slice(array, 0, -1)).toEqual([1, 2, 3, 4]);
+	});
+
+	it("should handle start index greater than end index", () => {
+		expect(slice(array, 3, 2)).toEqual([]);
+	});
+
+	it("should handle end index greater than array length", () => {
+		expect(slice(array, 1, 10)).toEqual([2, 3, 4, 5]);
+	});
+
+	it("should handle start index less than negative array length", () => {
+		expect(slice(array, -10, 5)).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it("should handle negative start and end indices", () => {
+		expect(slice(array, -3, -1)).toEqual([3, 4]);
+	});
+
+	it("should return an empty array for an empty input array", () => {
+		expect(slice([], 0, 1)).toEqual([]);
+	});
+});

--- a/src/app/lib/helpers/slice.ts
+++ b/src/app/lib/helpers/slice.ts
@@ -1,7 +1,6 @@
 /* eslint-disable unicorn/no-new-array */
 // Taken from https://raw.githubusercontent.com/lodash/lodash/4.17.15-post/lodash.js
 
-/* istanbul ignore next */
 export const slice = <T>(array: T[], start: number, end: number): T[] => {
 	let index = -1;
 	let length = array.length;

--- a/src/app/lib/helpers/unset.test.ts
+++ b/src/app/lib/helpers/unset.test.ts
@@ -10,7 +10,12 @@ describe("unset", () => {
 		expect(unset([], "a.b.c")).toBe(false);
 	});
 
-	it("should work with a string or array as path", () => {
+	it("should return false if the path is not a string", () => {
+		// @ts-expect-error
+		expect(unset({}, 123)).toBe(false);
+	});
+
+	it("should work with a string path", () => {
 		const object = { a: { b: { c: 7 } } };
 
 		unset(object, "a.b.c");

--- a/src/app/lib/helpers/unset.ts
+++ b/src/app/lib/helpers/unset.ts
@@ -2,7 +2,7 @@ import dot from "dot-prop";
 import { isObject } from "./is-object.js";
 import { isString } from "./is-string.js";
 
-export const unset = <T>(object: T, path: string | string[]): boolean => {
+export const unset = <T>(object: T, path: string): boolean => {
 	if (!isObject(object) || !isString(path)) {
 		return false;
 	}

--- a/src/app/lib/helpers/validator.test.ts
+++ b/src/app/lib/helpers/validator.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import Joi from "joi";
+
+import { Validator } from "./validator";
+
+describe("Validator", () => {
+	const schema = Joi.object({
+		name: Joi.string().required(),
+		age: Joi.number().required(),
+	});
+
+	it("should pass validation with correct data", () => {
+		const validator = new Validator();
+		const data = { name: "John Doe", age: 30 };
+		const value = validator.validate(data, schema);
+
+		expect(validator.passes()).toBe(true);
+		expect(validator.fails()).toBe(false);
+		expect(validator.errors()).toBeUndefined();
+		expect(validator.error()).toBeUndefined();
+		expect(value).toEqual(data);
+	});
+
+	it("should fail validation with incorrect data", () => {
+		const validator = new Validator();
+		const data = { name: "John Doe" }; // age is missing
+		const value = validator.validate(data, schema);
+
+		expect(validator.passes()).toBe(false);
+		expect(validator.fails()).toBe(true);
+		expect(validator.errors()).toEqual(['"age" is required']);
+		expect(validator.error()).toBeInstanceOf(Joi.ValidationError);
+		expect(value).toEqual(data);
+	});
+
+	it("should return the full error object", () => {
+		const validator = new Validator();
+		const data = { name: "test" }; // age is missing
+		validator.validate(data, schema);
+		const error = validator.error();
+
+		expect(error).toBeInstanceOf(Joi.ValidationError);
+		expect(error?.details).toHaveLength(1);
+	});
+
+	it("should reset errors on subsequent validations", () => {
+		const validator = new Validator();
+		const failingData = {};
+		validator.validate(failingData, schema);
+
+		expect(validator.fails()).toBe(true);
+
+		const passingData = { name: "Jane Doe", age: 25 };
+		validator.validate(passingData, schema);
+
+		expect(validator.passes()).toBe(true);
+		expect(validator.errors()).toBeUndefined();
+	});
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dx03r17

100% test coverage for folder, can be tested with `COVERAGE_INCLUDE_PATH=src/app/lib/helpers pnpm test:coverage src/app/lib/helpers`


## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
