### PR TITLE
fix: back button functionality on send vote error

### DIFF
--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -497,7 +497,9 @@ export const SendVote = () => {
 								<ErrorStep
 									onClose={() => navigate(`/profiles/${activeProfile.id()}/dashboard`)}
 									isBackDisabled={isSubmitting}
-									onBack={() => {setActiveTab(Step.ReviewStep);}}
+									onBack={() => {
+										setActiveTab(Step.ReviewStep);
+									}}
 									errorMessage={errorMessage}
 								/>
 							</TabPanel>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[vote] using "back" does not allow you to edit vote](https://app.clickup.com/t/86dx7a385)

## Summary

- Using "back" button when having an error on the send vote flow will redirect you to the review step.
<img width="919" height="729" alt="image" src="https://github.com/user-attachments/assets/73afca0e-737a-45f1-9dd1-84b38f2cf68d" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
