### PR TITLE
refactor: remove outside click handling logic

### DIFF
--- a/src/app/components/SidePanel/SidePanel.tsx
+++ b/src/app/components/SidePanel/SidePanel.tsx
@@ -2,7 +2,6 @@ import {
 	FloatingFocusManager,
 	FloatingOverlay,
 	FloatingPortal,
-	OpenChangeReason,
 	useClick,
 	useDismiss,
 	useFloating,
@@ -89,7 +88,7 @@ export const SidePanel = ({
 	const shouldPreventClosing = useCallback(() => preventClosing, [preventClosing]);
 
 	const toggleOpen = useCallback(
-		(open: boolean = false, _?: Event) => {
+		(open: boolean = false) => {
 			if (open === false && shakeWhenClosing && shouldPreventClosing()) {
 				setShake(true);
 				setTimeout(() => setShake(false), 900);


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->


# [[general] remove current outside click handling](https://app.clickup.com/t/86dxtj0b9)

## Summary

- The logic for the outside click has been removed from the side panels, except for the multiaddress selection

<img width="670" height="858" alt="image" src="https://github.com/user-attachments/assets/cdb0b4b3-b9d6-42ff-9d31-0b1829ce523f" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
