### PR TITLE
fix: delete token modal balance overflow issue

### DIFF
--- a/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
+++ b/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
@@ -36,14 +36,18 @@ export const DeleteTokenConfirmationModal = ({ walletToken, onClose, onDelete }:
 
 							<div className="flex items-center space-x-2">
 								<TokenNameInitials tokenName={walletToken.token().name()} />
-								<div className="font-semibold text-sm leading-[17px] sm:leading-5 sm:text-base">{walletToken.token().name()}</div>
+								<div className="text-sm leading-[17px] font-semibold sm:text-base sm:leading-5">
+									{walletToken.token().name()}
+								</div>
 							</div>
 						</div>
 
 						<div className="flex items-center justify-between space-x-2 sm:justify-start sm:space-x-0">
 							<DetailTitle className="w-auto sm:min-w-24 sm:pr-6">{t("COMMON.SYMBOL")}</DetailTitle>
 
-							<div className="font-semibold text-sm leading-[17px] sm:leading-5 sm:text-base">{walletToken.token().symbol()}</div>
+							<div className="text-sm leading-[17px] font-semibold sm:text-base sm:leading-5">
+								{walletToken.token().symbol()}
+							</div>
 						</div>
 
 						<div className="flex justify-between space-x-2 sm:justify-start sm:space-x-0 md:items-center">

--- a/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
+++ b/src/domains/tokens/components/DeleteTokenConfirmationModal/DeleteTokenConfirmationModal.tsx
@@ -36,14 +36,14 @@ export const DeleteTokenConfirmationModal = ({ walletToken, onClose, onDelete }:
 
 							<div className="flex items-center space-x-2">
 								<TokenNameInitials tokenName={walletToken.token().name()} />
-								<div className="font-semibold">{walletToken.token().name()}</div>
+								<div className="font-semibold text-sm leading-[17px] sm:leading-5 sm:text-base">{walletToken.token().name()}</div>
 							</div>
 						</div>
 
 						<div className="flex items-center justify-between space-x-2 sm:justify-start sm:space-x-0">
 							<DetailTitle className="w-auto sm:min-w-24 sm:pr-6">{t("COMMON.SYMBOL")}</DetailTitle>
 
-							<div className="font-semibold">{walletToken.token().symbol()}</div>
+							<div className="font-semibold text-sm leading-[17px] sm:leading-5 sm:text-base">{walletToken.token().symbol()}</div>
 						</div>
 
 						<div className="flex justify-between space-x-2 sm:justify-start sm:space-x-0 md:items-center">
@@ -82,7 +82,7 @@ export const DeleteTokenConfirmationModal = ({ walletToken, onClose, onDelete }:
 								decimals={walletToken.token().decimals()}
 								ticker={walletToken.token().displaySymbol()}
 								value={walletToken.balance()}
-								className="font-semibold"
+								className="text-sm leading-[17px] font-semibold break-all whitespace-normal sm:text-base sm:leading-5"
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes: https://app.clickup.com/t/86e14tu2n

Contract for testing: `0xac2865629a820e18f3af48659f935cbcd5a9a4b4`


Fixes balance overflow issue in delete token confirmation modal:

<img width="676" height="684" alt="image" src="https://github.com/user-attachments/assets/208150ea-22b8-4125-b3da-48f227f16103" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
