### PR TITLE
fix: transactions table value overflow issue

### DIFF
--- a/src/app/components/Amount/AmountLabel.tsx
+++ b/src/app/components/Amount/AmountLabel.tsx
@@ -43,6 +43,7 @@ interface AmountLabelProperties {
 	allowHideBalance?: boolean;
 	profile?: Contracts.IProfile;
 	decimals?: number;
+	showCompactFormat?: boolean;
 }
 
 export const AmountLabel: React.FC<AmountLabelProperties> = ({
@@ -58,6 +59,7 @@ export const AmountLabel: React.FC<AmountLabelProperties> = ({
 	allowHideBalance = false,
 	profile,
 	decimals,
+	showCompactFormat,
 }) => {
 	let labelColor = "success-bg";
 	let hintClassName =
@@ -98,6 +100,7 @@ export const AmountLabel: React.FC<AmountLabelProperties> = ({
 					className={twMerge("text-sm", textClassName)}
 					allowHideBalance={allowHideBalance}
 					profile={profile}
+					showCompactFormat={showCompactFormat}
 				/>
 			</div>
 		</Label>

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -2713,11 +2713,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    + 2 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        + 2 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -2749,11 +2753,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    + 2 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        + 2 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -3253,11 +3261,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.00254046 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.00254046 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -3289,11 +3301,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.00254046 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.00254046 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -3793,11 +3809,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -3829,11 +3849,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -4333,11 +4357,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -4369,11 +4397,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -4873,11 +4905,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -4909,11 +4945,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -5413,11 +5453,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -5449,11 +5493,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -5953,11 +6001,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -5989,11 +6041,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.001 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.001 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -6532,11 +6588,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.200105 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.200105 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -6568,11 +6628,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 0.200105 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 0.200105 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -6910,11 +6974,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 1.50102853 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 1.50102853 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -6946,11 +7014,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    - 1.50102853 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        - 1.50102853 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -7493,11 +7565,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    + 4.98 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        + 4.98 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>
@@ -7529,11 +7605,15 @@ exports[`Dashboard > should render 1`] = `
                                 <div
                                   class="flex h-full items-center space-x-1"
                                 >
-                                  <span
-                                    class="whitespace-nowrap text-sm"
-                                    data-testid="Amount"
-                                  >
-                                    + 4.98 ARK
+                                  <span>
+                                    <span>
+                                      <span
+                                        class="whitespace-nowrap text-sm"
+                                        data-testid="Amount"
+                                      >
+                                        + 4.98 ARK
+                                      </span>
+                                    </span>
                                   </span>
                                 </div>
                               </div>

--- a/src/domains/tokens/components/TokenTransfers/__snapshots__/TokenTransfers.test.tsx.snap
+++ b/src/domains/tokens/components/TokenTransfers/__snapshots__/TokenTransfers.test.tsx.snap
@@ -665,11 +665,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -692,11 +696,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1197,11 +1205,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1224,11 +1236,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1729,11 +1745,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1756,11 +1776,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -2261,11 +2285,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2288,11 +2316,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -2793,11 +2825,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2820,11 +2856,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -3325,11 +3365,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -3352,11 +3396,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -3857,11 +3905,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -3884,11 +3936,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -4389,11 +4445,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -4416,11 +4476,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -4921,11 +4985,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -4948,11 +5016,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -5453,11 +5525,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -5480,11 +5556,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -5985,11 +6065,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -6012,11 +6096,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -6517,11 +6605,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -6544,11 +6636,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -7049,11 +7145,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -7076,11 +7176,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -7581,11 +7685,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -7608,11 +7716,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -8113,11 +8225,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -8140,11 +8256,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -8645,11 +8765,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -8672,11 +8796,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -9177,11 +9305,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -9204,11 +9336,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -9709,11 +9845,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -9736,11 +9876,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -10241,11 +10385,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10268,11 +10416,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -10773,11 +10925,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10800,11 +10956,15 @@ exports[`TokenTransfer > should fetch more token transfers 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -11509,11 +11669,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -11536,11 +11700,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12041,11 +12209,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12068,11 +12240,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12573,11 +12749,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12600,11 +12780,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13105,11 +13289,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13132,11 +13320,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13637,11 +13829,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13664,11 +13860,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14169,11 +14369,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14196,11 +14400,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14701,11 +14909,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14728,11 +14940,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15233,11 +15449,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15260,11 +15480,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15765,11 +15989,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15792,11 +16020,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -16297,11 +16529,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -16324,11 +16560,15 @@ exports[`TokenTransfer > should hide view more button when there are no next pag
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17018,11 +17258,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17045,11 +17289,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17550,11 +17798,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17577,11 +17829,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18082,11 +18338,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18109,11 +18369,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18614,11 +18878,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18641,11 +18909,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19146,11 +19418,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -19173,11 +19449,15 @@ exports[`TokenTransfer > should open detail side panel on token transfer row cli
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"

--- a/src/domains/tokens/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/tokens/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -665,11 +665,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -692,11 +696,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1197,11 +1205,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1224,11 +1236,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1729,11 +1745,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1756,11 +1776,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -2261,11 +2285,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2288,11 +2316,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -2793,11 +2825,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2820,11 +2856,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -3325,11 +3365,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -3352,11 +3396,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -3857,11 +3905,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -3884,11 +3936,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -4389,11 +4445,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -4416,11 +4476,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -4921,11 +4985,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -4948,11 +5016,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -5453,11 +5525,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -5480,11 +5556,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -5985,11 +6065,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -6012,11 +6096,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -6517,11 +6605,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -6544,11 +6636,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -7049,11 +7145,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -7076,11 +7176,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -7581,11 +7685,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -7608,11 +7716,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -8113,11 +8225,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -8140,11 +8256,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -8645,11 +8765,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -8672,11 +8796,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -9177,11 +9305,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -9204,11 +9336,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -9709,11 +9845,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -9736,11 +9876,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -10241,11 +10385,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10268,11 +10416,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -10773,11 +10925,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10800,11 +10956,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -11509,11 +11669,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -11536,11 +11700,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12041,11 +12209,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12068,11 +12240,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12573,11 +12749,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12600,11 +12780,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13105,11 +13289,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13132,11 +13320,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13637,11 +13829,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13664,11 +13860,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14169,11 +14369,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14196,11 +14400,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14701,11 +14909,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14728,11 +14940,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15233,11 +15449,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15260,11 +15480,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15765,11 +15989,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15792,11 +16020,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -16297,11 +16529,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -16324,11 +16560,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17018,11 +17258,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17045,11 +17289,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      5
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          5
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17550,11 +17798,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17577,11 +17829,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18082,11 +18338,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18109,11 +18369,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      100.378293
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          100.378293
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18614,11 +18878,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18641,11 +18909,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      10.3
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          10.3
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19146,11 +19418,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -19173,11 +19449,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionAmount.blocks.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionAmount.blocks.tsx
@@ -80,6 +80,7 @@ export const TransactionTotalLabel = ({
 				className="text-sm font-semibold"
 				allowHideBalance
 				profile={profile}
+				showCompactFormat
 			/>
 		);
 	}
@@ -100,6 +101,7 @@ export const TransactionTotalLabel = ({
 			className="h-[21px] rounded dark:border"
 			allowHideBalance
 			profile={profile}
+			showCompactFormat
 		/>
 	);
 };

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRow.test.tsx.snap
@@ -484,11 +484,15 @@ exports[`TransactionRow > should omit the currency for transactions from test ne
             <div
               class="flex flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1006,11 +1010,15 @@ exports[`TransactionRow > should render responsive (lg) 1`] = `
             <div
               class="flex flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1033,11 +1041,15 @@ exports[`TransactionRow > should render responsive (lg) 1`] = `
             <div
               class="flex w-40 flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1543,11 +1555,15 @@ exports[`TransactionRow > should render responsive (md) 1`] = `
             <div
               class="flex flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1570,11 +1586,15 @@ exports[`TransactionRow > should render responsive (md) 1`] = `
             <div
               class="flex w-40 flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1872,11 +1892,15 @@ exports[`TransactionRow > should render responsive (sm) 1`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -2392,11 +2416,15 @@ exports[`TransactionRow > should render responsive (xl) 1`] = `
             <div
               class="flex flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2706,11 +2734,15 @@ exports[`TransactionRow > should render responsive (xs) 1`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -3018,11 +3050,15 @@ exports[`TransactionRow > should render responsive 1`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -3330,11 +3366,15 @@ exports[`TransactionRow > should render responsive 2`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -3850,11 +3890,15 @@ exports[`TransactionRow > should render with currency 1`] = `
             <div
               class="flex flex-col items-end gap-1"
             >
-              <span
-                class="whitespace-nowrap text-sm font-semibold"
-                data-testid="Amount"
-              >
-                121
+              <span>
+                <span>
+                  <span
+                    class="whitespace-nowrap text-sm font-semibold"
+                    data-testid="Amount"
+                  >
+                    121
+                  </span>
+                </span>
               </span>
               <span
                 class="text-theme-secondary-700 text-xs font-semibold lg:hidden"

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/__snapshots__/TransactionRowMobile.test.tsx.snap
@@ -276,11 +276,15 @@ exports[`TransactionRowMobile > should render 1`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -588,11 +592,15 @@ exports[`TransactionRowMobile > should render 2`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -902,11 +910,15 @@ exports[`TransactionRowMobile > should render with currency 1`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -1216,11 +1228,15 @@ exports[`TransactionRowMobile > should render with currency 2`] = `
                 <div
                   class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    121
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        121
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -3714,11 +3714,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        2
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            2
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -4037,11 +4041,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.00254046
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.00254046
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -4360,11 +4368,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -4683,11 +4695,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -5006,11 +5022,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -5329,11 +5349,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -5652,11 +5676,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -5990,11 +6018,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.200105
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.200105
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -6259,11 +6291,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        1.50102853
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            1.50102853
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -6597,11 +6633,15 @@ exports[`TransactionTable > should render responsive 1`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        4.98
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            4.98
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -6959,11 +6999,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        2
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            2
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -7282,11 +7326,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.00254046
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.00254046
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -7605,11 +7653,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -7928,11 +7980,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -8251,11 +8307,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -8574,11 +8634,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -8897,11 +8961,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.001
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.001
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -9235,11 +9303,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        0.200105
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            0.200105
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -9504,11 +9576,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        1.50102853
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            1.50102853
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -9842,11 +9918,15 @@ exports[`TransactionTable > should render responsive 2`] = `
                     <div
                       class="text-theme-secondary-900 dark:text-theme-secondary-200 dim:text-theme-dim-50 text-sm font-semibold"
                     >
-                      <span
-                        class="whitespace-nowrap text-sm font-semibold"
-                        data-testid="Amount"
-                      >
-                        4.98
+                      <span>
+                        <span>
+                          <span
+                            class="whitespace-nowrap text-sm font-semibold"
+                            data-testid="Amount"
+                          >
+                            4.98
+                          </span>
+                        </span>
                       </span>
                     </div>
                   </div>
@@ -10565,11 +10645,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    2
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        2
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10592,11 +10676,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    2
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        2
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -11087,11 +11175,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.00254046
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.00254046
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -11114,11 +11206,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.00254046
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.00254046
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -11609,11 +11705,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -11636,11 +11736,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12131,11 +12235,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12158,11 +12266,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12653,11 +12765,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12680,11 +12796,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13175,11 +13295,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13202,11 +13326,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13697,11 +13825,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13724,11 +13856,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14264,11 +14400,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.200105
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.200105
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14291,11 +14431,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.200105
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.200105
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14624,11 +14768,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    1.50102853
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        1.50102853
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14651,11 +14799,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    1.50102853
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        1.50102853
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15189,11 +15341,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    4.98
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        4.98
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15216,11 +15372,15 @@ exports[`TransactionTable > should render responsive 3`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    4.98
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        4.98
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15929,11 +16089,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    2
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        2
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15956,11 +16120,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    2
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        2
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -16451,11 +16619,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.00254046
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.00254046
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -16478,11 +16650,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.00254046
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.00254046
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -16973,11 +17149,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17000,11 +17180,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17495,11 +17679,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17522,11 +17710,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18017,11 +18209,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18044,11 +18240,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18539,11 +18739,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18566,11 +18770,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19061,11 +19269,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -19088,11 +19300,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19628,11 +19844,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.200105
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.200105
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -19655,11 +19875,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.200105
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.200105
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19988,11 +20212,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    1.50102853
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        1.50102853
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -20015,11 +20243,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    1.50102853
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        1.50102853
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -20553,11 +20785,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    4.98
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        4.98
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -20580,11 +20816,15 @@ exports[`TransactionTable > should render responsive 4`] = `
                 <div
                   class="flex w-40 flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    4.98
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        4.98
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -21293,11 +21533,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    2
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        2
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -21800,11 +22044,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.00254046
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.00254046
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -22307,11 +22555,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -22814,11 +23066,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -23321,11 +23577,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -23828,11 +24088,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -24335,11 +24599,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.001
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.001
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -24887,11 +25155,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    0.200105
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        0.200105
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -25232,11 +25504,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    1.50102853
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        1.50102853
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -25782,11 +26058,15 @@ exports[`TransactionTable > should render responsive 5`] = `
                 <div
                   class="flex flex-col items-end gap-1"
                 >
-                  <span
-                    class="whitespace-nowrap text-sm font-semibold"
-                    data-testid="Amount"
-                  >
-                    4.98
+                  <span>
+                    <span>
+                      <span
+                        class="whitespace-nowrap text-sm font-semibold"
+                        data-testid="Amount"
+                      >
+                        4.98
+                      </span>
+                    </span>
                   </span>
                   <span
                     class="text-theme-secondary-700 text-xs font-semibold lg:hidden"

--- a/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -921,11 +921,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -948,11 +952,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -1482,11 +1490,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -1509,11 +1521,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -2043,11 +2059,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2070,11 +2090,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -2604,11 +2628,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -2631,11 +2659,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -3165,11 +3197,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -3192,11 +3228,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -3726,11 +3766,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -3753,11 +3797,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -4248,11 +4296,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -4275,11 +4327,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -4770,11 +4826,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -4797,11 +4857,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -5292,11 +5356,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -5319,11 +5387,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -5814,11 +5886,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -5841,11 +5917,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -6336,11 +6416,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -6363,11 +6447,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -6858,11 +6946,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -6885,11 +6977,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -7380,11 +7476,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -7407,11 +7507,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -7902,11 +8006,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -7929,11 +8037,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -8424,11 +8536,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -8451,11 +8567,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -8946,11 +9066,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -8973,11 +9097,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -9468,11 +9596,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -9495,11 +9627,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -9990,11 +10126,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10017,11 +10157,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -10512,11 +10656,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -10539,11 +10687,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -11034,11 +11186,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -11061,11 +11217,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -11556,11 +11716,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -11583,11 +11747,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12078,11 +12246,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12105,11 +12277,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -12600,11 +12776,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -12627,11 +12807,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13122,11 +13306,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13149,11 +13337,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -13644,11 +13836,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -13671,11 +13867,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14166,11 +14366,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14193,11 +14397,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -14688,11 +14896,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -14715,11 +14927,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15210,11 +15426,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15237,11 +15457,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -15732,11 +15956,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -15759,11 +15987,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -16254,11 +16486,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -16281,11 +16517,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -16776,11 +17016,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -16803,11 +17047,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17298,11 +17546,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17325,11 +17577,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -17820,11 +18076,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -17847,11 +18107,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18342,11 +18606,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18369,11 +18637,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -18864,11 +19136,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -18891,11 +19167,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19386,11 +19666,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -19413,11 +19697,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -19908,11 +20196,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -19935,11 +20227,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -20430,11 +20726,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -20457,11 +20757,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -20952,11 +21256,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -20979,11 +21287,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -21474,11 +21786,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -21501,11 +21817,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -21996,11 +22316,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -22023,11 +22347,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -22518,11 +22846,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -22545,11 +22877,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -23079,11 +23415,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -23106,11 +23446,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -23640,11 +23984,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -23667,11 +24015,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -24201,11 +24553,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -24228,11 +24584,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -24762,11 +25122,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -24789,11 +25153,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -25323,11 +25691,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -25350,11 +25722,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -25884,11 +26260,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -25911,11 +26291,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -26244,11 +26628,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -26271,11 +26659,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -26604,11 +26996,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -26631,11 +27027,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -26964,11 +27364,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -26991,11 +27395,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -27324,11 +27732,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -27351,11 +27763,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -27684,11 +28100,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -27711,11 +28131,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -28044,11 +28468,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -28071,11 +28499,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -28609,11 +29041,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -28636,11 +29072,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -29174,11 +29614,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -29201,11 +29645,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -29739,11 +30187,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -29766,11 +30218,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -30304,11 +30760,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -30331,11 +30791,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -30869,11 +31333,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -30896,11 +31364,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -31434,11 +31906,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -31461,11 +31937,15 @@ exports[`Transactions > should fetch more transactions 1`] = `
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -32426,11 +32906,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -32453,11 +32937,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -32948,11 +33436,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -32975,11 +33467,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -33470,11 +33966,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -33497,11 +33997,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -33992,11 +34496,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -34019,11 +34527,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -34514,11 +35026,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -34541,11 +35057,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -35036,11 +35556,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -35063,11 +35587,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -35558,11 +36086,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -35585,11 +36117,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -36119,11 +36655,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -36146,11 +36686,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -36479,11 +37023,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -36506,11 +37054,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -37044,11 +37596,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -37071,11 +37627,15 @@ exports[`Transactions > should hide view more button when there are no next page
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -38021,11 +38581,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -38048,11 +38612,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      2
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          2
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -38543,11 +39111,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -38570,11 +39142,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.00254046
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.00254046
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -39065,11 +39641,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -39092,11 +39672,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -39587,11 +40171,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -39614,11 +40202,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -40109,11 +40701,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -40136,11 +40732,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -40631,11 +41231,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -40658,11 +41262,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -41153,11 +41761,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -41180,11 +41792,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.001
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.001
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -41714,11 +42330,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -41741,11 +42361,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      0.200105
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          0.200105
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -42074,11 +42698,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -42101,11 +42729,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      1.50102853
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          1.50102853
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"
@@ -42639,11 +43271,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold lg:hidden"
@@ -42666,11 +43302,15 @@ exports[`Transactions > should open detail side panel on transaction row click 1
                   <div
                     class="flex w-40 flex-col items-end gap-1"
                   >
-                    <span
-                      class="whitespace-nowrap text-sm font-semibold"
-                      data-testid="Amount"
-                    >
-                      4.98
+                    <span>
+                      <span>
+                        <span
+                          class="whitespace-nowrap text-sm font-semibold"
+                          data-testid="Amount"
+                        >
+                          4.98
+                        </span>
+                      </span>
                     </span>
                     <span
                       class="text-theme-secondary-700 text-xs font-semibold xl:hidden"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes: https://app.clickup.com/t/86dzwcu0u

This PR displays transaction amounts in a compact way:

<img width="1288" height="838" alt="image" src="https://github.com/user-attachments/assets/29b97144-6134-4417-9886-68ac9a6fda89" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
