### PR TITLE
fix: wrong method in token transfers table

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@ardenthq/arkvault-crypto": "^0.0.7",
 		"@ardenthq/arkvault-url": "^1.2.0",
 		"@arkecosystem/typescript-client": "^0.15.0",
-		"@arkecosystem/typescript-crypto": "^0.0.20",
+		"@arkecosystem/typescript-crypto": "^0.0.21",
 		"@faustbrian/node-haveibeenpwned": "^1.1.0",
 		"@floating-ui/react": "^0.27.13",
 		"@ledgerhq/hw-app-eth": "^6.45.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.15.0
         version: 0.15.0
       '@arkecosystem/typescript-crypto':
-        specifier: ^0.0.20
-        version: 0.0.20
+        specifier: ^0.0.21
+        version: 0.0.21
       '@faustbrian/node-haveibeenpwned':
         specifier: ^1.1.0
         version: 1.1.0
@@ -427,8 +427,8 @@ packages:
     resolution: {integrity: sha512-B7tcG1vu2z2gCPR41kSc4qJZe6AhlVmy7jDNF+viVnT8I/XW7p/lnN4Fh9o/R2fy2mfsfIeRYX2nKxvaX+UKFA==}
     engines: {node: '>=20.12.2'}
 
-  '@arkecosystem/typescript-crypto@0.0.20':
-    resolution: {integrity: sha512-mD2pwiw3z64JF93ptj5tg7X0GvnGZqmEHmhezhJIFm9/2R1Ww9D71fO78YRhAMiCoIse9xaVWp8Pg9iefnlPlg==}
+  '@arkecosystem/typescript-crypto@0.0.21':
+    resolution: {integrity: sha512-QUDFYXG4u3UjB02LXAeb+sXsCeRUmgtxo/56XyqkvDgNCndBr2hYkqUiTs9kXV8tD9wgfBRxpfMG9zNw6yXLfw==}
     engines: {node: '>=20.12.2'}
 
   '@asamuzakjp/css-color@3.2.0':
@@ -3407,8 +3407,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  ethers@6.15.0:
-    resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
   eventemitter3@5.0.1:
@@ -6604,11 +6604,11 @@ snapshots:
 
   '@arkecosystem/typescript-client@0.15.0': {}
 
-  '@arkecosystem/typescript-crypto@0.0.20':
+  '@arkecosystem/typescript-crypto@0.0.21':
     dependencies:
       '@noble/secp256k1': 2.3.0
       bignumber.js: 9.3.1
-      ethers: 6.15.0
+      ethers: 6.16.0
       wif: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -10185,7 +10185,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  ethers@6.15.0:
+  ethers@6.16.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0

--- a/src/app/lib/mainsail/client.service.ts
+++ b/src/app/lib/mainsail/client.service.ts
@@ -21,7 +21,12 @@ import { WalletTokenDTO } from "@/app/lib/profiles/wallet-token.dto";
 import { WalletTokenCollection } from "@/app/lib/mainsail/wallet-token.collection";
 import { WalletToken } from "@/app/lib/profiles/wallet-token";
 import { TokenTransfersQuery } from "@/app/lib/mainsail/client.contract";
-import { Helpers, TransactionFunctionSigs, UsernamesContract } from "@arkecosystem/typescript-crypto";
+import {
+	Helpers,
+	TransactionFunctionSigs,
+	TransactionTypeIdentifier,
+	UsernamesContract,
+} from "@arkecosystem/typescript-crypto";
 
 type searchParams<T extends Record<string, any> = {}> = T & { page: number; limit?: number };
 
@@ -148,6 +153,7 @@ export class ClientService {
 						status: 1,
 					},
 					...transfer,
+					to: TransactionTypeIdentifier.isTokenTransfer(transfer.functionSig) ? transfer.to : undefined,
 					tokens: [
 						{
 							from: transfer.from,
@@ -162,7 +168,6 @@ export class ClientService {
 							value: transfer.value,
 						},
 					],
-					type: "transfer",
 				}),
 			),
 			this.#createMetaPagination(response),

