### PR TITLE
refactor: sidepanel background dim

### DIFF
--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -106,7 +106,7 @@ export const SidePanel = ({
 			<FloatingPortal>
 				{isMounted && (
 					<>
-						<div className="fixed inset-0 z-40 bg-[#212225]/10 backdrop-blur-xl dark:bg-[#191d22]/90 dark:backdrop-blur-none dim:bg-[#101627CC]/90 dim:backdrop-blur-sm" />
+						<div className="dim:bg-[#101627CC]/90 dim:backdrop-blur-sm fixed inset-0 z-40 bg-[#212225]/10 backdrop-blur-xl dark:bg-[#191d22]/90 dark:backdrop-blur-none" />
 						<FloatingOverlay className="z-50 transition-opacity duration-300" lockScroll>
 							<FloatingFocusManager context={context} disabled={isUnit()}>
 								<div

--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -106,7 +106,7 @@ export const SidePanel = ({
 			<FloatingPortal>
 				{isMounted && (
 					<>
-						<div className="fixed inset-0 z-40 bg-[#212225]/10 backdrop-blur-xl dark:bg-[#191d22]/90 dark:backdrop-blur-none" />
+						<div className="fixed inset-0 z-40 bg-[#212225]/10 backdrop-blur-xl dark:bg-[#191d22]/90 dark:backdrop-blur-none dim:bg-[#101627CC]/90 dim:backdrop-blur-sm" />
 						<FloatingOverlay className="z-50 transition-opacity duration-300" lockScroll>
 							<FloatingFocusManager context={context} disabled={isUnit()}>
 								<div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dim] adjust backdrop in dim mode](https://app.clickup.com/t/86dwzw2jx)

## Summary

- Sidepanel's background styling has been adjusted in dim mode to match the designs.

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/bdcf4f39-ba4f-4217-80c3-33ba72f89cfe" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
