### PR TITLE
fix: transaction input font size

### DIFF
--- a/src/domains/message/components/SignMessage/FormStep.tsx
+++ b/src/domains/message/components/SignMessage/FormStep.tsx
@@ -43,7 +43,7 @@ export const FormStep = ({
 	return (
 		<section className="space-y-4">
 			<FormField name="signatory-address">
-				<FormLabel textClassName="text-base" label={t("COMMON.SIGNING_ADDRESS")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SIGNING_ADDRESS")} />
 				<SelectAddressDropdown
 					disabled={disabled}
 					profile={profile}
@@ -55,7 +55,7 @@ export const FormStep = ({
 			</FormField>
 
 			<FormField name="message">
-				<FormLabel label={t("COMMON.MESSAGE")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.MESSAGE")} />
 				<InputCounter
 					defaultValue={message}
 					onChange={(event: ChangeEvent<HTMLInputElement>) =>

--- a/src/domains/message/components/SignMessage/FormStep.tsx
+++ b/src/domains/message/components/SignMessage/FormStep.tsx
@@ -43,7 +43,10 @@ export const FormStep = ({
 	return (
 		<section className="space-y-4">
 			<FormField name="signatory-address">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SIGNING_ADDRESS")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("COMMON.SIGNING_ADDRESS")}
+				/>
 				<SelectAddressDropdown
 					disabled={disabled}
 					profile={profile}
@@ -55,7 +58,10 @@ export const FormStep = ({
 			</FormField>
 
 			<FormField name="message">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.MESSAGE")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("COMMON.MESSAGE")}
+				/>
 				<InputCounter
 					defaultValue={message}
 					onChange={(event: ChangeEvent<HTMLInputElement>) =>

--- a/src/domains/message/components/VerifyMessage/FormStep.tsx
+++ b/src/domains/message/components/VerifyMessage/FormStep.tsx
@@ -21,7 +21,10 @@ const JsonForm = () => {
 	return (
 		<div data-testid="VerifyMessage__json" className="mt-4">
 			<FormField name="jsonString">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("MESSAGE.PAGE_VERIFY_MESSAGE.FORM_STEP.JSON_STRING")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("MESSAGE.PAGE_VERIFY_MESSAGE.FORM_STEP.JSON_STRING")}
+				/>
 				<TextArea
 					data-testid="VerifyMessage__json-jsonString"
 					className="py-4"
@@ -47,17 +50,26 @@ const ManualForm = () => {
 	return (
 		<div data-testid="VerifyMessage__manual" className="mt-4 space-y-4">
 			<FormField name="signatory">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SIGNATORY")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("COMMON.SIGNATORY")}
+				/>
 				<InputDefault data-testid="VerifyMessage__manual-signatory" ref={register(verifyMessage.signatory())} />
 			</FormField>
 
 			<FormField name="message">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.MESSAGE")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("COMMON.MESSAGE")}
+				/>
 				<InputDefault data-testid="VerifyMessage__manual-message" ref={register(verifyMessage.message())} />
 			</FormField>
 
 			<FormField name="signature">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SIGNATURE")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("COMMON.SIGNATURE")}
+				/>
 				<InputDefault data-testid="VerifyMessage__manual-signature" ref={register(verifyMessage.signature())} />
 			</FormField>
 		</div>

--- a/src/domains/message/components/VerifyMessage/FormStep.tsx
+++ b/src/domains/message/components/VerifyMessage/FormStep.tsx
@@ -21,7 +21,7 @@ const JsonForm = () => {
 	return (
 		<div data-testid="VerifyMessage__json" className="mt-4">
 			<FormField name="jsonString">
-				<FormLabel label={t("MESSAGE.PAGE_VERIFY_MESSAGE.FORM_STEP.JSON_STRING")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("MESSAGE.PAGE_VERIFY_MESSAGE.FORM_STEP.JSON_STRING")} />
 				<TextArea
 					data-testid="VerifyMessage__json-jsonString"
 					className="py-4"
@@ -47,17 +47,17 @@ const ManualForm = () => {
 	return (
 		<div data-testid="VerifyMessage__manual" className="mt-4 space-y-4">
 			<FormField name="signatory">
-				<FormLabel label={t("COMMON.SIGNATORY")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SIGNATORY")} />
 				<InputDefault data-testid="VerifyMessage__manual-signatory" ref={register(verifyMessage.signatory())} />
 			</FormField>
 
 			<FormField name="message">
-				<FormLabel label={t("COMMON.MESSAGE")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.MESSAGE")} />
 				<InputDefault data-testid="VerifyMessage__manual-message" ref={register(verifyMessage.message())} />
 			</FormField>
 
 			<FormField name="signature">
-				<FormLabel label={t("COMMON.SIGNATURE")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SIGNATURE")} />
 				<InputDefault data-testid="VerifyMessage__manual-signature" ref={register(verifyMessage.signature())} />
 			</FormField>
 		</div>

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -312,7 +312,9 @@ export const AddRecipient = ({
 	return (
 		<AddRecipientWrapper>
 			<div className="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between">
-				<div className="font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5">{t("TRANSACTION.RECIPIENT")}</div>
+				<div className="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5">
+					{t("TRANSACTION.RECIPIENT")}
+				</div>
 
 				{network?.allows(Enums.FeatureFlag.TransactionMultiPayment) && (
 					<TransferType
@@ -388,7 +390,9 @@ export const AddRecipient = ({
 							<span className="items-centers flex w-full justify-between">
 								<div className="flex flex-row items-center gap-1.5">
 									<span className="sm:hidden">{t("COMMON.AMOUNT")}</span>
-									<span className="hidden sm:block text-base leading-5">{t("COMMON.ASSET_AMOUNT")}</span>
+									<span className="hidden text-base leading-5 sm:block">
+										{t("COMMON.ASSET_AMOUNT")}
+									</span>
 									<span className="text-theme-secondary-700 dark:text-theme-dark-200 dim:text-theme-dim-200 text-sm sm:hidden">
 										(
 										<Amount

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { SelectToken } from "@/domains/tokens/components/SelectToken";
 import { Enums } from "@/app/lib/mainsail";
 import { useTransferAssets } from "@/domains/transaction/hooks/use-send-transfer-assets";
+import { DISPLAY_DECIMALS } from "@/domains/transaction/utils";
 
 const TransferType = ({ isSingle, onChange, maxRecipients, disableMultiple }: ToggleButtonProperties) => {
 	const { t } = useTranslation();
@@ -311,7 +312,7 @@ export const AddRecipient = ({
 	return (
 		<AddRecipientWrapper>
 			<div className="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between">
-				<div className="text-sm font-semibold transition-colors duration-100">{t("TRANSACTION.RECIPIENT")}</div>
+				<div className="font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5">{t("TRANSACTION.RECIPIENT")}</div>
 
 				{network?.allows(Enums.FeatureFlag.TransactionMultiPayment) && (
 					<TransferType
@@ -387,7 +388,7 @@ export const AddRecipient = ({
 							<span className="items-centers flex w-full justify-between">
 								<div className="flex flex-row items-center gap-1.5">
 									<span className="sm:hidden">{t("COMMON.AMOUNT")}</span>
-									<span className="hidden sm:block">{t("COMMON.ASSET_AMOUNT")}</span>
+									<span className="hidden sm:block text-base leading-5">{t("COMMON.ASSET_AMOUNT")}</span>
 									<span className="text-theme-secondary-700 dark:text-theme-dark-200 dim:text-theme-dim-200 text-sm sm:hidden">
 										(
 										<Amount
@@ -407,7 +408,7 @@ export const AddRecipient = ({
 										>
 											<span className="hidden pr-1 sm:inline">{t("COMMON.BALANCE")}:</span>
 											<Amount
-												value={remainingBalance}
+												value={remainingBalance.decimalPlaces(DISPLAY_DECIMALS)}
 												ticker={ticker}
 												showTicker
 												showCompactFormat

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -404,7 +404,7 @@ exports[`AddRecipient > should hide available balance if fee > balance 1`] = `
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -682,7 +682,7 @@ exports[`AddRecipient > should render 1`] = `
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -1052,7 +1052,7 @@ exports[`AddRecipient > should render 1`] = `
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -1289,7 +1289,7 @@ exports[`AddRecipient > should render with assets field 1`] = `
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -1659,7 +1659,7 @@ exports[`AddRecipient > should render with assets field 1`] = `
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -1896,7 +1896,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -2266,7 +2266,7 @@ exports[`AddRecipient > should render with empty array of recipients as default 
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -2503,7 +2503,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -2873,7 +2873,7 @@ exports[`AddRecipient > should render with multiple recipients switch 1`] = `
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -3110,7 +3110,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -3496,7 +3496,7 @@ exports[`AddRecipient > should render with single recipient data 1`] = `
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -3905,7 +3905,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -4275,7 +4275,7 @@ exports[`AddRecipient > should render without the single & multiple switch 1`] =
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -4512,7 +4512,7 @@ exports[`AddRecipient > should set available amount 1`] = `
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -4907,7 +4907,7 @@ exports[`AddRecipient > should set available amount 1`] = `
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>
@@ -4947,7 +4947,7 @@ exports[`AddRecipient > should set available amount 1`] = `
                         class="whitespace-nowrap"
                         data-testid="Amount"
                       >
-                        95.27653252325068 ARK
+                        95.27653252 ARK
                       </span>
                     </span>
                   </span>
@@ -5170,7 +5170,7 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
       class="text-theme-secondary-text hover:text-theme-primary-600 dim:text-theme-dim-200 mb-2 flex items-center justify-between"
     >
       <div
-        class="text-sm font-semibold transition-colors duration-100"
+        class="text-sm leading-[17px] font-semibold transition-colors duration-100 sm:text-base sm:leading-5"
       >
         Recipient
       </div>
@@ -5540,7 +5540,7 @@ exports[`AddRecipient > should show zero amount if wallet has zero or insufficie
                   Amount
                 </span>
                 <span
-                  class="hidden sm:block"
+                  class="hidden text-base leading-5 sm:block"
                 >
                   Asset and Amount
                 </span>

--- a/src/domains/transaction/components/AuthenticationStep/AuthenticationStep.tsx
+++ b/src/domains/transaction/components/AuthenticationStep/AuthenticationStep.tsx
@@ -258,7 +258,7 @@ export const AuthenticationStep = ({
 					)}
 
 					<FormField name="secret">
-						<FormLabel>{t("COMMON.SECRET")}</FormLabel>
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">{t("COMMON.SECRET")}</FormLabel>
 						<InputPassword
 							data-testid="AuthenticationStep__secret"
 							ref={register(authentication.secret(wallet))}

--- a/src/domains/transaction/components/AuthenticationStep/AuthenticationStep.tsx
+++ b/src/domains/transaction/components/AuthenticationStep/AuthenticationStep.tsx
@@ -258,7 +258,9 @@ export const AuthenticationStep = ({
 					)}
 
 					<FormField name="secret">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">{t("COMMON.SECRET")}</FormLabel>
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">
+							{t("COMMON.SECRET")}
+						</FormLabel>
 						<InputPassword
 							data-testid="AuthenticationStep__secret"
 							ref={register(authentication.secret(wallet))}

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
@@ -635,7 +635,7 @@ exports[`AuthenticationStep (message) > should request secret if wallet was impo
       class="[&:focus-within_.FormLabel]:text-theme-danger-500 [&>.FormLabel]:text-theme-danger-500 flex min-w-0 flex-col"
     >
       <label
-        class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+        class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
         data-testid="FormLabel"
         for="secret"
       >
@@ -1802,7 +1802,7 @@ exports[`AuthenticationStep (transaction) > should request secret if wallet was 
       class="[&:focus-within_.FormLabel]:text-theme-danger-500 [&>.FormLabel]:text-theme-danger-500 flex min-w-0 flex-col"
     >
       <label
-        class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+        class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
         data-testid="FormLabel"
         for="secret"
       >

--- a/src/domains/transaction/components/ContractDeploymentForm/FormStep.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/FormStep.tsx
@@ -44,7 +44,10 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 		<section data-testid="ContractDeploymentForm__form-step">
 			<div className="space-y-4">
 				<FormField name="senderAddress">
-					<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.SENDER")} />
+					<FormLabel
+						textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+						label={t("TRANSACTION.SENDER")}
+					/>
 					<SelectAddressDropdown
 						disabled={profile.wallets().count() === 0}
 						profile={profile}
@@ -61,7 +64,10 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 
 				<FormField name="bytecode">
 					<div className="flex flex-1 flex-row justify-between leading-[17px]">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5 self-center" label={t("COMMON.BYTECODE")}/>
+						<FormLabel
+							textClassName="text-sm leading-[17px] sm:text-base sm:leading-5 self-center"
+							label={t("COMMON.BYTECODE")}
+						/>
 						<Link
 							isExternal
 							to="https://docs.mainsailhq.com/mainsail/deployment/becoming-a-validator"

--- a/src/domains/transaction/components/ContractDeploymentForm/FormStep.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/FormStep.tsx
@@ -44,7 +44,7 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 		<section data-testid="ContractDeploymentForm__form-step">
 			<div className="space-y-4">
 				<FormField name="senderAddress">
-					<FormLabel label={t("TRANSACTION.SENDER")} />
+					<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.SENDER")} />
 					<SelectAddressDropdown
 						disabled={profile.wallets().count() === 0}
 						profile={profile}
@@ -61,7 +61,7 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 
 				<FormField name="bytecode">
 					<div className="flex flex-1 flex-row justify-between leading-[17px]">
-						<FormLabel label={t("COMMON.BYTECODE")} textClassName="self-center text-sm" />
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5 self-center" label={t("COMMON.BYTECODE")}/>
 						<Link
 							isExternal
 							to="https://docs.mainsailhq.com/mainsail/deployment/becoming-a-validator"

--- a/src/domains/transaction/components/ContractDeploymentForm/ReviewStep.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ReviewStep.tsx
@@ -89,7 +89,10 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
+						<FormLabel
+							textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+							label={t("TRANSACTION.TRANSACTION_FEE")}
+						/>
 						<FeeField
 							type="contractDeployment"
 							data={feeTransactionData}

--- a/src/domains/transaction/components/ContractDeploymentForm/ReviewStep.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ReviewStep.tsx
@@ -89,7 +89,7 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
 						<FeeField
 							type="contractDeployment"
 							data={feeTransactionData}

--- a/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
@@ -66,7 +66,7 @@ export const FormStep = ({
 						<div className="mb-2 flex items-center justify-between">
 							<FormLabel
 								label={t("TRANSACTION.SENDER")}
-								className="text-theme-secondary-text hover:text-theme-primary-600! mb-0 text-sm leading-[17px] font-semibold"
+								className="text-theme-secondary-text hover:text-theme-primary-600! mb-0 font-semibold text-sm leading-[17px] sm:text-base sm:leading-5"
 							/>
 							<Button
 								type="button"

--- a/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
@@ -66,7 +66,7 @@ export const FormStep = ({
 						<div className="mb-2 flex items-center justify-between">
 							<FormLabel
 								label={t("TRANSACTION.SENDER")}
-								className="text-theme-secondary-text hover:text-theme-primary-600! mb-0 font-semibold text-sm leading-[17px] sm:text-base sm:leading-5"
+								className="text-theme-secondary-text hover:text-theme-primary-600! mb-0 text-sm leading-[17px] font-semibold sm:text-base sm:leading-5"
 							/>
 							<Button
 								type="button"

--- a/src/domains/transaction/components/SendTransferSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/ReviewStep.tsx
@@ -187,7 +187,10 @@ export const ReviewStep = ({ wallet, network }: ReviewStepProperties) => {
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					{showFeeInput && (
 						<FormField name="fee" disableStateHints>
-							<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
+							<FormLabel
+								textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+								label={t("TRANSACTION.TRANSACTION_FEE")}
+							/>
 							{!!network && (
 								<FeeField
 									type={getFeeType(recipients?.length)}

--- a/src/domains/transaction/components/SendTransferSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/ReviewStep.tsx
@@ -187,7 +187,7 @@ export const ReviewStep = ({ wallet, network }: ReviewStepProperties) => {
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					{showFeeInput && (
 						<FormField name="fee" disableStateHints>
-							<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+							<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
 							{!!network && (
 								<FeeField
 									type={getFeeType(recipients?.length)}

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/ReviewStep.tsx
@@ -56,7 +56,7 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel>{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
 						<FeeField
 							type="usernameResignation"
 							data={undefined}

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/ReviewStep.tsx
@@ -56,7 +56,9 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">
+							{t("TRANSACTION.TRANSACTION_FEE")}
+						</FormLabel>
 						<FeeField
 							type="usernameResignation"
 							data={undefined}

--- a/src/domains/transaction/components/SendValidatorResignationSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendValidatorResignationSidePanel/ReviewStep.tsx
@@ -111,7 +111,9 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">
+							{t("TRANSACTION.TRANSACTION_FEE")}
+						</FormLabel>
 						<FeeField
 							type="validatorResignation"
 							data={undefined}

--- a/src/domains/transaction/components/SendValidatorResignationSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendValidatorResignationSidePanel/ReviewStep.tsx
@@ -111,7 +111,7 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel>{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5">{t("TRANSACTION.TRANSACTION_FEE")}</FormLabel>
 						<FeeField
 							type="validatorResignation"
 							data={undefined}

--- a/src/domains/transaction/components/SendVoteSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/FormStep.tsx
@@ -21,7 +21,10 @@ export const FormStep = ({ unvotes, votes, wallet, profile, isWalletFieldDisable
 	return (
 		<section data-testid="SendVote__form-step" className="space-y-3 sm:space-y-4">
 			<FormField name="senderAddress">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.SENDER")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("TRANSACTION.SENDER")}
+				/>
 
 				<div data-testid="sender-address" className="mb-3 sm:mb-0">
 					<SelectAddress

--- a/src/domains/transaction/components/SendVoteSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/FormStep.tsx
@@ -21,7 +21,7 @@ export const FormStep = ({ unvotes, votes, wallet, profile, isWalletFieldDisable
 	return (
 		<section data-testid="SendVote__form-step" className="space-y-3 sm:space-y-4">
 			<FormField name="senderAddress">
-				<FormLabel label={t("TRANSACTION.SENDER")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.SENDER")} />
 
 				<div data-testid="sender-address" className="mb-3 sm:mb-0">
 					<SelectAddress

--- a/src/domains/transaction/components/SendVoteSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/ReviewStep.tsx
@@ -65,7 +65,10 @@ export const ReviewStep = ({ unvotes, votes, wallet, profile }: SendVoteStepProp
 					<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 						{showFeeInput && (
 							<FormField name="fee" className="flex-1">
-								<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
+								<FormLabel
+									textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+									label={t("TRANSACTION.TRANSACTION_FEE")}
+								/>
 								<FeeField
 									type="vote"
 									data={{

--- a/src/domains/transaction/components/SendVoteSidePanel/ReviewStep.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/ReviewStep.tsx
@@ -65,7 +65,7 @@ export const ReviewStep = ({ unvotes, votes, wallet, profile }: SendVoteStepProp
 					<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 						{showFeeInput && (
 							<FormField name="fee" className="flex-1">
-								<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+								<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
 								<FeeField
 									type="vote"
 									data={{

--- a/src/domains/transaction/components/UsernameRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/FormStep.tsx
@@ -88,7 +88,10 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 
 			<div className="mt-3 space-y-4 sm:mt-4">
 				<FormField name="senderAddress">
-					<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.SENDER")} />
+					<FormLabel
+						textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+						label={t("TRANSACTION.SENDER")}
+					/>
 
 					<SelectAddressDropdown
 						disabled={profile.wallets().count() === 0}
@@ -105,7 +108,10 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 				</FormField>
 
 				<FormField name="username">
-					<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.USERNAME")} />
+					<FormLabel
+						textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+						label={t("COMMON.USERNAME")}
+					/>
 					<InputDefault
 						data-testid="Input__username"
 						defaultValue={username}

--- a/src/domains/transaction/components/UsernameRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/FormStep.tsx
@@ -88,7 +88,7 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 
 			<div className="mt-3 space-y-4 sm:mt-4">
 				<FormField name="senderAddress">
-					<FormLabel label={t("TRANSACTION.SENDER")} />
+					<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.SENDER")} />
 
 					<SelectAddressDropdown
 						disabled={profile.wallets().count() === 0}
@@ -105,7 +105,7 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 				</FormField>
 
 				<FormField name="username">
-					<FormLabel label={t("COMMON.USERNAME")} />
+					<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.USERNAME")} />
 					<InputDefault
 						data-testid="Input__username"
 						defaultValue={username}

--- a/src/domains/transaction/components/UsernameRegistrationForm/ReviewStep.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/ReviewStep.tsx
@@ -58,7 +58,10 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
+						<FormLabel
+							textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+							label={t("TRANSACTION.TRANSACTION_FEE")}
+						/>
 						<FeeField
 							type="usernameRegistration"
 							data={feeTransactionData}

--- a/src/domains/transaction/components/UsernameRegistrationForm/ReviewStep.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/ReviewStep.tsx
@@ -58,7 +58,7 @@ export const ReviewStep = ({
 
 				<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 					<FormField name="fee">
-						<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
 						<FeeField
 							type="usernameRegistration"
 							data={feeTransactionData}

--- a/src/domains/transaction/components/UsernameRegistrationForm/__snapshots__/UsernameRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/UsernameRegistrationForm/__snapshots__/UsernameRegistrationForm.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`UsernameRegistrationForm > should render form step 1`] = `
             class="[&:focus-within_.FormLabel]:text-theme-primary-600 dark:[&:focus-within_.FormLabel]:text-theme-primary-500 flex min-w-0 flex-col"
           >
             <label
-              class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+              class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
               data-testid="FormLabel"
               for="senderAddress"
             >
@@ -238,7 +238,7 @@ exports[`UsernameRegistrationForm > should render form step 1`] = `
             class="[&:focus-within_.FormLabel]:text-theme-primary-600 dark:[&:focus-within_.FormLabel]:text-theme-primary-500 flex min-w-0 flex-col"
           >
             <label
-              class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+              class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
               data-testid="FormLabel"
               for="username"
             >
@@ -459,7 +459,7 @@ exports[`UsernameRegistrationForm > should render review step 1`] = `
               class="[&:focus-within_.FormLabel]:text-theme-primary-600 dark:[&:focus-within_.FormLabel]:text-theme-primary-500 flex min-w-0 flex-col"
             >
               <label
-                class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+                class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
                 data-testid="FormLabel"
                 for="fee"
               >

--- a/src/domains/transaction/components/ValidatorRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/FormStep.tsx
@@ -57,7 +57,7 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 			{errors.lockedFee && <Alert className="mb-4">{errors.lockedFee.message}</Alert>}
 
 			<FormField name="senderAddress">
-				<FormLabel label={t("COMMON.SENDER")} />
+				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SENDER")} />
 
 				<SelectAddressDropdown
 					disabled={profile.wallets().count() === 0}
@@ -76,7 +76,7 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 			<div className="mt-3 space-y-4 sm:mt-4">
 				<FormField name="validatorPublicKey">
 					<div className="flex flex-1 flex-row justify-between">
-						<FormLabel label={t("TRANSACTION.VALIDATOR_PUBLIC_KEY")} />
+						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.VALIDATOR_PUBLIC_KEY")} />
 						<Link
 							isExternal
 							to="https://docs.mainsailhq.com/mainsail/deployment/becoming-a-validator"

--- a/src/domains/transaction/components/ValidatorRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/FormStep.tsx
@@ -57,7 +57,10 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 			{errors.lockedFee && <Alert className="mb-4">{errors.lockedFee.message}</Alert>}
 
 			<FormField name="senderAddress">
-				<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("COMMON.SENDER")} />
+				<FormLabel
+					textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+					label={t("COMMON.SENDER")}
+				/>
 
 				<SelectAddressDropdown
 					disabled={profile.wallets().count() === 0}
@@ -76,7 +79,10 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 			<div className="mt-3 space-y-4 sm:mt-4">
 				<FormField name="validatorPublicKey">
 					<div className="flex flex-1 flex-row justify-between">
-						<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.VALIDATOR_PUBLIC_KEY")} />
+						<FormLabel
+							textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+							label={t("TRANSACTION.VALIDATOR_PUBLIC_KEY")}
+						/>
 						<Link
 							isExternal
 							to="https://docs.mainsailhq.com/mainsail/deployment/becoming-a-validator"

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ReviewStep.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ReviewStep.tsx
@@ -127,7 +127,10 @@ export const ReviewStep = ({
 				<div data-testid="DetailWrapper">
 					<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 						<FormField name="fee">
-							<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
+							<FormLabel
+								textClassName="text-sm leading-[17px] sm:text-base sm:leading-5"
+								label={t("TRANSACTION.TRANSACTION_FEE")}
+							/>
 							<FeeField
 								type={wallet.isValidator() ? "updateValidator" : "validatorRegistration"}
 								data={feeTransactionData}

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ReviewStep.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ReviewStep.tsx
@@ -127,7 +127,7 @@ export const ReviewStep = ({
 				<div data-testid="DetailWrapper">
 					<div className="border-theme-secondary-300 dark:border-theme-dark-700 dim:border-theme-dim-700 border-t px-3 pt-6 sm:border-none sm:px-0 sm:pt-0">
 						<FormField name="fee">
-							<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+							<FormLabel textClassName="text-sm leading-[17px] sm:text-base sm:leading-5" label={t("TRANSACTION.TRANSACTION_FEE")} />
 							<FeeField
 								type={wallet.isValidator() ? "updateValidator" : "validatorRegistration"}
 								data={feeTransactionData}

--- a/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ReviewStep.test.tsx.snap
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ReviewStep.test.tsx.snap
@@ -277,7 +277,7 @@ exports[`ReviewStep > should render review step 1`] = `
             class="[&:focus-within_.FormLabel]:text-theme-primary-600 dark:[&:focus-within_.FormLabel]:text-theme-primary-500 flex min-w-0 flex-col"
           >
             <label
-              class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+              class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
               data-testid="FormLabel"
               for="fee"
             >

--- a/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ValidatorRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ValidatorRegistrationForm.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`ValidatorRegistrationForm > should render form step 1`] = `
           class="[&:focus-within_.FormLabel]:text-theme-primary-600 dark:[&:focus-within_.FormLabel]:text-theme-primary-500 flex min-w-0 flex-col"
         >
           <label
-            class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+            class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
             data-testid="FormLabel"
             for="senderAddress"
           >
@@ -187,7 +187,7 @@ exports[`ValidatorRegistrationForm > should render form step 1`] = `
               class="flex flex-1 flex-row justify-between"
             >
               <label
-                class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+                class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
                 data-testid="FormLabel"
                 for="validatorPublicKey"
               >
@@ -557,7 +557,7 @@ exports[`ValidatorRegistrationForm > should render review step 1`] = `
                 class="[&:focus-within_.FormLabel]:text-theme-primary-600 dark:[&:focus-within_.FormLabel]:text-theme-primary-500 flex min-w-0 flex-col"
               >
                 <label
-                  class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm"
+                  class="FormLabel text-theme-secondary-text hover:text-theme-primary-600! mb-2 flex leading-[17px] font-semibold transition-colors duration-100 text-sm leading-[17px] sm:text-base sm:leading-5"
                   data-testid="FormLabel"
                   for="fee"
                 >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86e12befd

This PR fixes input label to have:

- `font-size:16px` and `line-height:20px` on screen with >= sm
- `font-size:14px` and `line-height:17px` on screen with < sm

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
