### PR TITLE
refactor: improve tooltip on mobile

### DIFF
--- a/src/app/components/Tooltip/Tooltip.tsx
+++ b/src/app/components/Tooltip/Tooltip.tsx
@@ -20,7 +20,7 @@ export const Tooltip: React.FC<TooltipProperties> = ({ size, theme, ...propertie
 			maxWidth={600}
 			theme={theme || themeOptions.theme}
 			{...properties}
-			className={cn(getStyles(size), properties.className)}
+			className={cn("break-words whitespace-normal overflow-wrap-anywhere", getStyles(size), properties.className)}
 		/>
 	);
 };

--- a/src/app/components/Tooltip/Tooltip.tsx
+++ b/src/app/components/Tooltip/Tooltip.tsx
@@ -20,7 +20,11 @@ export const Tooltip: React.FC<TooltipProperties> = ({ size, theme, ...propertie
 			maxWidth={600}
 			theme={theme || themeOptions.theme}
 			{...properties}
-			className={cn("break-words whitespace-normal overflow-wrap-anywhere", getStyles(size), properties.className)}
+			className={cn(
+				"overflow-wrap-anywhere break-words whitespace-normal",
+				getStyles(size),
+				properties.className,
+			)}
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] improve address tooltip](https://app.clickup.com/t/86dx79tjq)

## Summary

- Tooltip will now break words if the content is too long in mobile.

<img width="355" height="479" alt="image" src="https://github.com/user-attachments/assets/f4adbc9e-0f38-4c2e-a1c9-89f90e0d8120" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
