### PR TITLE
fix: delete address buttons in addresses side panel

### DIFF
--- a/src/domains/portfolio/components/AddressesSidePanel/DeleteAddressMessage.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/DeleteAddressMessage.tsx
@@ -20,7 +20,7 @@ export const DeleteAddressMessage = ({
 				{t("COMMON.DELETE_DESCRIPTION")}
 			</p>
 
-			<div className="mt-4 flex w-full items-center leading-[18px] justify-end sm:leading-5">
+			<div className="mt-4 flex w-full items-center justify-end leading-[18px] sm:leading-5">
 				<Button
 					data-testid="CancelDelete"
 					size="icon"

--- a/src/domains/portfolio/components/AddressesSidePanel/DeleteAddressMessage.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/DeleteAddressMessage.tsx
@@ -20,13 +20,13 @@ export const DeleteAddressMessage = ({
 				{t("COMMON.DELETE_DESCRIPTION")}
 			</p>
 
-			<div className="mt-4 flex w-full items-center justify-center leading-[18px] sm:justify-end sm:leading-5">
+			<div className="mt-4 flex w-full items-center leading-[18px] justify-end sm:leading-5">
 				<Button
 					data-testid="CancelDelete"
 					size="icon"
 					variant="transparent"
 					onClick={onCancelDelete}
-					className="text-theme-primary-600 dark:text-theme-primary-400 dim:text-theme-dim-navy-400 px-2 py-[3px] text-sm leading-[18px] sm:text-base sm:leading-5"
+					className="text-theme-primary-600 dark:text-theme-primary-400 dim:text-theme-dim-navy-400 px-2 py-[3px] leading-5"
 				>
 					{t("COMMON.CANCEL")}
 				</Button>
@@ -41,7 +41,7 @@ export const DeleteAddressMessage = ({
 					size="icon"
 					variant="transparent"
 					onClick={onConfirmDelete}
-					className="text-theme-danger-400 dim:text-theme-danger-400 px-2 py-[3px] text-sm leading-[18px] sm:text-base sm:leading-5"
+					className="text-theme-danger-400 dim:text-theme-danger-400 px-2 py-[3px] leading-5"
 				>
 					{t("COMMON.DELETE_ADDRESS")}
 				</Button>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dxf01ux

Buttons in delete mode should be aligned to the right: https://helloardent.slack.com/archives/C03889W1KHT/p1754389636377679?thread_ts=1754319560.980389&cid=C03889W1KHT

Design: https://www.figma.com/design/OX18z9oCfYiV4cW35bzxsu/ARKVault-Mainsail?node-id=27193-138854&m=dev

<img width="502" height="838" alt="image" src="https://github.com/user-attachments/assets/9852f216-26c4-4367-89ba-97b6e274d8fe" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
