### PR TITLE
fix: validation issue with multi-payment sending

### DIFF
--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -369,10 +369,9 @@ export const AddRecipient = ({
 									const tokenAddress = value;
 									const token = tokens.find((token) => token.token().address() === tokenAddress);
 
-									setValue("amount", amount, {
-										shouldDirty: !!token,
-										shouldValidate: !!dirtyFields.amount,
-									});
+									if (amount) {
+										void trigger("amount");
+									}
 
 									setValue("tokenContractAddress", tokenAddress, {
 										shouldDirty: true,
@@ -455,10 +454,9 @@ export const AddRecipient = ({
 										const tokenAddress = value;
 										const token = tokens.find((token) => token.token().address() === tokenAddress);
 
-										setValue("amount", amount, {
-											shouldDirty: !!token,
-											shouldValidate: !!dirtyFields.amount,
-										});
+										if (amount) {
+											void trigger("amount");
+										}
 
 										setValue("tokenContractAddress", tokenAddress, {
 											shouldDirty: true,

--- a/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
+++ b/src/domains/transaction/components/AddRecipient/AddRecipient.tsx
@@ -73,7 +73,7 @@ export const AddRecipient = ({
 		watch,
 		trigger,
 		clearErrors,
-		formState: { errors, dirtyFields },
+		formState: { errors },
 	} = useFormContext();
 	const {
 		network,

--- a/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
@@ -62,9 +62,9 @@ export const FormStep = ({
 	// We keep the current form values but clear "dirty" flags to avoid triggering
 	// unintended validations (notably in AddRecipient, where a previously edited
 	// amount field would otherwise validate on entry to this step).
-	useEffect(() => {
-		reset(getValues());
-	}, []);
+	// useEffect(() => {
+	// 	reset(getValues());
+	// }, []);
 
 	return (
 		<section data-testid="SendTransfer__form-step">

--- a/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
@@ -35,7 +35,7 @@ export const FormStep = ({
 }) => {
 	const { t } = useTranslation();
 
-	const { setValue, getValues, unregister, reset } = useFormContext();
+	const { setValue, getValues, unregister } = useFormContext();
 
 	const { activeNetwork } = useActiveNetwork({ profile });
 
@@ -57,14 +57,6 @@ export const FormStep = ({
 			sender,
 		});
 	};
-
-	// Reset dirty state when this step is mounted (e.g., after navigating from a previous step).
-	// We keep the current form values but clear "dirty" flags to avoid triggering
-	// unintended validations (notably in AddRecipient, where a previously edited
-	// amount field would otherwise validate on entry to this step).
-	// useEffect(() => {
-	// 	reset(getValues());
-	// }, []);
 
 	return (
 		<section data-testid="SendTransfer__form-step">

--- a/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
+++ b/src/domains/transaction/components/SendTransferSidePanel/FormStep.tsx
@@ -35,7 +35,7 @@ export const FormStep = ({
 }) => {
 	const { t } = useTranslation();
 
-	const { setValue, getValues, unregister } = useFormContext();
+	const { setValue, getValues, unregister, reset } = useFormContext();
 
 	const { activeNetwork } = useActiveNetwork({ profile });
 
@@ -57,6 +57,14 @@ export const FormStep = ({
 			sender,
 		});
 	};
+
+	// Reset dirty state when this step is mounted (e.g., after navigating from a previous step).
+	// We keep the current form values but clear "dirty" flags to avoid triggering
+	// unintended validations (notably in AddRecipient, where a previously edited
+	// amount field would otherwise validate on entry to this step).
+	useEffect(() => {
+		reset(getValues());
+	}, []);
 
 	return (
 		<section data-testid="SendTransfer__form-step">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86e12apxm

This PR fixes validation issue when sending multi-payment transaction. The video recording includes checks to ensure it still validates amount when a different token selected.

[Screencast from 2026-04-28 18-22-33.webm](https://github.com/user-attachments/assets/9a4346e5-933a-4927-9e73-9a20b8a49df7)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
