### PR TITLE
test: fix flaky tests in profile & message domains

### DIFF
--- a/src/domains/message/pages/VerifyMessage/VerifyMessage.test.tsx
+++ b/src/domains/message/pages/VerifyMessage/VerifyMessage.test.tsx
@@ -48,6 +48,10 @@ vi.stubGlobal(
 	},
 );
 
+vi.mock("@/utils/delay", () => ({
+	delay: (callback: () => void) => callback(),
+}));
+
 const originalHasInstance = Uint8Array[Symbol.hasInstance];
 
 describe("VerifyMessage", () => {

--- a/src/domains/profile/pages/CreateProfile/CreateProfile.test.tsx
+++ b/src/domains/profile/pages/CreateProfile/CreateProfile.test.tsx
@@ -48,6 +48,10 @@ const renderComponent = async () => {
 	return utils;
 };
 
+vi.mock("@/utils/delay", () => ({
+	delay: (callback: () => void) => callback(),
+}));
+
 describe("CreateProfile", () => {
 	beforeAll(() => {
 		env.reset({ httpClient, storage: new StubStorage() });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dx2dvkb 

The error seems to be happening because probably the test finishes before `setTimeout` in
https://github.com/ArdentHQ/arkvault/blob/d17c37878c27dcdbebe94e40b3e885aea9061bc6/src/app/hooks/use-input-focus.ts#L24
which is called by several tests in profile creation and message verification.

The PR mocks the `delay` function in thoses tests in order to avoid any delays regarding the input focus/unfocus, though it's not easily reproducible.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
