### PR TITLE
fix: wallet alias consistency

### DIFF
--- a/src/app/hooks/use-search-wallet.test.tsx
+++ b/src/app/hooks/use-search-wallet.test.tsx
@@ -118,24 +118,21 @@ describe("useSearchWallet", () => {
 
 	it("should return empty list when wallets is an empty array", () => {
 		const { result } = renderHook(() => useSearchWallet({ profile, wallets: [] }), { wrapper });
-	  
+
 		expect(result.current.filteredList).toHaveLength(0);
 		expect(result.current.isEmptyResults).toBe(false);
-	  
+
 		act(() => result.current.setSearchKeyword("anything"));
 		expect(result.current.filteredList).toHaveLength(0);
 		expect(result.current.isEmptyResults).toBe(true);
 	});
 
 	it("should return empty list when wallets is undefined", () => {
-		const { result } = renderHook(
-		  () => useSearchWallet({ profile, wallets: undefined as any }),
-		  { wrapper },
-		);
-	  
+		const { result } = renderHook(() => useSearchWallet({ profile, wallets: undefined as any }), { wrapper });
+
 		expect(result.current.filteredList).toHaveLength(0);
 		expect(result.current.isEmptyResults).toBe(false);
-	  
+
 		act(() => result.current.setSearchKeyword("anything"));
 		expect(result.current.filteredList).toHaveLength(0);
 		expect(result.current.isEmptyResults).toBe(true);

--- a/src/app/hooks/use-search-wallet.test.tsx
+++ b/src/app/hooks/use-search-wallet.test.tsx
@@ -47,7 +47,7 @@ describe("useSearchWallet", () => {
 			const defaultList = getList(listType);
 			const {
 				result: { current },
-			} = renderHook(() => useSearchWallet({ wallets: defaultList }), { wrapper });
+			} = renderHook(() => useSearchWallet({ profile, wallets: defaultList }), { wrapper });
 
 			const { filteredList } = current;
 
@@ -56,7 +56,7 @@ describe("useSearchWallet", () => {
 	);
 
 	it.each([ListType.wallets, ListType.recipients])("should filter %s by address", (listType) => {
-		const { result } = renderHook(() => useSearchWallet({ wallets: getList(listType) }), { wrapper });
+		const { result } = renderHook(() => useSearchWallet({ profile, wallets: getList(listType) }), { wrapper });
 
 		expect(result.current.filteredList).toHaveLength(2);
 
@@ -100,7 +100,7 @@ describe("useSearchWallet", () => {
 	it.each([ListType.wallets, ListType.recipients])(
 		"should not find search %s and turn 'isEmptyResults' to true",
 		(listType) => {
-			const { result } = renderHook(() => useSearchWallet({ wallets: getList(listType) }), { wrapper });
+			const { result } = renderHook(() => useSearchWallet({ profile, wallets: getList(listType) }), { wrapper });
 
 			expect(result.current.filteredList).toHaveLength(2);
 			expect(result.current.isEmptyResults).toBeFalsy();
@@ -115,4 +115,29 @@ describe("useSearchWallet", () => {
 			expect(isEmptyResults).toBeTruthy();
 		},
 	);
+
+	it("should return empty list when wallets is an empty array", () => {
+		const { result } = renderHook(() => useSearchWallet({ profile, wallets: [] }), { wrapper });
+	  
+		expect(result.current.filteredList).toHaveLength(0);
+		expect(result.current.isEmptyResults).toBe(false);
+	  
+		act(() => result.current.setSearchKeyword("anything"));
+		expect(result.current.filteredList).toHaveLength(0);
+		expect(result.current.isEmptyResults).toBe(true);
+	});
+
+	it("should return empty list when wallets is undefined", () => {
+		const { result } = renderHook(
+		  () => useSearchWallet({ profile, wallets: undefined as any }),
+		  { wrapper },
+		);
+	  
+		expect(result.current.filteredList).toHaveLength(0);
+		expect(result.current.isEmptyResults).toBe(false);
+	  
+		act(() => result.current.setSearchKeyword("anything"));
+		expect(result.current.filteredList).toHaveLength(0);
+		expect(result.current.isEmptyResults).toBe(true);
+	});
 });

--- a/src/app/hooks/use-search-wallet.tsx
+++ b/src/app/hooks/use-search-wallet.tsx
@@ -5,78 +5,76 @@ import { useWalletAlias } from "./use-wallet-alias";
 import { RecipientProperties } from "@/domains/transaction/components/SearchRecipient/SearchRecipient.contracts";
 
 interface SearchWalletProperties {
-	profile: Contracts.IProfile;
-	wallets: (Contracts.IReadWriteWallet | RecipientProperties)[];
+  profile: Contracts.IProfile;
+  wallets: (Contracts.IReadWriteWallet | RecipientProperties)[];
 }
 
 export const useSearchWallet = ({ profile, wallets }: SearchWalletProperties) => {
-	const [searchKeyword, setSearchKeyword] = useState("");
-	const { getWalletAlias } = useWalletAlias();
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const { getWalletAlias } = useWalletAlias();
 
-	const looksLikeRecipientList = useMemo(() => {
-		const first = wallets?.[0] as any;
-		return typeof first?.address === "string";
-	}, [wallets]);
+  const isRecipientList = useMemo(() => {
+    const first = wallets?.[0] as any;
+    return typeof first?.address === "string";
+  }, [wallets]);
 
-	const allWallets = useMemo(() => profile.wallets().values(), [profile]);
+  const allProfileWallets = useMemo(() => profile.wallets().values(), [profile]);
 
-	const normalizedList = useMemo(() => {
-		if (!wallets || wallets.length === 0) {
-			return [];
-		}
+  const normalizedList = useMemo(() => {
+    if (!wallets || wallets.length === 0) {
+      return [];
+    }
 
-		if (looksLikeRecipientList) {
-			const recipients = wallets as RecipientProperties[];
+    if (isRecipientList) {
+      const recipients = wallets as RecipientProperties[];
+      return recipients.map((recipient) => {
+        const resolvedWallet = allProfileWallets.find((w) => w.address() === recipient.address);
+        const { alias } = getWalletAlias({
+          address: recipient.address,
+          network: resolvedWallet?.network(),
+          profile,
+        });
+        return { ...recipient, alias: alias ?? recipient.alias };
+      });
+    }
 
-			return recipients.map((recipient) => {
-				const resolvedWallet = allWallets.find((w) => w.address() === recipient.address);
-				const { alias } = getWalletAlias({
-					address: recipient.address,
-					network: resolvedWallet?.network(),
-					profile,
-				});
+    return wallets;
+  }, [wallets, isRecipientList, allProfileWallets, getWalletAlias, profile]);
 
-				return { ...recipient, alias: alias ?? recipient.alias };
-			});
-		}
+  const matchKeyword = useCallback(
+    (value?: string) => value?.toLowerCase().includes(searchKeyword.toLowerCase()),
+    [searchKeyword]
+  );
 
-		return wallets;
-	}, [wallets, looksLikeRecipientList, allWallets, getWalletAlias, profile]);
+  const filteredList = useMemo(() => {
+    if (searchKeyword.length === 0) {
+      return normalizedList;
+    }
 
-	const matchKeyword = useCallback(
-		(value?: string) => value?.toLowerCase().includes(searchKeyword.toLowerCase()),
-		[searchKeyword],
-	);
+    if (isRecipientList) {
+      const recipients = normalizedList as RecipientProperties[];
+      return recipients.filter(({ address, alias }) => matchKeyword(address) || matchKeyword(alias));
+    }
 
-	const filteredList = useMemo(() => {
-		if (searchKeyword.length === 0) {
-			return normalizedList;
-		}
+    const typedWallets = normalizedList as Contracts.IReadWriteWallet[];
+    return typedWallets.filter((wallet) => {
+      const { alias } = getWalletAlias({
+        address: wallet.address(),
+        network: wallet.network(),
+        profile,
+      });
+      return matchKeyword(wallet.address()) || matchKeyword(alias);
+    });
+  }, [normalizedList, isRecipientList, matchKeyword, searchKeyword.length, getWalletAlias, profile]);
 
-		if (looksLikeRecipientList) {
-			const recipients = normalizedList as RecipientProperties[];
-			return recipients.filter(({ address, alias }) => matchKeyword(address) || matchKeyword(alias));
-		}
+  const isEmptyResults = useMemo(
+    () => searchKeyword.length > 0 && filteredList.length === 0,
+    [filteredList.length, searchKeyword.length]
+  );
 
-		const typedWallets = normalizedList as Contracts.IReadWriteWallet[];
-		return typedWallets.filter((wallet) => {
-			const { alias } = getWalletAlias({
-				address: wallet.address(),
-				network: wallet.network(),
-				profile,
-			});
-			return matchKeyword(wallet.address()) || matchKeyword(alias);
-		});
-	}, [normalizedList, looksLikeRecipientList, matchKeyword, searchKeyword.length, getWalletAlias, profile]);
-
-	const isEmptyResults = useMemo(
-		() => searchKeyword.length > 0 && filteredList.length === 0,
-		[filteredList.length, searchKeyword.length],
-	);
-
-	return {
-		filteredList,
-		isEmptyResults,
-		setSearchKeyword,
-	};
+  return {
+    filteredList,
+    isEmptyResults,
+    setSearchKeyword,
+  };
 };

--- a/src/app/hooks/use-search-wallet.tsx
+++ b/src/app/hooks/use-search-wallet.tsx
@@ -5,76 +5,76 @@ import { useWalletAlias } from "./use-wallet-alias";
 import { RecipientProperties } from "@/domains/transaction/components/SearchRecipient/SearchRecipient.contracts";
 
 interface SearchWalletProperties {
-  profile: Contracts.IProfile;
-  wallets: (Contracts.IReadWriteWallet | RecipientProperties)[];
+	profile: Contracts.IProfile;
+	wallets: (Contracts.IReadWriteWallet | RecipientProperties)[];
 }
 
 export const useSearchWallet = ({ profile, wallets }: SearchWalletProperties) => {
-  const [searchKeyword, setSearchKeyword] = useState("");
-  const { getWalletAlias } = useWalletAlias();
+	const [searchKeyword, setSearchKeyword] = useState("");
+	const { getWalletAlias } = useWalletAlias();
 
-  const isRecipientList = useMemo(() => {
-    const first = wallets?.[0] as any;
-    return typeof first?.address === "string";
-  }, [wallets]);
+	const isRecipientList = useMemo(() => {
+		const first = wallets?.[0] as any;
+		return typeof first?.address === "string";
+	}, [wallets]);
 
-  const allProfileWallets = useMemo(() => profile.wallets().values(), [profile]);
+	const allProfileWallets = useMemo(() => profile.wallets().values(), [profile]);
 
-  const normalizedList = useMemo(() => {
-    if (!wallets || wallets.length === 0) {
-      return [];
-    }
+	const normalizedList = useMemo(() => {
+		if (!wallets || wallets.length === 0) {
+			return [];
+		}
 
-    if (isRecipientList) {
-      const recipients = wallets as RecipientProperties[];
-      return recipients.map((recipient) => {
-        const resolvedWallet = allProfileWallets.find((w) => w.address() === recipient.address);
-        const { alias } = getWalletAlias({
-          address: recipient.address,
-          network: resolvedWallet?.network(),
-          profile,
-        });
-        return { ...recipient, alias: alias ?? recipient.alias };
-      });
-    }
+		if (isRecipientList) {
+			const recipients = wallets as RecipientProperties[];
+			return recipients.map((recipient) => {
+				const resolvedWallet = allProfileWallets.find((w) => w.address() === recipient.address);
+				const { alias } = getWalletAlias({
+					address: recipient.address,
+					network: resolvedWallet?.network(),
+					profile,
+				});
+				return { ...recipient, alias: alias ?? recipient.alias };
+			});
+		}
 
-    return wallets;
-  }, [wallets, isRecipientList, allProfileWallets, getWalletAlias, profile]);
+		return wallets;
+	}, [wallets, isRecipientList, allProfileWallets, getWalletAlias, profile]);
 
-  const matchKeyword = useCallback(
-    (value?: string) => value?.toLowerCase().includes(searchKeyword.toLowerCase()),
-    [searchKeyword]
-  );
+	const matchKeyword = useCallback(
+		(value?: string) => value?.toLowerCase().includes(searchKeyword.toLowerCase()),
+		[searchKeyword],
+	);
 
-  const filteredList = useMemo(() => {
-    if (searchKeyword.length === 0) {
-      return normalizedList;
-    }
+	const filteredList = useMemo(() => {
+		if (searchKeyword.length === 0) {
+			return normalizedList;
+		}
 
-    if (isRecipientList) {
-      const recipients = normalizedList as RecipientProperties[];
-      return recipients.filter(({ address, alias }) => matchKeyword(address) || matchKeyword(alias));
-    }
+		if (isRecipientList) {
+			const recipients = normalizedList as RecipientProperties[];
+			return recipients.filter(({ address, alias }) => matchKeyword(address) || matchKeyword(alias));
+		}
 
-    const typedWallets = normalizedList as Contracts.IReadWriteWallet[];
-    return typedWallets.filter((wallet) => {
-      const { alias } = getWalletAlias({
-        address: wallet.address(),
-        network: wallet.network(),
-        profile,
-      });
-      return matchKeyword(wallet.address()) || matchKeyword(alias);
-    });
-  }, [normalizedList, isRecipientList, matchKeyword, searchKeyword.length, getWalletAlias, profile]);
+		const typedWallets = normalizedList as Contracts.IReadWriteWallet[];
+		return typedWallets.filter((wallet) => {
+			const { alias } = getWalletAlias({
+				address: wallet.address(),
+				network: wallet.network(),
+				profile,
+			});
+			return matchKeyword(wallet.address()) || matchKeyword(alias);
+		});
+	}, [normalizedList, isRecipientList, matchKeyword, searchKeyword.length, getWalletAlias, profile]);
 
-  const isEmptyResults = useMemo(
-    () => searchKeyword.length > 0 && filteredList.length === 0,
-    [filteredList.length, searchKeyword.length]
-  );
+	const isEmptyResults = useMemo(
+		() => searchKeyword.length > 0 && filteredList.length === 0,
+		[filteredList.length, searchKeyword.length],
+	);
 
-  return {
-    filteredList,
-    isEmptyResults,
-    setSearchKeyword,
-  };
+	return {
+		filteredList,
+		isEmptyResults,
+		setSearchKeyword,
+	};
 };

--- a/src/app/hooks/use-search-wallet.tsx
+++ b/src/app/hooks/use-search-wallet.tsx
@@ -13,6 +13,36 @@ export const useSearchWallet = ({ profile, wallets }: SearchWalletProperties) =>
 	const [searchKeyword, setSearchKeyword] = useState("");
 	const { getWalletAlias } = useWalletAlias();
 
+	const looksLikeRecipientList = useMemo(() => {
+		const first = wallets?.[0] as any;
+		return typeof first?.address === "string";
+	}, [wallets]);
+
+	const allWallets = useMemo(() => profile.wallets().values(), [profile]);
+
+	const normalizedList = useMemo(() => {
+		if (!wallets || wallets.length === 0) {
+			return [];
+		}
+
+		if (looksLikeRecipientList) {
+			const recipients = wallets as RecipientProperties[];
+
+			return recipients.map((recipient) => {
+				const resolvedWallet = allWallets.find((w) => w.address() === recipient.address);
+				const { alias } = getWalletAlias({
+					address: recipient.address,
+					network: resolvedWallet?.network(),
+					profile,
+				});
+
+				return { ...recipient, alias: alias ?? recipient.alias };
+			});
+		}
+
+		return wallets;
+	}, [wallets, looksLikeRecipientList, allWallets, getWalletAlias, profile]);
+
 	const matchKeyword = useCallback(
 		(value?: string) => value?.toLowerCase().includes(searchKeyword.toLowerCase()),
 		[searchKeyword],
@@ -20,25 +50,24 @@ export const useSearchWallet = ({ profile, wallets }: SearchWalletProperties) =>
 
 	const filteredList = useMemo(() => {
 		if (searchKeyword.length === 0) {
-			return wallets;
+			return normalizedList;
 		}
 
-		if (typeof wallets[0].address === "string") {
-			return (wallets as RecipientProperties[]).filter(
-				({ address, alias }) => matchKeyword(address) || matchKeyword(alias),
-			);
+		if (looksLikeRecipientList) {
+			const recipients = normalizedList as RecipientProperties[];
+			return recipients.filter(({ address, alias }) => matchKeyword(address) || matchKeyword(alias));
 		}
 
-		return (wallets as Contracts.IReadWriteWallet[]).filter((wallet) => {
+		const typedWallets = normalizedList as Contracts.IReadWriteWallet[];
+		return typedWallets.filter((wallet) => {
 			const { alias } = getWalletAlias({
 				address: wallet.address(),
 				network: wallet.network(),
 				profile,
 			});
-
 			return matchKeyword(wallet.address()) || matchKeyword(alias);
 		});
-	}, [getWalletAlias, wallets, matchKeyword, profile, searchKeyword.length]);
+	}, [normalizedList, looksLikeRecipientList, matchKeyword, searchKeyword.length, getWalletAlias, profile]);
 
 	const isEmptyResults = useMemo(
 		() => searchKeyword.length > 0 && filteredList.length === 0,

--- a/src/domains/transaction/components/SearchRecipient/SearchRecipient.test.tsx
+++ b/src/domains/transaction/components/SearchRecipient/SearchRecipient.test.tsx
@@ -270,6 +270,7 @@ describe("SearchRecipient", () => {
 				recipients={recipients}
 				selectedAddress="0xcd15953dD076e56Dc6a5bc46Da23308Ff3158EE6"
 				onAction={onAction}
+				profile={profile}
 			/>,
 			"md",
 		);

--- a/src/domains/transaction/components/SearchRecipient/__snapshots__/SearchRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/SearchRecipient/__snapshots__/SearchRecipient.test.tsx.snap
@@ -2708,7 +2708,9 @@ exports[`SearchRecipient > should render with no alias if the recipient address 
                       >
                         <div
                           class="text-sm leading-5 group-hover:text-theme-primary-900 dark:group-hover:text-theme-dark-50 dim:group-hover:text-theme-dim-50"
-                        />
+                        >
+                          Mainsail Wallet 1
+                        </div>
                         <div
                           class="flex min-w-0 items-center gap-1 leading-[17px]"
                         >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[recipients] ensure address names are consistent](https://app.clickup.com/t/86dxh5460)

## Summary

- The wallet alias is now consistent in the recipient search modal for transactions.
- Unit tests have been updated to increase coverage.

<img width="831" height="581" alt="image" src="https://github.com/user-attachments/assets/d538bf56-9865-447f-9d76-c58792056158" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
