### PR TITLE
fix: remove margin for detail wrapper

### DIFF
--- a/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ValidatorRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ValidatorRegistrationForm.test.tsx.snap
@@ -432,7 +432,7 @@ exports[`ValidatorRegistrationForm > should render review step 1`] = `
             class="space-y-3 sm:space-y-2"
           >
             <div
-              class="mx-0"
+              class="mx-3 sm:mx-0"
             >
               <div
                 data-testid="DetailWrapper"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx flow] mobile headers not aligned](https://app.clickup.com/t/86dx5jcpf)

## Summary

- Alignment for the detail wrapper has been fixed in the transaction review and transaction approval pages on mobile views.

<img width="359" alt="image" src="https://github.com/user-attachments/assets/0f5828b1-4268-4eed-abd4-c1d878c82e2a" />
<img width="356" alt="image" src="https://github.com/user-attachments/assets/0d1c8bde-120b-43af-ae47-896e9f049aaf" />




<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
