### PR TITLE
fix: make token ordering deterministic

### DIFF
--- a/src/app/lib/mainsail/client.service.test.ts
+++ b/src/app/lib/mainsail/client.service.test.ts
@@ -791,7 +791,7 @@ describe("ClientService", () => {
 
 			const walletToken1 = result.items()[0];
 			expect(walletToken1.address()).toBe(walletAddress1);
-			expect(walletToken1.balance()).toBe(1);
+			expect(walletToken1.balance().toHuman()).toBe(1);
 			expect(walletToken1.token().address()).toBe(tokenAddress);
 			expect(walletToken1.token().symbol()).toBe("TEST");
 			expect(walletToken1.token().name()).toBe("Test Token");
@@ -799,7 +799,7 @@ describe("ClientService", () => {
 
 			const walletToken2 = result.items()[1];
 			expect(walletToken2.address()).toBe(walletAddress2);
-			expect(walletToken2.balance()).toBe(2);
+			expect(walletToken2.balance().toHuman()).toBe(2);
 		});
 
 		it("should handle multiple tokens across multiple wallets", async () => {

--- a/src/app/lib/profiles/token.service.ts
+++ b/src/app/lib/profiles/token.service.ts
@@ -42,7 +42,7 @@ export class TokenService {
 			.values()
 			.filter((token) => {
 				if (hideDustTokens === true) {
-					return token.balance() > this.#dustBalanceThreshold;
+					return token.balance().isGreaterThan(BigNumber.make(this.#dustBalanceThreshold);
 				}
 
 				return true;
@@ -140,7 +140,6 @@ export class TokenService {
 			}
 
 			aggregated.set(token.token().address(), token);
-			continue;
 		}
 		return [...aggregated.values()];
 	}
@@ -208,12 +207,12 @@ export class TokenService {
 	 *
 	 * @returns {number}
 	 */
-	selectedTotalBalance(): number {
-		let total = 0;
+	selectedTotalBalance(): BigNumber{
+		let total = BigNumber.make(0);
 
 		for (const wallet of this.#profile.wallets().selected().values()) {
 			for (const token of wallet.tokens().values()) {
-				total = total + token.balance();
+				total = total.plus(token.balance());
 			}
 		}
 

--- a/src/app/lib/profiles/token.service.ts
+++ b/src/app/lib/profiles/token.service.ts
@@ -42,7 +42,7 @@ export class TokenService {
 			.values()
 			.filter((token) => {
 				if (hideDustTokens === true) {
-					return token.balance().isGreaterThan(BigNumber.make(this.#dustBalanceThreshold);
+					return token.balance().isGreaterThan(BigNumber.make(this.#dustBalanceThreshold));
 				}
 
 				return true;
@@ -207,7 +207,7 @@ export class TokenService {
 	 *
 	 * @returns {number}
 	 */
-	selectedTotalBalance(): BigNumber{
+	selectedTotalBalance(): BigNumber {
 		let total = BigNumber.make(0);
 
 		for (const wallet of this.#profile.wallets().selected().values()) {

--- a/src/app/lib/profiles/wallet-token.dto.ts
+++ b/src/app/lib/profiles/wallet-token.dto.ts
@@ -11,8 +11,8 @@ export class WalletTokenDTO {
 		return this.#data.address;
 	}
 
-	balance(): number {
-		return +this.#data.balance;
+	balance(): string {
+		return this.#data.balance;
 	}
 
 	tokenAddress(): string {

--- a/src/app/lib/profiles/wallet-token.test.ts
+++ b/src/app/lib/profiles/wallet-token.test.ts
@@ -34,7 +34,7 @@ describe("WalletToken", () => {
 	});
 
 	it("#balance", () => {
-		expect(walletToken.balance()).toBe(100000000);
+		expect(walletToken.balance().toHuman()).toBe(100000000);
 	});
 
 	it("#token", () => {

--- a/src/app/lib/profiles/wallet-token.ts
+++ b/src/app/lib/profiles/wallet-token.ts
@@ -30,11 +30,11 @@ export class WalletToken {
 		return this.#walletToken.address();
 	}
 
-	balance(): number {
-		return +BigNumber.make(this.#walletToken.balance(), this.token().decimals()).toHuman();
+	balance(): BigNumber {
+		return BigNumber.make(this.#walletToken.balance(), this.token().decimals());
 	}
 
-	balanceRaw(): number {
+	balanceRaw(): string {
 		return this.#walletToken.balance();
 	}
 

--- a/src/domains/portfolio/components/Tokens/TokensSummary.test.tsx
+++ b/src/domains/portfolio/components/Tokens/TokensSummary.test.tsx
@@ -37,7 +37,6 @@ describe("TokensSummary", () => {
 		expect(screen.getByTestId("TokensSummary--Count")).toBeInTheDocument();
 	});
 
-
 	it("should sort tokens by balance", async () => {
 		vi.spyOn(profile.tokens(), "selectedCount").mockReturnValue(4);
 
@@ -54,9 +53,9 @@ describe("TokensSummary", () => {
 			}),
 			walletToken: new WalletTokenDTO({
 				address: wallet.address(),
-				balance: '100',
+				balance: "100",
 				tokenAddress: "0xabc",
-			})
+			}),
 		});
 
 		repo.create({
@@ -70,9 +69,9 @@ describe("TokensSummary", () => {
 			}),
 			walletToken: new WalletTokenDTO({
 				address: wallet.address(),
-				balance: '200',
+				balance: "200",
 				tokenAddress: "0xabd",
-			})
+			}),
 		});
 
 		repo.create({
@@ -86,9 +85,9 @@ describe("TokensSummary", () => {
 			}),
 			walletToken: new WalletTokenDTO({
 				address: wallet.address(),
-				balance: '300',
+				balance: "300",
 				tokenAddress: "0xabe",
-			})
+			}),
 		});
 
 		repo.create({
@@ -102,9 +101,9 @@ describe("TokensSummary", () => {
 			}),
 			walletToken: new WalletTokenDTO({
 				address: wallet.address(),
-				balance: '300',
+				balance: "300",
 				tokenAddress: "0xabf",
-			})
+			}),
 		});
 
 		vi.spyOn(wallet, "tokens").mockReturnValue(repo);
@@ -112,8 +111,8 @@ describe("TokensSummary", () => {
 		render(<TokensSummary wallet={wallet} />);
 
 		expect(screen.getByTestId("TokensSummary")).toBeInTheDocument();
-		expect(screen.getAllByTestId("TokeNameInitials")[0]).toHaveTextContent("D")
-		expect(screen.getAllByTestId("TokeNameInitials")[1]).toHaveTextContent("H")
-		expect(screen.getAllByTestId("TokeNameInitials")[2]).toHaveTextContent("P")
+		expect(screen.getAllByTestId("TokeNameInitials")[0]).toHaveTextContent("D");
+		expect(screen.getAllByTestId("TokeNameInitials")[1]).toHaveTextContent("H");
+		expect(screen.getAllByTestId("TokeNameInitials")[2]).toHaveTextContent("P");
 	});
 });

--- a/src/domains/portfolio/components/Tokens/TokensSummary.test.tsx
+++ b/src/domains/portfolio/components/Tokens/TokensSummary.test.tsx
@@ -4,6 +4,9 @@ import React from "react";
 import { env, render, screen, getMainsailProfileId } from "@/utils/testing-library";
 import { expect } from "vitest";
 import { TokensSummary } from "./TokensSummary";
+import { WalletTokenRepository } from "@/app/lib/profiles/wallet-token.repository";
+import { WalletTokenDTO } from "@/app/lib/profiles/wallet-token.dto";
+import { TokenDTO } from "@/app/lib/profiles/token.dto";
 
 const fixtureProfileId = getMainsailProfileId();
 
@@ -32,5 +35,85 @@ describe("TokensSummary", () => {
 
 		expect(screen.getByTestId("TokensSummary")).toBeInTheDocument();
 		expect(screen.getByTestId("TokensSummary--Count")).toBeInTheDocument();
+	});
+
+
+	it("should sort tokens by balance", async () => {
+		vi.spyOn(profile.tokens(), "selectedCount").mockReturnValue(4);
+
+		const repo = new WalletTokenRepository(profile.activeNetwork(), profile);
+
+		repo.create({
+			token: new TokenDTO({
+				address: "0xabc",
+				decimals: 18,
+				deploymentHash: "0xabc",
+				name: "ABC",
+				symbol: "ABC",
+				totalSupply: "10000",
+			}),
+			walletToken: new WalletTokenDTO({
+				address: wallet.address(),
+				balance: '100',
+				tokenAddress: "0xabc",
+			})
+		});
+
+		repo.create({
+			token: new TokenDTO({
+				address: "0xabd",
+				decimals: 18,
+				deploymentHash: "0xabd",
+				name: "DEF",
+				symbol: "DEF",
+				totalSupply: "20000",
+			}),
+			walletToken: new WalletTokenDTO({
+				address: wallet.address(),
+				balance: '200',
+				tokenAddress: "0xabd",
+			})
+		});
+
+		repo.create({
+			token: new TokenDTO({
+				address: "0xabe",
+				decimals: 18,
+				deploymentHash: "0xabe",
+				name: "PET",
+				symbol: "PET",
+				totalSupply: "30000",
+			}),
+			walletToken: new WalletTokenDTO({
+				address: wallet.address(),
+				balance: '300',
+				tokenAddress: "0xabe",
+			})
+		});
+
+		repo.create({
+			token: new TokenDTO({
+				address: "0xabf",
+				decimals: 18,
+				deploymentHash: "0xabf",
+				name: "HOF",
+				symbol: "HOF",
+				totalSupply: "40000",
+			}),
+			walletToken: new WalletTokenDTO({
+				address: wallet.address(),
+				balance: '300',
+				tokenAddress: "0xabf",
+			})
+		});
+
+		vi.spyOn(wallet, "tokens").mockReturnValue(repo);
+
+		render(<TokensSummary wallet={wallet} />);
+
+		expect(screen.getByTestId("TokensSummary")).toBeInTheDocument();
+		expect(screen.getAllByTestId("TokeNameInitials")[0]).toHaveTextContent("D")
+		expect(screen.getAllByTestId("TokeNameInitials")[1]).toHaveTextContent("H")
+		expect(screen.getAllByTestId("TokeNameInitials")[2]).toHaveTextContent("P")
 	});
 });

--- a/src/domains/portfolio/components/Tokens/TokensSummary.tsx
+++ b/src/domains/portfolio/components/Tokens/TokensSummary.tsx
@@ -10,7 +10,7 @@ export const TokenNameInitials = ({ tokenName, className }: { tokenName: string;
 			className,
 		)}
 	>
-		<div>{tokenName.charAt(0).toUpperCase()}</div>
+		<div data-testid="TokeNameInitials">{tokenName.charAt(0).toUpperCase()}</div>
 	</div>
 );
 

--- a/src/domains/portfolio/components/Tokens/TokensSummary.tsx
+++ b/src/domains/portfolio/components/Tokens/TokensSummary.tsx
@@ -21,7 +21,9 @@ export const TokensSummary = ({ wallet }: { wallet: Contracts.IReadWriteWallet }
 				{wallet
 					.tokens()
 					.values()
+					.toSorted((a, b) => b.balance().comparedTo(a.balance()))
 					.slice(0, VISIBLE_TOKEN_COUNT)
+					.toSorted((a, b) => a.token().name().localeCompare(b.token().name()))
 					.map((walletToken, index) => (
 						<div
 							key={index}

--- a/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.test.tsx
+++ b/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.test.tsx
@@ -3,12 +3,13 @@ import userEvent from "@testing-library/user-event";
 import { DeleteTokenConfirmationModal } from "./DeleteTokenConfirmationModal";
 import { buildTranslations } from "@/app/i18n/helpers";
 import { render, screen, waitFor } from "@/utils/testing-library";
+import { BigNumber } from "@/app/lib/helpers";
 
 const translations = buildTranslations();
 
 const createMockWalletToken = (overrides = {}) => ({
 	address: () => "0xA5cc0BfEB09742C5e4C610f2EBaaB82Eb142Ca10",
-	balance: () => 100,
+	balance: () => BigNumber.make(100),
 	contractExplorerLink: () => "https://explorer.com/token/0xToken1",
 	token: () => ({
 		address: () => "0xToken1",

--- a/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
+++ b/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
@@ -80,7 +80,7 @@ export const DeleteTokenConfirmationModal = ({ walletToken, onClose, onDelete }:
 
 							<Amount
 								ticker={walletToken.token().symbol()}
-								value={walletToken.balance()}
+								value={walletToken.balance().toNumber()}
 								className="font-semibold"
 							/>
 						</div>

--- a/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
+++ b/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
@@ -80,7 +80,7 @@ export const DeleteTokenConfirmationModal = ({ walletToken, onClose, onDelete }:
 
 							<Amount
 								ticker={walletToken.token().symbol()}
-								value={walletToken.balance().toNumber()}
+								value={walletToken.balance().toHuman()}
 								className="font-semibold"
 							/>
 						</div>

--- a/src/domains/tokens/components/SelectToken/__snapshots__/SelectToken.test.tsx.snap
+++ b/src/domains/tokens/components/SelectToken/__snapshots__/SelectToken.test.tsx.snap
@@ -302,7 +302,9 @@ exports[`SelectToken > should render with default value  1`] = `
                   <div
                     class="bg-theme-primary-600 dark:bg-theme-dark-navy-600 dim:bg-theme-dim-navy-600 flex items-center justify-center overflow-hidden rounded-full font-semibold text-white text-md h-8 w-8 p-3 leading-8"
                   >
-                    <div>
+                    <div
+                      data-testid="TokeNameInitials"
+                    >
                       T
                     </div>
                   </div>

--- a/src/domains/tokens/components/TokenDetailsSidepanel/TokensDetailSidepanel.tsx
+++ b/src/domains/tokens/components/TokenDetailsSidepanel/TokensDetailSidepanel.tsx
@@ -117,7 +117,7 @@ export const TokenDetailSidepanel = ({
 								<div className="flex w-full flex-1 flex-row items-center justify-end gap-2 pr-2 sm:w-full sm:justify-start">
 									<Amount
 										ticker={walletToken.token().symbol()}
-										value={walletToken.balance().toNumber()}
+										value={walletToken.balance().toHuman()}
 										className="text-sm font-semibold break-all whitespace-normal md:text-base"
 										showTicker={false}
 									/>

--- a/src/domains/tokens/components/TokenDetailsSidepanel/TokensDetailSidepanel.tsx
+++ b/src/domains/tokens/components/TokenDetailsSidepanel/TokensDetailSidepanel.tsx
@@ -117,7 +117,7 @@ export const TokenDetailSidepanel = ({
 								<div className="flex w-full flex-1 flex-row items-center justify-end gap-2 pr-2 sm:w-full sm:justify-start">
 									<Amount
 										ticker={walletToken.token().symbol()}
-										value={walletToken.balance()}
+										value={walletToken.balance().toNumber()}
 										className="text-sm font-semibold break-all whitespace-normal md:text-base"
 										showTicker={false}
 									/>

--- a/src/domains/tokens/components/TokenHeader/TokenHeader.tsx
+++ b/src/domains/tokens/components/TokenHeader/TokenHeader.tsx
@@ -42,7 +42,7 @@ export const TokenHeader = ({
 		wallet
 			.tokens()
 			.values()
-			.some((walletToken) => walletToken.balance() > 0),
+			.some((walletToken) => walletToken.balance().isGreaterThan(0)),
 	);
 
 	return (

--- a/src/domains/tokens/components/TokenRow/TokenRow.test.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRow.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 
 import { TokenRow } from "./TokenRow";
 import { env, getDefaultProfileId, render, screen } from "@/utils/testing-library";
-import { BigNumber } from "../../../../app/lib/helpers";
+import { BigNumber } from "@/app/lib/helpers";
 
 let profile: Contracts.IProfile;
 

--- a/src/domains/tokens/components/TokenRow/TokenRow.test.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRow.test.tsx
@@ -3,12 +3,13 @@ import userEvent from "@testing-library/user-event";
 
 import { TokenRow } from "./TokenRow";
 import { env, getDefaultProfileId, render, screen } from "@/utils/testing-library";
+import { BigNumber } from "../../../../app/lib/helpers";
 
 let profile: Contracts.IProfile;
 
 const createMockWalletToken = (overrides = {}) => ({
 	address: () => "0xA5cc0BfEB09742C5e4C610f2EBaaB82Eb142Ca10",
-	balance: () => 100,
+	balance: () => BigNumber.make(100),
 	contractExplorerLink: () => "https://explorer.com/token/0xToken1",
 	token: () => ({
 		address: () => "0xToken1",

--- a/src/domains/tokens/components/TokenRow/TokenRow.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRow.tsx
@@ -121,7 +121,7 @@ export const TokenRow = memo(
 					<Amount
 						ticker={walletToken.token().symbol()}
 						showTicker={false}
-						value={walletToken.balance().toNumber()}
+						value={walletToken.balance().toHuman()}
 						className="text-theme-secondary-700 dark:text-theme-dark-200 dim:text-theme-dim-200 text-sm leading-[17px] font-semibold"
 						showCompactFormat
 					/>

--- a/src/domains/tokens/components/TokenRow/TokenRow.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRow.tsx
@@ -121,7 +121,7 @@ export const TokenRow = memo(
 					<Amount
 						ticker={walletToken.token().symbol()}
 						showTicker={false}
-						value={walletToken.balance()}
+						value={walletToken.balance().toNumber()}
 						className="text-theme-secondary-700 dark:text-theme-dark-200 dim:text-theme-dim-200 text-sm leading-[17px] font-semibold"
 						showCompactFormat
 					/>

--- a/src/domains/tokens/components/TokenRow/TokenRowMobile.test.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRowMobile.test.tsx
@@ -6,12 +6,13 @@ import userEvent from "@testing-library/user-event";
 import { TokenRowMobile } from "./TokenRowMobile";
 import { translations as commonTranslations } from "@/app/i18n/common/i18n";
 import { env, getDefaultProfileId, screen, render } from "@/utils/testing-library";
+import { BigNumber } from "@/app/lib/helpers";
 
 let profile: Contracts.IProfile;
 
 const createMockWalletToken = (overrides = {}) => ({
 	address: () => "0xA5cc0BfEB09742C5e4C610f2EBaaB82Eb142Ca10",
-	balance: () => 100,
+	balance: () => BigNumber.make(100),
 	contractExplorerLink: () => "https://explorer.com/token1",
 	token: () => ({
 		address: () => "0xToken1",

--- a/src/domains/tokens/components/TokenRow/TokenRowMobile.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRowMobile.tsx
@@ -135,7 +135,7 @@ export const TokenRowMobile = memo(
 								<Amount
 									ticker={walletToken.token().symbol()}
 									showTicker={false}
-									value={walletToken.balance()}
+									value={walletToken.balance().toNumber()}
 									className="dark:text-theme-dark-50 dim:text-theme-dim-50 text-sm leading-[17px] font-semibold"
 									showCompactFormat
 								/>

--- a/src/domains/tokens/components/TokenRow/TokenRowMobile.tsx
+++ b/src/domains/tokens/components/TokenRow/TokenRowMobile.tsx
@@ -135,7 +135,7 @@ export const TokenRowMobile = memo(
 								<Amount
 									ticker={walletToken.token().symbol()}
 									showTicker={false}
-									value={walletToken.balance().toNumber()}
+									value={walletToken.balance().toHuman()}
 									className="dark:text-theme-dark-50 dim:text-theme-dim-50 text-sm leading-[17px] font-semibold"
 									showCompactFormat
 								/>

--- a/src/domains/tokens/pages/Tokens/__snapshots__/Tokens.test.tsx.snap
+++ b/src/domains/tokens/pages/Tokens/__snapshots__/Tokens.test.tsx.snap
@@ -1562,7 +1562,9 @@ exports[`Tokens > should render 1`] = `
                                 <div
                                   class="bg-theme-primary-600 dark:bg-theme-dark-navy-600 dim:bg-theme-dim-navy-600 flex h-5 w-5 items-center justify-center overflow-hidden rounded-full text-xs font-semibold text-white shrink-0"
                                 >
-                                  <div>
+                                  <div
+                                    data-testid="TokeNameInitials"
+                                  >
                                     D
                                   </div>
                                 </div>

--- a/src/domains/tokens/pages/hooks/use-profile-tokens.test.tsx
+++ b/src/domains/tokens/pages/hooks/use-profile-tokens.test.tsx
@@ -253,7 +253,7 @@ describe("useProfileTokens", () => {
 		expect(result.current.tokens).toHaveLength(1);
 		expect(result.current.tokens[0].token().address()).toBe("0xToken1");
 		expect(result.current.tokens[0].token().name()).toBe("Token 1");
-		expect(result.current.tokens[0].balance()).toBe(1);
+		expect(result.current.tokens[0].balance().toHuman()).toBe(1);
 
 		await act(async () => {
 			await vi.advanceTimersByTimeAsync(15_000);
@@ -266,7 +266,7 @@ describe("useProfileTokens", () => {
 		// Verify that after checkNewTokens runs, the second token is present
 		expect(result.current.tokens[0].token().address()).toBe("0xToken2");
 		expect(result.current.tokens[0].token().name()).toBe("Token 2");
-		expect(result.current.tokens[0].balance()).toBe(2);
+		expect(result.current.tokens[0].balance().toHuman()).toBe(2);
 
 		vi.useRealTimers();
 	});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dzrzfu8

This PR adds sorting for tokens in portfolio header. First it sorts by balance, picks first 3 from the list and then sorts those 3 tokens by name - in case there is more than 1 tokens with the same balance. This PR also refactors `balance` to use `BigNumber` instead of JS number.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
