### PR TITLE
fix: encrypted password removing imported addresses

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -98,11 +98,7 @@ export const ImportAddressesSidePanel = ({
 	const forgetImportedWallets = (importedWallet?: Contracts.IReadWriteWallet) => {
 		assertWallet(importedWallet);
 
-		for (const profileWallet of activeProfile.wallets().values()) {
-			if (profileWallet.address() === importedWallet.address()) {
-				activeProfile.wallets().forget(profileWallet.id());
-			}
-		}
+		activeProfile.wallets().forget(importedWallet.id());
 
 		if (activeProfile.wallets().selected().length === 0) {
 			activeProfile.wallets().selectOne(activeProfile.wallets().first());


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[import] using encrypted password can remove current addresses](https://app.clickup.com/t/86dwz4k7e)

## Summary

- The code will now forget only the current imported address when cancelling an import (it can be due to clicking "back" on the encrypted password step or even closing the modal).

## Steps to reproduce

1. Create a new profile.
2. Import any address in the next window
3. Select import again
4. Select secret or mnemonic, but this time enable the password encryption
5. Click on the "Next" button
6. At the password encryption page, click on "Back"
7. Once back at the Portfolio page, the address that was added originally will remain and just the imported one will disappear.

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/0faefd3c-3ae0-43f7-82b2-6a5e3bd66122" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
