### PR TITLE
refactor: remove link styling from vote address row

### DIFF
--- a/src/domains/vote/components/AddressTable/AddressRow/__snapshots__/AddressRow.test.tsx.snap
+++ b/src/domains/vote/components/AddressTable/AddressRow/__snapshots__/AddressRow.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`AddressRow > should emit action on select button 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -99,7 +99,7 @@ exports[`AddressRow > should emit action on select button 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -166,7 +166,7 @@ exports[`AddressRow > should emit action on select button 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Active
@@ -179,7 +179,7 @@ exports[`AddressRow > should emit action on select button 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -213,7 +213,7 @@ exports[`AddressRow > should render 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -297,7 +297,7 @@ exports[`AddressRow > should render 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -364,7 +364,7 @@ exports[`AddressRow > should render 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Active
@@ -377,7 +377,7 @@ exports[`AddressRow > should render 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -411,7 +411,7 @@ exports[`AddressRow > should render tooltip wallet when ledger and incompatible 
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -495,7 +495,7 @@ exports[`AddressRow > should render tooltip wallet when ledger and incompatible 
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -562,7 +562,7 @@ exports[`AddressRow > should render tooltip wallet when ledger and incompatible 
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Active
@@ -575,7 +575,7 @@ exports[`AddressRow > should render tooltip wallet when ledger and incompatible 
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 disabled=""
                 type="button"
@@ -610,7 +610,7 @@ exports[`AddressRow > should render when the maximum votes is greater than 1 1`]
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -705,7 +705,7 @@ exports[`AddressRow > should render when the maximum votes is greater than 1 1`]
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="font-semibold text-theme-secondary-400"
+              class="text-theme-secondary-400 font-semibold"
             >
               <span
                 class="text-theme-secondary-text"
@@ -724,7 +724,7 @@ exports[`AddressRow > should render when the maximum votes is greater than 1 1`]
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -758,7 +758,7 @@ exports[`AddressRow > should render when the wallet has exactly 4 votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -842,14 +842,14 @@ exports[`AddressRow > should render when the wallet has exactly 4 votes 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <div
                 class="inline-flex items-center justify-center rounded-full border-2 align-middle transition-all h-11 w-11 px-2 py-1 ring-6 border-theme-secondary-300 bg-theme-secondary-200 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 relative h-8! w-8! ring-theme-background duration-100"
               >
                 <span
-                  class="text-sm font-semibold text-theme-primary-700 dark:text-theme-secondary-500"
+                  class="text-theme-primary-700 dark:text-theme-secondary-500 text-sm font-semibold"
                 >
                   +4
                 </span>
@@ -907,7 +907,7 @@ exports[`AddressRow > should render when the wallet has exactly 4 votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="font-semibold text-theme-secondary-400"
+              class="text-theme-secondary-400 font-semibold"
             >
               <span
                 class="text-theme-secondary-text"
@@ -926,7 +926,7 @@ exports[`AddressRow > should render when the wallet has exactly 4 votes 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -960,7 +960,7 @@ exports[`AddressRow > should render when the wallet has many votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1044,14 +1044,14 @@ exports[`AddressRow > should render when the wallet has many votes 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <div
                 class="inline-flex items-center justify-center rounded-full border-2 align-middle transition-all h-11 w-11 px-2 py-1 ring-6 border-theme-secondary-300 bg-theme-secondary-200 dark:border-theme-secondary-600 dark:bg-theme-secondary-800 relative h-8! w-8! ring-theme-background duration-100"
               >
                 <span
-                  class="text-sm font-semibold text-theme-primary-700 dark:text-theme-secondary-500"
+                  class="text-theme-primary-700 dark:text-theme-secondary-500 text-sm font-semibold"
                 >
                   +5
                 </span>
@@ -1109,7 +1109,7 @@ exports[`AddressRow > should render when the wallet has many votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="font-semibold text-theme-secondary-400"
+              class="text-theme-secondary-400 font-semibold"
             >
               <span
                 class="text-theme-secondary-text"
@@ -1128,7 +1128,7 @@ exports[`AddressRow > should render when the wallet has many votes 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -1162,7 +1162,7 @@ exports[`AddressRow > should render when wallet hasn't voted 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1246,7 +1246,7 @@ exports[`AddressRow > should render when wallet hasn't voted 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -1313,7 +1313,7 @@ exports[`AddressRow > should render when wallet hasn't voted 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Active
@@ -1326,7 +1326,7 @@ exports[`AddressRow > should render when wallet hasn't voted 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -1351,7 +1351,7 @@ exports[`AddressRow > should render when wallet hasn't voted 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1448,7 +1448,7 @@ exports[`AddressRow > should render when wallet hasn't voted 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-1"
                 disabled=""
                 type="button"
@@ -1483,7 +1483,7 @@ exports[`AddressRow > should render when wallet not found for votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1567,7 +1567,7 @@ exports[`AddressRow > should render when wallet not found for votes 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -1634,7 +1634,7 @@ exports[`AddressRow > should render when wallet not found for votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Active
@@ -1647,7 +1647,7 @@ exports[`AddressRow > should render when wallet not found for votes 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -1672,7 +1672,7 @@ exports[`AddressRow > should render when wallet not found for votes 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1769,7 +1769,7 @@ exports[`AddressRow > should render when wallet not found for votes 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed disabled:text-theme-secondary-400 dark:disabled:text-theme-secondary-700 text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-1"
                 disabled=""
                 type="button"
@@ -1804,7 +1804,7 @@ exports[`AddressRow > should render with active validator 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1888,7 +1888,7 @@ exports[`AddressRow > should render with active validator 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -1955,7 +1955,7 @@ exports[`AddressRow > should render with active validator 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Active
@@ -1968,7 +1968,7 @@ exports[`AddressRow > should render with active validator 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -2002,7 +2002,7 @@ exports[`AddressRow > should render with resigned validator 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -2086,7 +2086,7 @@ exports[`AddressRow > should render with resigned validator 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -2155,7 +2155,7 @@ exports[`AddressRow > should render with resigned validator 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Resigned
@@ -2168,7 +2168,7 @@ exports[`AddressRow > should render with resigned validator 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >
@@ -2202,7 +2202,7 @@ exports[`AddressRow > should render with standby validator 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
           >
             <div
-              class="flex-1 w-40"
+              class="w-40 flex-1"
             >
               <div
                 class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -2286,7 +2286,7 @@ exports[`AddressRow > should render with standby validator 1`] = `
             class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
           >
             <div
-              class="flex overflow-hidden items-center space-x-3"
+              class="flex items-center space-x-3 overflow-hidden"
               data-testid="AddressRow__wallet-vote"
             >
               <a
@@ -2353,7 +2353,7 @@ exports[`AddressRow > should render with standby validator 1`] = `
             class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
           >
             <div
-              class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+              class="bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
               data-testid="AddressRow__wallet-status"
             >
               Standby
@@ -2366,7 +2366,7 @@ exports[`AddressRow > should render with standby validator 1`] = `
           >
             <div>
               <button
-                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                 data-testid="AddressRow__select-0"
                 type="button"
               >

--- a/src/domains/vote/components/AddressTable/AddressRow/__snapshots__/AddressRowMobile.test.tsx.snap
+++ b/src/domains/vote/components/AddressTable/AddressRow/__snapshots__/AddressRowMobile.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`AddressRowMobile > should emit action on select button 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -153,7 +153,7 @@ exports[`AddressRowMobile > should emit action on select button 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -198,7 +198,7 @@ exports[`AddressRowMobile > should render in 375 screen width 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -324,7 +324,7 @@ exports[`AddressRowMobile > should render in 375 screen width 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -368,7 +368,7 @@ exports[`AddressRowMobile > should render in 420 screen width 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -494,7 +494,7 @@ exports[`AddressRowMobile > should render in 420 screen width 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -538,7 +538,7 @@ exports[`AddressRowMobile > should render when the maximum votes is greater than
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -665,7 +665,7 @@ exports[`AddressRowMobile > should render when the maximum votes is greater than
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -708,7 +708,7 @@ exports[`AddressRowMobile > should render when the wallet has many votes 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -835,7 +835,7 @@ exports[`AddressRowMobile > should render when the wallet has many votes 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -878,7 +878,7 @@ exports[`AddressRowMobile > should render when wallet hasn't voted 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -1004,7 +1004,7 @@ exports[`AddressRowMobile > should render when wallet hasn't voted 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -1144,7 +1144,7 @@ exports[`AddressRowMobile > should render when wallet not found for votes 1`] = 
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -1270,7 +1270,7 @@ exports[`AddressRowMobile > should render when wallet not found for votes 1`] = 
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -1518,7 +1518,7 @@ exports[`AddressRowMobile > should render with active validator 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Active
@@ -1644,7 +1644,7 @@ exports[`AddressRowMobile > should render with active validator 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-success-100 text-theme-success-700 dark:border-theme-success-800 dark:text-theme-success-500 inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Active
@@ -1687,7 +1687,7 @@ exports[`AddressRowMobile > should render with resigned validator 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Resigned
@@ -1813,7 +1813,7 @@ exports[`AddressRowMobile > should render with resigned validator 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Resigned
@@ -1856,7 +1856,7 @@ exports[`AddressRowMobile > should render with standby validator 1`] = `
                 class="flex items-center gap-3"
               >
                 <div
-                  class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text min-w-[58px] py-[3px] dark:border dark:bg-transparent sm:hidden"
+                  class="bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent sm:hidden"
                   data-testid="AddressRowMobile__wallet-status-0"
                 >
                   Standby
@@ -1982,7 +1982,7 @@ exports[`AddressRowMobile > should render with standby validator 1`] = `
                 </div>
                 <div>
                   <div
-                    class="inline-block px-1 text-xs font-semibold text-center rounded bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text min-w-[58px] py-[3px] dark:border dark:bg-transparent"
+                    class="bg-theme-warning-100 text-theme-warning-900 dark:border-theme-danger-info-border dark:text-theme-danger-info-text inline-block min-w-[58px] rounded px-1 py-[3px] text-center text-xs font-semibold dark:border dark:bg-transparent"
                     data-testid="AddressRow__wallet-status"
                   >
                     Standby

--- a/src/domains/vote/components/AddressTable/__snapshots__/AddressTable.test.tsx.snap
+++ b/src/domains/vote/components/AddressTable/__snapshots__/AddressTable.test.tsx.snap
@@ -212,7 +212,7 @@ exports[`AddressTable > should render 1`] = `
                 class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
               >
                 <div
-                  class="flex-1 w-40"
+                  class="w-40 flex-1"
                 >
                   <div
                     class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -296,7 +296,7 @@ exports[`AddressTable > should render 1`] = `
                 class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
               >
                 <div
-                  class="flex overflow-hidden items-center space-x-3"
+                  class="flex items-center space-x-3 overflow-hidden"
                   data-testid="AddressRow__wallet-vote"
                 >
                   <a
@@ -352,7 +352,7 @@ exports[`AddressTable > should render 1`] = `
                 class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
               >
                 <div
-                  class="font-semibold text-theme-secondary-400"
+                  class="text-theme-secondary-400 font-semibold"
                 >
                   <span
                     class="text-theme-secondary-text"
@@ -371,7 +371,7 @@ exports[`AddressTable > should render 1`] = `
               >
                 <div>
                   <button
-                    class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                    class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                     data-testid="AddressRow__select-0"
                     type="button"
                   >
@@ -604,7 +604,7 @@ exports[`AddressTable > should render when the maximum votes is greater than 1 1
                 class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
               >
                 <div
-                  class="flex-1 w-40"
+                  class="w-40 flex-1"
                 >
                   <div
                     class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -688,7 +688,7 @@ exports[`AddressTable > should render when the maximum votes is greater than 1 1
                 class="px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm font-semibold space-x-3 flex justify-end"
               >
                 <div
-                  class="flex overflow-hidden items-center space-x-3"
+                  class="flex items-center space-x-3 overflow-hidden"
                   data-testid="AddressRow__wallet-vote"
                 >
                   <a
@@ -744,7 +744,7 @@ exports[`AddressTable > should render when the maximum votes is greater than 1 1
                 class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
               >
                 <div
-                  class="font-semibold text-theme-secondary-400"
+                  class="text-theme-secondary-400 font-semibold"
                 >
                   <span
                     class="text-theme-secondary-text"
@@ -763,7 +763,7 @@ exports[`AddressTable > should render when the maximum votes is greater than 1 1
               >
                 <div>
                   <button
-                    class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                    class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                     data-testid="AddressRow__select-0"
                     type="button"
                   >
@@ -1229,7 +1229,7 @@ exports[`AddressTable > should render with voting validators and handle exceptio
                 class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 pl-3 ml-3 rounded-l dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 space-x-3"
               >
                 <div
-                  class="flex-1 w-40"
+                  class="w-40 flex-1"
                 >
                   <div
                     class="flex overflow-hidden whitespace-nowrap items-center space-x-2 w-full"
@@ -1324,7 +1324,7 @@ exports[`AddressTable > should render with voting validators and handle exceptio
                 class="flex px-3 items-center my-1 transition-colors duration-100 min-h-11 dark:group-hover:bg-theme-dark-950 group-hover:bg-theme-primary-100 dim:group-hover:bg-theme-dim-950 text-sm justify-center"
               >
                 <div
-                  class="font-semibold text-theme-secondary-400"
+                  class="text-theme-secondary-400 font-semibold"
                 >
                   <span
                     class="text-theme-secondary-text"
@@ -1343,7 +1343,7 @@ exports[`AddressTable > should render with voting validators and handle exceptio
               >
                 <div>
                   <button
-                    class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none -mr-3 text-sm text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 hover:underline"
+                    class="p-3 relative items-center inline-flex justify-center font-semibold text-center transition-colors-shadow duration-100 ease-linear outline-hidden rounded cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-theme-primary-400 disabled:cursor-not-allowed border-none text-theme-primary-600 dark:hover:text-theme-primary-500 hover:text-theme-primary-700 dim:text-theme-dim-navy-600 dim-hover:text-theme-dim-navy-700 dim:disabled:text-theme-dim-500 dim-hover:disabled:text-theme-dim-500 -mr-3 text-sm hover:underline"
                     data-testid="AddressRow__select-0"
                     type="button"
                   >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[votes] remove link styling for address names](https://app.clickup.com/t/86dxrff6u)

## Summary

- Link styling has been removed from the address row in the vote page.
- Update snapshots have been updated.

<img width="1511" height="644" alt="image" src="https://github.com/user-attachments/assets/0798eb2b-9839-43ac-9fa9-9f6891373220" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
