### PR TITLE
fix: increase max width for tooltip content

### DIFF
--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`AmountLabel > should render compact with hint 1`] = `
           tabindex="-1"
         >
           <div
-            style="opacity: 0; transform: scale(0.9);"
+            style="transition-property: opacity,transform; transition-duration: 250ms;"
           >
             <svg
               aria-hidden="true"
@@ -225,7 +225,7 @@ exports[`AmountLabel > should render with hint 1`] = `
           tabindex="-1"
         >
           <div
-            style="opacity: 0; transform: scale(0.9);"
+            style="transition-property: opacity,transform; transition-duration: 250ms;"
           >
             <svg
               aria-hidden="true"

--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`AmountLabel > should render compact with hint 1`] = `
           tabindex="-1"
         >
           <div
-            style="transition-property: opacity,transform; transition-duration: 250ms;"
+            style="opacity: 0; transform: scale(0.9);"
           >
             <svg
               aria-hidden="true"
@@ -225,7 +225,7 @@ exports[`AmountLabel > should render with hint 1`] = `
           tabindex="-1"
         >
           <div
-            style="transition-property: opacity,transform; transition-duration: 250ms;"
+            style="opacity: 0; transform: scale(0.9);"
           >
             <svg
               aria-hidden="true"

--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`AmountLabel > should render compact with hint 1`] = `
               </clippath>
             </svg>
             <div
-              class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+              class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
               style="font-feature-settings: "liga" off, "calt" off;"
             >
               <div>

--- a/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
+++ b/src/app/components/Amount/__snapshots__/AmountLabel.test.tsx.snap
@@ -251,7 +251,7 @@ exports[`AmountLabel > should render with hint 1`] = `
               </clippath>
             </svg>
             <div
-              class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+              class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
               style="font-feature-settings: "liga" off, "calt" off;"
             >
               <div>

--- a/src/app/components/Clipboard/__snapshots__/ClipboardIcon.test.tsx.snap
+++ b/src/app/components/Clipboard/__snapshots__/ClipboardIcon.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`ClipboardIcon > should render with tooltip in the dark mode 1`] = `
           </clippath>
         </svg>
         <div
-          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
           style="font-feature-settings: "liga" off, "calt" off;"
         >
           <div>

--- a/src/app/components/Form/__snapshots__/FormLabel.test.tsx.snap
+++ b/src/app/components/Form/__snapshots__/FormLabel.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`FormLabel > should render & hover if optional 1`] = `
         tabindex="-1"
       >
         <div
-          style="opacity: 0; transform: scale(0.9);"
+          style="transition-property: opacity,transform; transition-duration: 250ms;"
         >
           <svg
             aria-hidden="true"

--- a/src/app/components/Form/__snapshots__/FormLabel.test.tsx.snap
+++ b/src/app/components/Form/__snapshots__/FormLabel.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`FormLabel > should render & hover if optional 1`] = `
         tabindex="-1"
       >
         <div
-          style="transition-property: opacity,transform; transition-duration: 250ms;"
+          style="opacity: 0; transform: scale(0.9);"
         >
           <svg
             aria-hidden="true"
@@ -52,7 +52,7 @@ exports[`FormLabel > should render & hover if optional 1`] = `
             </clippath>
           </svg>
           <div
-            class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+            class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
             style="font-feature-settings: "liga" off, "calt" off;"
           >
             <div>

--- a/src/app/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/app/components/Link/__snapshots__/Link.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`Link > should render with tooltip 1`] = `
           </clippath>
         </svg>
         <div
-          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
           style="font-feature-settings: "liga" off, "calt" off;"
         >
           <div>

--- a/src/app/components/NetworkIcon/__snapshots__/NetworkIcon.test.tsx.snap
+++ b/src/app/components/NetworkIcon/__snapshots__/NetworkIcon.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`NetworkIcon > should render with tooltip in the dark mode 1`] = `
           </clippath>
         </svg>
         <div
-          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
           style="font-feature-settings: "liga" off, "calt" off;"
         >
           <div>

--- a/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
+++ b/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
@@ -973,7 +973,7 @@ exports[`SelectDropdown > should render option base with custom label 1`] = `
               style="transition-property: opacity,transform; transition-duration: 250ms;"
             >
               <div
-                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
+                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
                 style="font-feature-settings: "liga" off, "calt" off;"
               >
                 <div>
@@ -1183,7 +1183,7 @@ exports[`SelectDropdown > should render option base with custom label and allowe
               style="transition-property: opacity,transform; transition-duration: 250ms;"
             >
               <div
-                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
+                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
                 style="font-feature-settings: "liga" off, "calt" off;"
               >
                 <div>
@@ -1967,7 +1967,7 @@ exports[`SelectDropdown > should render option group with custom label 1`] = `
               style="transition-property: opacity,transform; transition-duration: 250ms;"
             >
               <div
-                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
+                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
                 style="font-feature-settings: "liga" off, "calt" off;"
               >
                 <div>
@@ -2176,7 +2176,7 @@ exports[`SelectDropdown > should render option group with custom label and allow
               style="transition-property: opacity,transform; transition-duration: 250ms;"
             >
               <div
-                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
+                class="overflow-wrap-anywhere dark:text-theme-secondary-200 dim:text-theme-dim-50 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap dim:bg-transparent w-full bg-transparent dark:bg-transparent"
                 style="font-feature-settings: "liga" off, "calt" off;"
               >
                 <div>

--- a/src/app/components/Tooltip/Tooltip.tsx
+++ b/src/app/components/Tooltip/Tooltip.tsx
@@ -106,7 +106,7 @@ export const Tooltip = ({
 								style={{ fontFeatureSettings: '"liga" off, "calt" off' }}
 								className={twMerge(
 									cn(
-										"overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap",
+										"overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap",
 										{
 											"text-xs font-medium": size === "sm",
 										},

--- a/src/app/components/WalletIcons/__snapshots__/WalletIcons.test.tsx.snap
+++ b/src/app/components/WalletIcons/__snapshots__/WalletIcons.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`WalletIcons > should render with tooltip in the dark mode 1`] = `
           </clippath>
         </svg>
         <div
-          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-2xl sm:whitespace-nowrap"
+          class="overflow-wrap-anywhere dark:bg-theme-secondary-700 dark:text-theme-secondary-200 bg-theme-secondary-900 dim:text-theme-dim-50 dim:bg-theme-dim-700 whitespace-wrap max-w-72 rounded-md px-2 py-1 text-sm font-semibold break-words text-white sm:max-w-3xl sm:whitespace-nowrap"
           style="font-feature-settings: "liga" off, "calt" off;"
         >
           <div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes <https://app.clickup.com/t/86e0f2t24>

<img width="1142" height="245" alt="screenshot-2026-03-19_12-59-47" src="https://github.com/user-attachments/assets/82baa0fe-9bcd-4f30-b2f5-e51a83dea3d9" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
