### PR TITLE
fix: image shake on Ledger connection step

### DIFF
--- a/src/domains/transaction/components/AuthenticationStep/Ledger/ListenLedger.tsx
+++ b/src/domains/transaction/components/AuthenticationStep/Ledger/ListenLedger.tsx
@@ -56,7 +56,7 @@ export const ListenLedger = ({
 	}, [hasDeviceAvailable, onDeviceAvailable]);
 
 	return (
-		<section data-testid="LedgerAuthStep" className="space-y-8">
+		<section data-testid="LedgerAuthStep" className="space-y-8 overflow-hidden h-full">
 			{!noHeading && <Header title={t("WALLETS.CONNECT_LEDGER.HEADER")} />}
 
 			{subject === "message" && (

--- a/src/domains/transaction/components/AuthenticationStep/Ledger/__snapshots__/ListenLedger.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/Ledger/__snapshots__/ListenLedger.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ListenLedger > should emit event on device available 1`] = `
 <div>
   <section
-    class="space-y-8"
+    class="space-y-8 overflow-hidden h-full"
     data-testid="LedgerAuthStep"
   >
     <div
@@ -186,7 +186,7 @@ exports[`ListenLedger > should emit event on device available 1`] = `
 exports[`ListenLedger > should emit event on device not available 1`] = `
 <div>
   <section
-    class="space-y-8"
+    class="space-y-8 overflow-hidden h-full"
     data-testid="LedgerAuthStep"
   >
     <div

--- a/src/domains/transaction/components/AuthenticationStep/Ledger/__snapshots__/ListenLedger.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/Ledger/__snapshots__/ListenLedger.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ListenLedger > should emit event on device available 1`] = `
 <div>
   <section
-    class="space-y-8 overflow-hidden h-full"
+    class="h-full space-y-8 overflow-hidden"
     data-testid="LedgerAuthStep"
   >
     <div
@@ -186,7 +186,7 @@ exports[`ListenLedger > should emit event on device available 1`] = `
 exports[`ListenLedger > should emit event on device not available 1`] = `
 <div>
   <section
-    class="space-y-8 overflow-hidden h-full"
+    class="h-full space-y-8 overflow-hidden"
     data-testid="LedgerAuthStep"
   >
     <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Ledger Import] image shake due to scrollbar](https://app.clickup.com/t/86dxfxf4v)

## Summary

- Scrollbar is now hidden, and the section tag will now take full height to prevent the scrollbar width from appearing and making the content "shake".

<img width="609" height="520" alt="image" src="https://github.com/user-attachments/assets/0a567f94-7894-45f9-b4d8-96dc15316f5e" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
