### PR TITLE
fix: use radios for addresses panel entries in mobile

### DIFF
--- a/src/domains/portfolio/components/AddressesSidePanel/AddressRow.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/AddressRow.tsx
@@ -49,6 +49,7 @@ export const AddressRow = ({
 				isError={isError}
 				errorMessage={errorMessage}
 				deleteContent={deleteContent}
+				isSingleView={isSingleView}
 			/>
 		);
 	}

--- a/src/domains/portfolio/components/AddressesSidePanel/MobileAddressRow.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/MobileAddressRow.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/app/components/Button";
 import { Icon } from "@/app/components/Icon";
 import { InfoDetail, MultiEntryItem } from "@/app/components/MultiEntryItem/MultiEntryItem";
 import { useWalletAlias } from "@/app/hooks";
+import { RadioButton } from "@/app/components/RadioButton";
 
 export const MobileAddressRow = ({
 	profile,
@@ -19,6 +20,7 @@ export const MobileAddressRow = ({
 	isError,
 	errorMessage,
 	deleteContent,
+	isSingleView,
 }: {
 	profile: Contracts.IProfile;
 	wallet: Contracts.IReadWriteWallet;
@@ -29,6 +31,7 @@ export const MobileAddressRow = ({
 	isError?: boolean;
 	errorMessage?: string;
 	deleteContent?: React.ReactNode;
+	isSingleView: boolean;
 }): JSX.Element => {
 	const { getWalletAlias } = useWalletAlias();
 	const { alias } = getWalletAlias({ address: wallet.address(), network: wallet.network(), profile });
@@ -47,11 +50,22 @@ export const MobileAddressRow = ({
 						tabIndex={0}
 						className={cn("flex w-full items-center gap-3", { "justify-between": usesDeleteMode })}
 					>
-						{!usesDeleteMode && (
+						{!usesDeleteMode && !isSingleView && (
 							<Checkbox
 								name="all"
 								data-testid="AddressRow--checkbox"
 								className="m-0.5"
+								checked={isSelected}
+								onChange={() => toggleAddress(wallet.address())}
+							/>
+						)}
+
+						{!usesDeleteMode && isSingleView && (
+							<RadioButton
+								name="single"
+								data-testid="AddressRow--radio"
+								color="info"
+								className="m-0.5 h-5 w-5"
 								checked={isSelected}
 								onChange={() => toggleAddress(wallet.address())}
 							/>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dxcw9be

Single view:

<img width="590" height="770" alt="image" src="https://github.com/user-attachments/assets/d196b918-e704-465c-b277-3af2942ae370" />

Multiple view:

<img width="590" height="770" alt="image" src="https://github.com/user-attachments/assets/a4569645-b8bd-4f38-878b-826f8b4edfa2" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
