### PR TITLE
chore: make mnemonic input hint open by default

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/ImportDetailStep.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportDetailStep.tsx
@@ -195,7 +195,7 @@ const ImportInputField = ({
 				<Alert
 					title={t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.MNEMONIC_TIP.TITLE")}
 					variant="info"
-					collapsible
+					collapsible={false}
 				>
 					<p>{t("WALLETS.PAGE_IMPORT_WALLET.IMPORT_DETAIL_STEP.MNEMONIC_TIP.GUIDELINES_TITLE")}</p>
 					<ol className="list-disc pl-5">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dxj1m54

<img width="612" height="933" alt="image" src="https://github.com/user-attachments/assets/bcfde370-68bd-4e82-90fb-1620de72885c" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
