### PR TITLE
fix: transfers table token symbol overflow issue

### DIFF
--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionAmount.blocks.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionAmount.blocks.tsx
@@ -56,7 +56,7 @@ export const TransactionTotalLabel = ({
 	const { t } = useTranslation();
 
 	const token = transaction.token();
-	const currency = transaction.isTokenTransfer() && token ? token.symbol() : transaction.wallet().currency();
+	const currency = transaction.isTokenTransfer() && token ? token.displaySymbol() : transaction.wallet().currency();
 
 	const { returnedAmount, total } = useTransactionTotal(transaction);
 

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionBlocks.test.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionBlocks.test.tsx
@@ -86,7 +86,7 @@ describe("TransactionAmount.blocks", () => {
 
 		render(<TransactionTotalLabel transaction={tokenTransferFixture} profile={profile} />);
 
-		expect(screen.getByText(/DARK20/)).toBeInTheDocument();
+		expect(screen.getByText(/DARK2/)).toBeInTheDocument();
 	});
 
 	it("should use wallet currency for non-token transfers", () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes: https://app.clickup.com/t/86dzy7mj8

This PR fixes token symbol overflow issue.

<img width="1920" height="940" alt="image" src="https://github.com/user-attachments/assets/77464c23-5cf4-49d2-8459-29aa1eb06e58" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
