### PR TITLE
fix: reset mnemonic state on exit in hd wallet import

### DIFF
--- a/src/domains/portfolio/components/ImportWallet/HDWallet/SelectAddressStep.tsx
+++ b/src/domains/portfolio/components/ImportWallet/HDWallet/SelectAddressStep.tsx
@@ -317,6 +317,7 @@ export const SelectAddressStep = ({
 
 		return () => {
 			unregister("selectedAddresses");
+			unregister("mnemonic");
 		};
 	}, [register, unregister]);
 

--- a/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
+++ b/src/domains/portfolio/components/ImportWallet/ImportAddressSidePanel.tsx
@@ -132,6 +132,7 @@ export const ImportAddressesSidePanel = ({
 		}
 
 		if (!open) {
+			form.reset();
 			setActiveTab(ImportAddressStep.MethodStep);
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/86dxv4gmb 
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
