### PR TITLE
fix: show full address on portfolio header on lg

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -922,7 +922,7 @@ exports[`Dashboard > should render 1`] = `
                             </span>
                           </span>
                           <span
-                            class="hidden lg:block min-w-[26.375rem]"
+                            class="hidden min-w-[26.375rem] lg:block"
                           >
                             <div
                               class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -922,7 +922,7 @@ exports[`Dashboard > should render 1`] = `
                             </span>
                           </span>
                           <span
-                            class="hidden lg:block"
+                            class="hidden lg:block min-w-[26.375rem]"
                           >
                             <div
                               class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -218,7 +218,7 @@ export const PortfolioHeader = ({
 											<span className="lg:hidden">
 												<TruncateMiddle text={wallet.address()} maxChars={16} />
 											</span>
-											<span className="hidden lg:block">
+											<span className="hidden lg:block min-w-[26.375rem]">
 												<Address address={wallet.address()} />
 											</span>
 										</span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dx5jbnu
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