--- a/src/app/lib/mainsail/transaction-data.dto.test.ts
+++ b/src/app/lib/mainsail/transaction-data.dto.test.ts
@@ -465,14 +465,6 @@ describe("TransactionData", () => {
 		transaction.configure({
 			...commonData,
 			asset: { lock: { expiration: { value: 100 } } },
-			token: { address: "0x1234567890abcdef" },
-			type: "transfer",
-		});
-		expect(transaction.isTokenTransfer()).toBe(true);
-
-		transaction.configure({
-			...commonData,
-			asset: { lock: { expiration: { value: 100 } } },
 			data: "0xa9059cbb000000000000000000000000a5cc0bfeb09742c5e4c610f2ebaab82eb142ca100000000000000000000000000000000000000000000000001bc16d674ec80000",
 		});
 		expect(transaction.isTokenTransfer()).toBe(true);

--- a/src/app/lib/mainsail/transaction-data.dto.ts
+++ b/src/app/lib/mainsail/transaction-data.dto.ts
@@ -73,10 +73,6 @@ export abstract class TransactionData {
 	}
 
 	public isTokenTransfer() {
-		if (this.data?.token?.address && this.data.type === "transfer") {
-			return true;
-		}
-
 		return TransactionTypeIdentifier.isTokenTransfer(this.data.data);
 	}
 
@@ -115,7 +111,7 @@ export abstract class TransactionData {
 	}
 
 	public tokens(): TransactionToken[] | undefined {
-		if (this.isTokenTransfer() && this.data.tokens) {
+		if (this.data.tokens) {
 			return this.data.tokens.map((token: TransactionTokenData) => new TransactionToken(token));
 		}
 	}

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -84,7 +84,7 @@ const ContractAddressing = ({
 }) => {
 	const address =
 		transaction.isContractDeployment() && transaction.confirmations() > 0
-			? transaction.data().data.receipt.deployedContractAddress
+			? (transaction.data().data.receipt.deployedContractAddress || transaction.from())
 			: transaction.to();
 
 	return (

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -85,7 +85,7 @@ const ContractAddressing = ({
 }) => {
 	const address =
 		transaction.isContractDeployment() && transaction.confirmations() > 0
-			? transaction.data().data.receipt.deployedContractAddress || transaction.from()
+			? transaction.data().data.receipt.deployedContractAddress
 			: transaction.to();
 
 	return (

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -84,7 +84,7 @@ const ContractAddressing = ({
 }) => {
 	const address =
 		transaction.isContractDeployment() && transaction.confirmations() > 0
-			? (transaction.data().data.receipt.deployedContractAddress || transaction.from())
+			? transaction.data().data.receipt.deployedContractAddress || transaction.from()
 			: transaction.to();
 
 	return (

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -220,10 +220,10 @@ export const TransactionRowAddressing = ({
 		);
 	}
 
-	const displayAsContract = (isContract || transaction.isContractDeployment()) && transaction.to();
+	const showAsContract = (isContract || transaction.isContractDeployment()) && transaction.to();
 
 	if (isAdvanced && variant === "recipient" && !transaction.isMultiPayment()) {
-		if (displayAsContract) {
+		if (showAsContract) {
 			return (
 				<div
 					className="flex w-full flex-row gap-2"
@@ -274,7 +274,7 @@ export const TransactionRowAddressing = ({
 		);
 	}
 
-	if (displayAsContract) {
+	if (showAsContract) {
 		return <ContractAddressing transaction={transaction} direction={direction} t={t} />;
 	}
 

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -175,7 +175,7 @@ export const TransactionRowAddressing = ({
 	const { recipients } = useTransactionRecipients({ profile, transaction });
 
 	const network = transaction.wallet().network();
-	const recipientAddress = transaction.to();
+	const recipientAddress = transaction.to() || transaction.token()?.to();
 	const senderAddress = transaction.from();
 
 	const recipientAlias = useMemo(() => {
@@ -220,8 +220,10 @@ export const TransactionRowAddressing = ({
 		);
 	}
 
+	const displayAsContract = (isContract || transaction.isContractDeployment()) && transaction.to();
+
 	if (isAdvanced && variant === "recipient" && !transaction.isMultiPayment()) {
-		if (isContract || transaction.isContractDeployment()) {
+		if (displayAsContract) {
 			return (
 				<div
 					className="flex w-full flex-row gap-2"
@@ -272,7 +274,7 @@ export const TransactionRowAddressing = ({
 		);
 	}
 
-	if (isContract || transaction.isContractDeployment()) {
+	if (displayAsContract) {
 		return <ContractAddressing transaction={transaction} direction={direction} t={t} />;
 	}
 

--- a/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
+++ b/src/domains/transaction/components/TransactionTable/TransactionRow/TransactionRowAddressing.tsx
@@ -12,6 +12,7 @@ import { useTransactionRecipients } from "@/domains/transaction/hooks/use-transa
 import { Tooltip } from "@/app/components/Tooltip";
 import { Icon } from "@/app/components/Icon";
 import { Clipboard } from "@/app/components/Clipboard";
+import { isNullAddress } from "@/domains/transaction/utils";
 
 type Direction = "sent" | "received" | "return";
 export const TransactionRowLabel = ({ direction, style }: { direction: Direction; style?: Direction }) => {
@@ -220,7 +221,7 @@ export const TransactionRowAddressing = ({
 		);
 	}
 
-	const showAsContract = (isContract || transaction.isContractDeployment()) && transaction.to();
+	const showAsContract = (isContract || transaction.isContractDeployment()) && !isNullAddress(senderAddress);
 
 	if (isAdvanced && variant === "recipient" && !transaction.isMultiPayment()) {
 		if (showAsContract) {

--- a/src/domains/transaction/utils.test.ts
+++ b/src/domains/transaction/utils.test.ts
@@ -5,7 +5,8 @@ import {
 	isNoDeviceError,
 	isRejectionError,
 	withAbortPromise,
-	getAuthenticationStepSubtitle, isNullAddress,
+	getAuthenticationStepSubtitle,
+	isNullAddress,
 } from "./utils";
 import { useTranslation } from "react-i18next";
 import { getMainsailProfileId } from "@/utils/testing-library";
@@ -36,7 +37,7 @@ describe("Transaction utils", () => {
 		it("should return `false`", () => {
 			const result = isNullAddress("0xabc");
 
-			expect(result ).toBe(false);
+			expect(result).toBe(false);
 		});
 
 		it("should return `true`", () => {

--- a/src/domains/transaction/utils.test.ts
+++ b/src/domains/transaction/utils.test.ts
@@ -5,7 +5,7 @@ import {
 	isNoDeviceError,
 	isRejectionError,
 	withAbortPromise,
-	getAuthenticationStepSubtitle,
+	getAuthenticationStepSubtitle, isNullAddress,
 } from "./utils";
 import { useTranslation } from "react-i18next";
 import { getMainsailProfileId } from "@/utils/testing-library";
@@ -29,6 +29,20 @@ describe("Transaction utils", () => {
 			const error = isNoDeviceError("random string");
 
 			expect(error).toBe(false);
+		});
+	});
+
+	describe("isNullAddress", () => {
+		it("should return `false`", () => {
+			const result = isNullAddress("0xabc");
+
+			expect(result ).toBe(false);
+		});
+
+		it("should return `true`", () => {
+			const result = isNullAddress("0x0000000000000000000000000000000000000000");
+
+			expect(result).toBe(true);
 		});
 	});
 

--- a/src/domains/transaction/utils.ts
+++ b/src/domains/transaction/utils.ts
@@ -5,6 +5,8 @@ import { TFunction } from "i18next";
 
 export const DISPLAY_DECIMALS = 8;
 
+export const isNullAddress = (address: string) => address.toLowerCase() === "0x0000000000000000000000000000000000000000";
+
 export const isNoDeviceError = (error: any) => {
 	if (!error) {
 		return false;

--- a/src/domains/transaction/utils.ts
+++ b/src/domains/transaction/utils.ts
@@ -5,7 +5,8 @@ import { TFunction } from "i18next";
 
 export const DISPLAY_DECIMALS = 8;
 
-export const isNullAddress = (address: string) => address.toLowerCase() === "0x0000000000000000000000000000000000000000";
+export const isNullAddress = (address: string) =>
+	address.toLowerCase() === "0x0000000000000000000000000000000000000000";
 
 export const isNoDeviceError = (error: any) => {
 	if (!error) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86e0647xe

This PR adjusts token transfers table to have `Contract Deployment` method for contract deployments which were displayed as `Transfer` previously.

[Screencast from 2026-03-06 17-08-23.webm](https://github.com/user-attachments/assets/caea7eeb-2b72-4078-bb53-267dba60c9ff)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
