### PR TITLE
refactor: dim mode for transaction confirmations 

### DIFF
--- a/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmations.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmations.tsx
@@ -19,7 +19,7 @@ export const TransactionConfirmations = ({
 	const { t } = useTranslation();
 	const { status } = useMultiSignatureStatus({ transaction, wallet: transaction.wallet() });
 
-	if (confirmations && confirmations > 1 && transaction.isSuccess()) {
+	if (confirmations && confirmations > 1 && !transaction.isSuccess()) {
 		return (
 			<div
 				data-testid="TransactionFailedAlert"
@@ -33,7 +33,7 @@ export const TransactionConfirmations = ({
 
 					<Divider
 						type="vertical"
-						className="text-theme-danger-200 dark:text-theme-secondary-800 dim:text-theme-secondary-800 h-5"
+						className="text-theme-danger-200 dark:text-theme-secondary-800 dim:text-theme-dim-700 h-5"
 					/>
 
 					<p className="text-theme-secondary-700 dark:text-theme-secondary-500 dim:text-theme-dim-200 font-semibold">
@@ -53,14 +53,14 @@ export const TransactionConfirmations = ({
 			{!isConfirmed && (
 				<div
 					data-testid="PendingConfirmationAlert"
-					className="border-theme-warning-200 bg-theme-warning-50 dark:border-theme-warning-600 dim:border-theme-warning-600 dim:bg-transparent flex items-center space-x-3 rounded-xl border px-3 py-2 max-sm:text-sm sm:px-6 sm:py-4 sm:leading-5 dark:bg-transparent"
+					className="border-theme-warning-200 bg-theme-warning-50 dark:border-theme-warning-600 dim:border-theme-warning-600 dim:bg-theme-dim-900 flex items-center space-x-3 rounded-xl border px-3 py-2 max-sm:text-sm sm:px-6 sm:py-4 sm:leading-5 dark:bg-transparent"
 				>
 					<Spinner color="warning-alt" size="sm" width={3} />
 					<Divider
 						type="vertical"
-						className="text-theme-warning-200 dark:text-theme-secondary-800 dim:text-theme-secondary-800 h-5"
+						className="text-theme-warning-200 dark:text-theme-secondary-800 dim:text-theme-dim-700 h-5"
 					/>
-					<p className="text-theme-secondary-700 dark:text-theme-warning-600 dim:text-theme-warning-600 font-semibold">
+					<p className="text-theme-secondary-700 dark:text-theme-warning-600 dim:text-theme-dim-200 font-semibold">
 						{status.value === "isBroadcasted" ? t("TRANSACTION.PENDING.STATUS_TEXT") : status.label}
 					</p>
 				</div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[tx details] dim mode issue when tx failed](https://app.clickup.com/t/86dx7ky3a)

## Summary

- Dim mode support has been added for the transaction confirmations component.


## Screenshots 

- Error variant:
<img width="748" height="363" alt="image" src="https://github.com/user-attachments/assets/debc1b61-74d8-4a99-bd0a-3545b3f9d5fc" />

- Warning variant:
<img width="717" height="248" alt="image" src="https://github.com/user-attachments/assets/738de505-97da-42fd-a45d-43ccaf68c6bb" />

- Success variant:
<img width="708" height="241" alt="image" src="https://github.com/user-attachments/assets/f32265b9-905c-4d2d-a414-6559e6ae07e4" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
