### PR TITLE
fix: update time ago accordingly

### DIFF
--- a/src/app/components/TimeAgo/TimeAgo.tsx
+++ b/src/app/components/TimeAgo/TimeAgo.tsx
@@ -27,16 +27,20 @@ const getNextUpdateDelay = (isoDate: string): number | null => {
 	const hour = 60 * minute;
 	const day = 24 * hour;
 
+	// If less than 1 minute old: wait until exactly 1 minute has passed
+	// e.g., if 2 seconds old, wait 58 more seconds to show "1 minute ago"
 	if (elapsed < minute) {
 		return minute - elapsed;
 	}
+	// If less than 1 hour old: update at the next minute boundary
 	if (elapsed < hour) {
 		return minute - (elapsed % minute);
 	}
+	// If less than 1 day old: update at the next hour boundary
 	if (elapsed < day) {
 		return hour - (elapsed % hour);
 	}
-
+	// After 1 day: stop updating (shows "1 day ago", "2 days ago", etc.)
 	return null;
 };
 

--- a/src/app/components/TimeAgo/TimeAgo.tsx
+++ b/src/app/components/TimeAgo/TimeAgo.tsx
@@ -1,7 +1,6 @@
-import { DateTime } from "@/app/lib/intl";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-
+import { DateTime } from "@/app/lib/intl";
 import { TIME_PERIODS } from "./TimeAgo.constants";
 import { DateDifferenceReturnValue } from "./TimeAgo.contracts";
 
@@ -11,7 +10,6 @@ const dateDifference = (date: string): DateDifferenceReturnValue => {
 
 	for (const period of TIME_PERIODS) {
 		const count: number = now[`diffIn${period}`](target);
-
 		if (count > 0) {
 			return { count, key: period.toUpperCase() };
 		}
@@ -20,10 +18,54 @@ const dateDifference = (date: string): DateDifferenceReturnValue => {
 	return { key: "FEW_SECONDS" };
 };
 
+const getNextUpdateDelay = (isoDate: string): number | null => {
+	const start = new Date(isoDate).getTime();
+	const now = Date.now();
+	const elapsed = now - start;
+
+	const minute = 60_000;
+	const hour = 60 * minute;
+	const day = 24 * hour;
+
+	if (elapsed < minute) {
+		return minute - elapsed;
+	}
+	if (elapsed < hour) {
+		return minute - (elapsed % minute);
+	}
+	if (elapsed < day) {
+		return hour - (elapsed % hour);
+	}
+
+	return null;
+};
+
 export const TimeAgo = ({ date }: { date: string }) => {
 	const { t } = useTranslation();
+	const [, forceTick] = useState(0);
+
+	useEffect(() => {
+		const schedule = () => {
+			const delay = getNextUpdateDelay(date);
+
+			if (delay === null) {
+				return;
+			}
+
+			const timerId = window.setTimeout(
+				() => {
+					forceTick((x) => x + 1);
+					schedule();
+				},
+				Math.max(1_000, delay),
+			);
+
+			return () => window.clearTimeout(timerId);
+		};
+
+		return schedule();
+	}, [date]);
 
 	const { count, key } = dateDifference(date);
-
 	return <span data-testid="TimeAgo">{t(`COMMON.DATETIME.${key}_AGO`, { count })}</span>;
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[pending] make sure age updates accordingly for pending transactions](https://app.clickup.com/t/86dxt78k5)

## Summary

- `TimeAgo` component was memoized and wasn't being updated accordingly unless any new transaction joined the array. This caused confusion between the rows, not updating their "Time Ago" column.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
