### PR TITLE
fix: rerender image upon theme color change

### DIFF
--- a/src/app/components/Image/Image.tsx
+++ b/src/app/components/Image/Image.tsx
@@ -13,7 +13,7 @@ type ImageProperties = {
 
 export const Image = ({ name, domain = "common", loading = "lazy", ...properties }: ImageProperties) => {
 	const [imageName, setImageName] = React.useState("");
-	const { isDarkMode } = useTheme();
+	const { isDarkMode, isDimMode } = useTheme();
 
 	// TODO: remove try/catch usage
 	let profile: Contracts.IProfile | undefined;
@@ -36,7 +36,7 @@ export const Image = ({ name, domain = "common", loading = "lazy", ...properties
 		}
 
 		setImageName(imageName);
-	}, [name, profile, isDarkMode]);
+	}, [name, profile, isDarkMode, isDimMode]);
 
 	const Image = (images as any)[domain][imageName] || (images as any)[domain][name];
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
When the theme changes without page refresh (dark, light, dim), the images are not updating with the new theme color variant. 

For example in settings
<img width="914" height="352" alt="image" src="https://github.com/user-attachments/assets/e70e7732-ee0d-4abe-b000-2d50fa236cfe" />

This PR forces the image to rerender once a theme change occurs.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
