### PR TITLE
fix: total balance decimals overflow issue

### DIFF
--- a/src/app/lib/mainsail/draft-transfer.ts
+++ b/src/app/lib/mainsail/draft-transfer.ts
@@ -6,15 +6,13 @@ import { TransactionFeeService } from "./transaction-fee.service";
 import { TransactionFee } from "./fee.contract";
 import { assertNumber, assertWallet } from "@/utils/assertions";
 import { ExtendedSignedTransactionData } from "@/app/lib/profiles/signed-transaction.dto";
-import { handleBroadcastError } from "@/domains/transaction/utils";
+import { DISPLAY_DECIMALS, handleBroadcastError } from "@/domains/transaction/utils";
 import { calculateGasFee } from "@/domains/transaction/components/InputFee/InputFee";
 
 export interface RecipientItem {
 	address: string;
 	amount?: number;
 }
-
-const FEE_DISPLAY_VALUE_DECIMALS = 8;
 
 export class DraftTransfer {
 	readonly #env: Environment;
@@ -56,7 +54,7 @@ export class DraftTransfer {
 	// To human
 	public fee(): number {
 		return BigNumber.make(calculateGasFee(this.selectedFee(), this.gasLimit()))
-			.decimalPlaces(FEE_DISPLAY_VALUE_DECIMALS)
+			.decimalPlaces(DISPLAY_DECIMALS)
 			.toNumber();
 	}
 

--- a/src/app/lib/mainsail/transaction-fee.service.ts
+++ b/src/app/lib/mainsail/transaction-fee.service.ts
@@ -27,8 +27,6 @@ export const GasLimit: Record<Properties["type"], BigNumber> = {
 	vote: BigNumber.make(200_000),
 };
 
-const FEE_DISPLAY_VALUE_DECIMALS = 8;
-
 export class TransactionFeeService {
 	readonly #network: Networks.Network;
 	readonly #env: Environment;

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -1228,7 +1228,7 @@ exports[`Dashboard > should render 1`] = `
                             class="whitespace-nowrap dark:text-theme-dark-50 dim:text-theme-dim-50"
                             data-testid="Amount"
                           >
-                            95.276532523250678785 ARK
+                            95.27653252 ARK
                           </span>
                           <div
                             class="relative mx-2 border-t-0 border-l border-solid align-middle border-theme-secondary-300 md-lg:block dark:border-theme-dark-700 dim:border-theme-dim-700 hidden h-6"

--- a/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
+++ b/src/domains/portfolio/components/PortfolioHeader/PortfolioHeader.tsx
@@ -31,6 +31,7 @@ import { useLocalStorage } from "usehooks-ts";
 import { useWalletActions } from "@/domains/wallet/hooks";
 import { useWalletOptions } from "@/domains/wallet/pages/WalletDetails/hooks/use-wallet-options";
 import { useProfileTokens } from "@/domains/tokens/hooks/use-profile-tokens";
+import { DISPLAY_DECIMALS } from "@/domains/transaction/utils";
 
 export const PortfolioHeader = ({
 	profile,
@@ -352,7 +353,7 @@ export const PortfolioHeader = ({
 										</p>
 										<div>
 											<Amount
-												value={profile.totalBalance()}
+												value={profile.totalBalance().decimalPlaces(DISPLAY_DECIMALS)}
 												ticker={wallet.currency()}
 												className="text-theme-primary-900 dark:text-theme-dark-50 dim:text-theme-dim-50 text-sm leading-[17px] font-semibold md:text-base md:leading-5"
 												allowHideBalance
@@ -416,7 +417,7 @@ export const PortfolioHeader = ({
 									<div className="text-theme-secondary-900 dim:text-theme-dim-50 flex flex-row items-center text-lg leading-[21px] font-semibold md:text-2xl md:leading-[29px]">
 										{isRestored && selectedWallets.length === 1 && (
 											<Amount
-												value={wallet.balance()}
+												value={wallet.balance().decimalPlaces(DISPLAY_DECIMALS)}
 												ticker={wallet.currency()}
 												className="dark:text-theme-dark-50 dim:text-theme-dim-50"
 												allowHideBalance

--- a/src/domains/transaction/components/InputFee/InputFee.tsx
+++ b/src/domains/transaction/components/InputFee/InputFee.tsx
@@ -17,6 +17,7 @@ import { useExchangeRate } from "@/app/hooks/use-exchange-rate";
 import { useTranslation } from "react-i18next";
 import { UnitConverter } from "@arkecosystem/typescript-crypto";
 import { Network } from "@/app/lib/mainsail/network";
+import { DISPLAY_DECIMALS } from "@/domains/transaction/utils";
 
 export const calculateGasFee = (gasPrice?: BigNumber, gasLimit?: BigNumber): BigNumber => {
 	if (!gasPrice || !gasLimit) {
@@ -25,8 +26,6 @@ export const calculateGasFee = (gasPrice?: BigNumber, gasLimit?: BigNumber): Big
 
 	return BigNumber.make(UnitConverter.formatUnits(gasLimit.times(gasPrice).toString(), "gwei"));
 };
-
-const FEE_DISPLAY_VALUE_DECIMALS = 8;
 
 export const getFeeMinMax = (network: Network) => {
 	const milestone = network.milestone();
@@ -78,7 +77,7 @@ export const InputFee: React.FC<InputFeeProperties> = memo(
 		const options: InputFeeOptions = {
 			[InputFeeOption.Slow]: {
 				displayValue: BigNumber.make(calculateGasFee(min, gasLimit))
-					.decimalPlaces(FEE_DISPLAY_VALUE_DECIMALS)
+					.decimalPlaces(DISPLAY_DECIMALS)
 					.toNumber(),
 				displayValueConverted: convert(calculateGasFee(min, gasLimit)),
 				gasPrice: min,
@@ -86,7 +85,7 @@ export const InputFee: React.FC<InputFeeProperties> = memo(
 			},
 			[InputFeeOption.Average]: {
 				displayValue: BigNumber.make(calculateGasFee(avg, gasLimit))
-					.decimalPlaces(FEE_DISPLAY_VALUE_DECIMALS)
+					.decimalPlaces(DISPLAY_DECIMALS)
 					.toNumber(),
 				displayValueConverted: convert(calculateGasFee(avg, gasLimit)),
 				gasPrice: avg,
@@ -94,7 +93,7 @@ export const InputFee: React.FC<InputFeeProperties> = memo(
 			},
 			[InputFeeOption.Fast]: {
 				displayValue: BigNumber.make(calculateGasFee(max, gasLimit))
-					.decimalPlaces(FEE_DISPLAY_VALUE_DECIMALS)
+					.decimalPlaces(DISPLAY_DECIMALS)
 					.toNumber(),
 				displayValueConverted: convert(calculateGasFee(max, gasLimit)),
 				gasPrice: max,

--- a/src/domains/transaction/components/InputFee/InputFee.tsx
+++ b/src/domains/transaction/components/InputFee/InputFee.tsx
@@ -76,25 +76,19 @@ export const InputFee: React.FC<InputFeeProperties> = memo(
 
 		const options: InputFeeOptions = {
 			[InputFeeOption.Slow]: {
-				displayValue: BigNumber.make(calculateGasFee(min, gasLimit))
-					.decimalPlaces(DISPLAY_DECIMALS)
-					.toNumber(),
+				displayValue: BigNumber.make(calculateGasFee(min, gasLimit)).decimalPlaces(DISPLAY_DECIMALS).toNumber(),
 				displayValueConverted: convert(calculateGasFee(min, gasLimit)),
 				gasPrice: min,
 				label: t("TRANSACTION.FEES.SLOW"),
 			},
 			[InputFeeOption.Average]: {
-				displayValue: BigNumber.make(calculateGasFee(avg, gasLimit))
-					.decimalPlaces(DISPLAY_DECIMALS)
-					.toNumber(),
+				displayValue: BigNumber.make(calculateGasFee(avg, gasLimit)).decimalPlaces(DISPLAY_DECIMALS).toNumber(),
 				displayValueConverted: convert(calculateGasFee(avg, gasLimit)),
 				gasPrice: avg,
 				label: t("TRANSACTION.FEES.AVERAGE"),
 			},
 			[InputFeeOption.Fast]: {
-				displayValue: BigNumber.make(calculateGasFee(max, gasLimit))
-					.decimalPlaces(DISPLAY_DECIMALS)
-					.toNumber(),
+				displayValue: BigNumber.make(calculateGasFee(max, gasLimit)).decimalPlaces(DISPLAY_DECIMALS).toNumber(),
 				displayValueConverted: convert(calculateGasFee(max, gasLimit)),
 				gasPrice: max,
 				label: t("TRANSACTION.FEES.FAST"),

--- a/src/domains/transaction/utils.ts
+++ b/src/domains/transaction/utils.ts
@@ -3,6 +3,8 @@ import { Contracts } from "@/app/lib/profiles";
 import { RecipientItem } from "@/domains/transaction/components/RecipientList/RecipientList.contracts";
 import { TFunction } from "i18next";
 
+export const DISPLAY_DECIMALS = 8;
+
 export const isNoDeviceError = (error: any) => {
 	if (!error) {
 		return false;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86e064q6k

This PR rounds balance to have 8 decimals in portfolio header.

<img width="1338" height="292" alt="image" src="https://github.com/user-attachments/assets/927e555c-682d-4d40-91ab-e8e33eecdb1b" />

<img width="430" height="865" alt="image" src="https://github.com/user-attachments/assets/15eae7c8-8625-4e07-aa47-4db3652ce655" />



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
