### PR TITLE
refactor: add `isLegacyColdWallet` property

### DIFF
--- a/src/app/lib/mainsail/contracts.ts
+++ b/src/app/lib/mainsail/contracts.ts
@@ -28,6 +28,8 @@ export interface WalletData {
 
 	nonce(): BigNumber;
 
+	legacyNonce(): BigNumber;
+
 	// Second Signature
 	secondPublicKey(): string | undefined;
 

--- a/src/app/lib/mainsail/legacy-address.service.ts
+++ b/src/app/lib/mainsail/legacy-address.service.ts
@@ -5,7 +5,7 @@ import { abort_if, abort_unless } from "@/app/lib/helpers";
 
 export class LegacyAddressService {
 	public fromMnemonic(mnemonic: string, pubKeyHash: number): Services.AddressDataTransferObject {
-		// abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
+		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			address: LegacyAddress.fromPassphrase(mnemonic, pubKeyHash),

--- a/src/app/lib/mainsail/legacy-address.service.ts
+++ b/src/app/lib/mainsail/legacy-address.service.ts
@@ -5,7 +5,7 @@ import { abort_if, abort_unless } from "@/app/lib/helpers";
 
 export class LegacyAddressService {
 	public fromMnemonic(mnemonic: string, pubKeyHash: number): Services.AddressDataTransferObject {
-		abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
+		// abort_unless(BIP39.compatible(mnemonic), "The given value is not BIP39 compliant.");
 
 		return {
 			address: LegacyAddress.fromPassphrase(mnemonic, pubKeyHash),

--- a/src/app/lib/mainsail/wallet.dto.test.ts
+++ b/src/app/lib/mainsail/wallet.dto.test.ts
@@ -100,6 +100,24 @@ describe("WalletData", () => {
 		});
 	});
 
+	describe("legacyNonce", () => {
+		it("should return `legacyNonce` as BigNumber", () => {
+			walletData.fill({ address: "test-address", attributes: { legacyNonce: "5" } });
+			const nonce = walletData.legacyNonce();
+
+			expect(nonce).toBeInstanceOf(BigNumber);
+			expect(nonce.toHuman()).toBe(5);
+		});
+
+		it("should handle undefined nonce", () => {
+			walletData.fill({ address: "test-address" });
+			const nonce = walletData.legacyNonce();
+
+			expect(nonce).toBeInstanceOf(BigNumber);
+			expect(nonce.toHuman()).toBe(0);
+		});
+	});
+
 	describe("nested properties", () => {
 		it("should get secondPublicKey from root level", () => {
 			walletData.fill({ address: "test-address", secondPublicKey: "test-second-key" });

--- a/src/app/lib/mainsail/wallet.dto.ts
+++ b/src/app/lib/mainsail/wallet.dto.ts
@@ -49,6 +49,10 @@ export class WalletData {
 		return BigNumber.make(this.data.nonce ?? 0);
 	}
 
+	public legacyNonce(): BigNumber {
+		return BigNumber.make(this.#getProperty(["attributes.legacyNonce"]) ?? 0);
+	}
+
 	public secondPublicKey(): string | undefined {
 		return this.#getProperty(["secondPublicKey", "attributes.secondPublicKey"]);
 	}

--- a/src/app/lib/profiles/serialiser.ts
+++ b/src/app/lib/profiles/serialiser.ts
@@ -48,6 +48,7 @@ export class WalletSerialiser {
 				[WalletData.LedgerModel]: this.#wallet.data().get(WalletData.LedgerModel),
 				[WalletData.Status]: this.#wallet.data().get(WalletData.Status),
 				[WalletData.IsPrimary]: this.#wallet.data().get(WalletData.IsPrimary, false),
+				[WalletData.IsLegacyColdWallet]: this.#wallet.data().get(WalletData.IsLegacyColdWallet, false),
 				[WalletData.AddressIndex]: this.#wallet.data().get(WalletData.AddressIndex),
 				[WalletData.TokenCount]: this.#wallet.tokenCount(),
 				[WalletData.LegacyAddress]: this.#wallet.legacyAddress(),

--- a/src/app/lib/profiles/serializers.test.ts
+++ b/src/app/lib/profiles/serializers.test.ts
@@ -35,6 +35,7 @@ describe("WalletSerialiser", () => {
 			    "ENCRYPTED_CONFIRM_KEY": undefined,
 			    "ENCRYPTED_SIGNING_KEY": undefined,
 			    "IMPORT_METHOD": "BIP39.MNEMONIC",
+			    "IS_LEGACY_COLD_WALLET": false,
 			    "IS_PRIMARY": false,
 			    "LEDGER_MODEL": undefined,
 			    "LEGACY_ADDRESS": undefined,

--- a/src/app/lib/profiles/wallet.contract.ts
+++ b/src/app/lib/profiles/wallet.contract.ts
@@ -212,6 +212,14 @@ export interface IReadWriteWallet {
 	nonce(): BigNumber;
 
 	/**
+	 * Get the legacy nonce.
+	 *
+	 * @return {BigNumber}
+	 * @memberof IReadWriteWallet
+	 */
+	legacyNonce(): BigNumber;
+
+	/**
 	 * Get the avatar.
 	 *
 	 * @return {string}

--- a/src/app/lib/profiles/wallet.contract.ts
+++ b/src/app/lib/profiles/wallet.contract.ts
@@ -414,6 +414,14 @@ export interface IReadWriteWallet {
 	isCold(): boolean;
 
 	/**
+	 * Determine if the wallet is a legacy cold wallet.
+	 *
+	 * @return {boolean}
+	 * @memberof IReadWriteWallet
+	 */
+	isLegacyCold(): boolean;
+
+	/**
 	 * Toggle the starred state.
 	 *
 	 * @memberof IReadWriteWallet

--- a/src/app/lib/profiles/wallet.enum.ts
+++ b/src/app/lib/profiles/wallet.enum.ts
@@ -28,6 +28,7 @@ export enum WalletData {
 	LedgerModel = "LEDGER_MODEL",
 	Status = "STATUS",
 	IsPrimary = "IS_PRIMARY",
+	IsLegacyColdWallet = "IS_LEGACY_COLD_WALLET",
 	AddressIndex = "ADDRESS_INDEX",
 	TokenCount = "TOKEN_COUNT",
 	LegacyAddress = "LEGACY_ADDRESS",

--- a/src/app/lib/profiles/wallet.synchroniser.ts
+++ b/src/app/lib/profiles/wallet.synchroniser.ts
@@ -1,6 +1,6 @@
 import { Contracts, Services } from "@/app/lib/mainsail";
 
-import { IReadWriteWallet, IWalletSynchroniser, WalletData, WalletFlag } from "./contracts.js";
+import { IReadWriteWallet, IWalletSynchroniser, WalletData } from "./contracts.js";
 import { WalletIdentifierFactory } from "./wallet.identifier.factory.js";
 import { WalletData as WalletDataDto } from "@/app/lib/mainsail/wallet.dto";
 

--- a/src/app/lib/profiles/wallet.synchroniser.ts
+++ b/src/app/lib/profiles/wallet.synchroniser.ts
@@ -1,6 +1,6 @@
 import { Contracts, Services } from "@/app/lib/mainsail";
 
-import { IReadWriteWallet, IWalletSynchroniser, WalletData } from "./contracts.js";
+import { IReadWriteWallet, IWalletSynchroniser, WalletData, WalletFlag } from "./contracts.js";
 import { WalletIdentifierFactory } from "./wallet.identifier.factory.js";
 import { WalletData as WalletDataDto } from "@/app/lib/mainsail/wallet.dto";
 
@@ -20,10 +20,6 @@ export class WalletSynchroniser implements IWalletSynchroniser {
 
 		try {
 			const wallet: Contracts.WalletData = await this.#wallet.client().wallet(walletIdentifier);
-
-			// Clear legacy attributes — they only apply to cold wallets tha don't exist on chain (see legacyIdentity below).
-			wallet.setAttribute("attributes.isLegacy", false);
-			wallet.setAttribute("attributes.legacyNonce", undefined);
 
 			this.#wallet.getAttributes().set("wallet", wallet);
 
@@ -46,6 +42,7 @@ export class WalletSynchroniser implements IWalletSynchroniser {
 
 					this.#wallet.getAttributes().set("wallet", legacyWalletData);
 					this.#wallet.data().set(WalletData.Balance, legacyWalletData.balance());
+					this.#wallet.data().set(WalletData.IsLegacyColdWallet, true);
 				}
 			}
 

--- a/src/app/lib/profiles/wallet.test.ts
+++ b/src/app/lib/profiles/wallet.test.ts
@@ -180,6 +180,16 @@ describe("Wallet", () => {
 		expect(wallet.nonce()).toEqual(BigNumber.ZERO);
 	});
 
+	it("should have a legacy nonce", () => {
+		const result = wallet.legacyNonce();
+		expect(result).toBeInstanceOf(BigNumber);
+	});
+
+	it("should return zero `legacyNonce` when undefined", () => {
+		vi.spyOn(wallet.data(), "get").mockReturnValue(undefined);
+		expect(wallet.legacyNonce()).toEqual(BigNumber.ZERO);
+	});
+
 	it("should have an avatar", () => {
 		const result = wallet.avatar();
 		expect(result).toBeDefined();

--- a/src/app/lib/profiles/wallet.test.ts
+++ b/src/app/lib/profiles/wallet.test.ts
@@ -455,6 +455,12 @@ describe("Wallet", () => {
 		spy.mockRestore();
 	});
 
+	it("should check if is legacy cold wallet", () => {
+		const spy = vi.spyOn(wallet.data(), "get").mockReturnValue(true);
+		expect(wallet.isLegacyCold()).toBe(true);
+		spy.mockRestore();
+	});
+
 	it("should toggle starred", () => {
 		const setSpy = vi.spyOn(wallet.data(), "set");
 		const statusSpy = vi.spyOn(profile.status(), "markAsDirty");

--- a/src/app/lib/profiles/wallet.ts
+++ b/src/app/lib/profiles/wallet.ts
@@ -405,6 +405,11 @@ export class Wallet implements IReadWriteWallet {
 		return this.data().get(WalletData.Status) === WalletFlag.Cold;
 	}
 
+	/** {@inheritDoc IReadWriteWallet.isLegacyCold} */
+	public isLegacyCold(): boolean {
+		return this.data().get(WalletData.IsLegacyColdWallet) === true;
+	}
+
 	/** {@inheritDoc IReadWriteWallet.toggleStarred} */
 	public toggleStarred(): void {
 		this.data().set(WalletFlag.Starred, !this.isStarred());

--- a/src/app/lib/profiles/wallet.ts
+++ b/src/app/lib/profiles/wallet.ts
@@ -214,6 +214,12 @@ export class Wallet implements IReadWriteWallet {
 		return BigNumber.make(value, this.#decimals());
 	}
 
+	/** {@inheritDoc IReadWriteWallet.legacyNonce} */
+	public legacyNonce(): BigNumber {
+		const value = this.#attributes.get<Contracts.WalletData>("wallet").legacyNonce();
+		return BigNumber.make(value, this.#decimals());
+	}
+
 	/** {@inheritDoc IReadWriteWallet.avatar} */
 	public avatar(): string {
 		const value: string | undefined = this.data().get(WalletSetting.Avatar);

--- a/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
@@ -73,9 +73,7 @@ export const signContractDeployment = async ({ env, form, profile, signatory }: 
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.isLegacyCold()
-			? senderWallet.legacyNonce()
-			: undefined,
+		nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
@@ -73,7 +73,7 @@ export const signContractDeployment = async ({ env, form, profile, signatory }: 
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce"),
+		nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
@@ -74,7 +74,7 @@ export const signContractDeployment = async ({ env, form, profile, signatory }: 
 		gasLimit,
 		gasPrice,
 		nonce: senderWallet.isLegacyCold()
-			? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+			? senderWallet.legacyNonce()
 			: undefined,
 		signatory,
 	});

--- a/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
@@ -73,7 +73,7 @@ export const signContractDeployment = async ({ env, form, profile, signatory }: 
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
+		nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce().toFixed(0) : undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
+++ b/src/domains/transaction/components/ContractDeploymentForm/ContractDeploymentForm.tsx
@@ -73,7 +73,9 @@ export const signContractDeployment = async ({ env, form, profile, signatory }: 
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
+		nonce: senderWallet.isLegacyCold()
+			? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+			: undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.test.tsx
@@ -235,7 +235,6 @@ describe("SendUsernameResignationSidePanel", () => {
 				expect.objectContaining({
 					gasLimit: expect.any(BigNumber),
 					gasPrice: expect.any(BigNumber),
-					nonce: undefined,
 					signatory: expect.any(Object),
 				}),
 			);
@@ -356,6 +355,83 @@ describe("SendUsernameResignationSidePanel", () => {
 
 		// Close the side panel
 		await userEvent.click(screen.getByTestId("SendUsernameResignation__close-button"));
+	});
+
+	it("should not call `legacyNonce` when wallet is not a legacy cold wallet", async () => {
+		const isLegacyColdSpy = vi.spyOn(wallet, "isLegacyCold").mockReturnValue(false);
+		const legacyNonceSpy = vi.spyOn(wallet, "legacyNonce").mockReturnValue(BigNumber.make(1));
+
+		vi.spyOn(wallet, "client").mockImplementation(() => ({
+			transaction: vi.fn().mockReturnValue(signedTransactionMock),
+		}));
+
+		await renderPanel();
+
+		// Step 1 - Form step
+		await expect(formStep()).resolves.toBeVisible();
+
+		await waitFor(() => expect(continueButton()).toBeEnabled());
+
+		// Navigate to review step with Enter key
+		await userEvent.keyboard("{enter}");
+
+		await expect(screen.findByTestId(reviewStepID)).resolves.toBeVisible();
+
+		// Navigate back to form step
+		await userEvent.click(screen.getByTestId(backButtonTestId));
+		await expect(formStep()).resolves.toBeVisible();
+
+		// Continue to review step again
+		await waitFor(() => expect(continueButton()).toBeEnabled());
+		await userEvent.click(continueButton());
+
+		await expect(screen.findByTestId(reviewStepID)).resolves.toBeVisible();
+
+		// Continue to authentication step
+		await userEvent.click(continueButton());
+
+		await expect(screen.findByTestId("AuthenticationStep")).resolves.toBeVisible();
+
+		// Enter mnemonic and submit
+		const passwordInput = screen.getByTestId("AuthenticationStep__mnemonic");
+		await userEvent.type(passwordInput, passphrase);
+		await waitFor(() => expect(passwordInput).toHaveValue(passphrase));
+
+		await waitFor(() => expect(sendButton()).toBeEnabled());
+
+		const signMock = vi
+			.spyOn(wallet.transaction(), "signUsernameResignation")
+			.mockReturnValue(Promise.resolve(UsernameResignationFixture.data.hash));
+		const broadcastMock = vi.spyOn(wallet.transaction(), "broadcast").mockResolvedValue({
+			accepted: [UsernameResignationFixture.data.hash],
+			errors: {},
+			rejected: [],
+		});
+		const transactionMock = createUsernameResignationMock(wallet);
+
+		await userEvent.click(sendButton());
+
+		expect(isLegacyColdSpy).toHaveBeenCalled();
+		expect(legacyNonceSpy).not.toHaveBeenCalled();
+
+		await waitFor(() => {
+			expect(signMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					gasLimit: expect.any(BigNumber),
+					gasPrice: expect.any(BigNumber),
+					nonce: undefined,
+					signatory: expect.any(Object),
+				}),
+			);
+		});
+
+		await waitFor(() => expect(broadcastMock).toHaveBeenCalledWith(UsernameResignationFixture.data.hash));
+		await waitFor(() => expect(transactionMock).toHaveBeenCalledWith(UsernameResignationFixture.data.hash));
+
+		signMock.mockRestore();
+		broadcastMock.mockRestore();
+		transactionMock.mockRestore();
+		legacyNonceSpy.mockRestore();
 	});
 
 	it("should handle on change with undefined wallet selection", async () => {

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.test.tsx
@@ -235,6 +235,7 @@ describe("SendUsernameResignationSidePanel", () => {
 				expect.objectContaining({
 					gasLimit: expect.any(BigNumber),
 					gasPrice: expect.any(BigNumber),
+					nonce: undefined,
 					signatory: expect.any(Object),
 				}),
 			);
@@ -319,6 +320,9 @@ describe("SendUsernameResignationSidePanel", () => {
 		const transactionMock = createUsernameResignationMock(wallet);
 
 		await userEvent.click(sendButton());
+
+		expect(legacyNonceSpy).toHaveBeenCalled();
+		expect(isLegacyColdSpy).toHaveBeenCalled();
 
 		await waitFor(() => {
 			expect(signMock).toHaveBeenCalledWith(

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.test.tsx
@@ -134,8 +134,6 @@ describe("SendUsernameResignationSidePanel", () => {
 			.wallets()
 			.findByAddressWithNetwork("0xcd15953dD076e56Dc6a5bc46Da23308Ff3158EE6", "mainsail.devnet")!;
 
-		vi.spyOn(wallet, "isValidator").mockImplementation(() => true);
-
 		vi.spyOn(PublicKeyService.prototype, "verifyPublicKeyWithBLS").mockReturnValue(true);
 
 		await wallet.synchroniser().identity();
@@ -266,6 +264,94 @@ describe("SendUsernameResignationSidePanel", () => {
 		findWalletMock.mockRestore();
 		syncedWithNetworkMock.mockRestore();
 		fullyRestoredMock.mockRestore();
+	});
+
+	it("should pass `legacyNonce` when wallet is a legacy cold wallet", async () => {
+		const isLegacyColdSpy = vi.spyOn(wallet, "isLegacyCold").mockReturnValue(true);
+		const legacyNonceSpy = vi.spyOn(wallet, "legacyNonce").mockReturnValue(BigNumber.make(1));
+
+		vi.spyOn(wallet, "client").mockImplementation(() => ({
+			transaction: vi.fn().mockReturnValue(signedTransactionMock),
+		}));
+
+		await renderPanel();
+
+		// Step 1 - Form step
+		await expect(formStep()).resolves.toBeVisible();
+
+		await waitFor(() => expect(continueButton()).toBeEnabled());
+
+		// Navigate to review step with Enter key
+		await userEvent.keyboard("{enter}");
+
+		await expect(screen.findByTestId(reviewStepID)).resolves.toBeVisible();
+
+		// Navigate back to form step
+		await userEvent.click(screen.getByTestId(backButtonTestId));
+		await expect(formStep()).resolves.toBeVisible();
+
+		// Continue to review step again
+		await waitFor(() => expect(continueButton()).toBeEnabled());
+		await userEvent.click(continueButton());
+
+		await expect(screen.findByTestId(reviewStepID)).resolves.toBeVisible();
+
+		// Continue to authentication step
+		await userEvent.click(continueButton());
+
+		await expect(screen.findByTestId("AuthenticationStep")).resolves.toBeVisible();
+
+		// Enter mnemonic and submit
+		const passwordInput = screen.getByTestId("AuthenticationStep__mnemonic");
+		await userEvent.type(passwordInput, passphrase);
+		await waitFor(() => expect(passwordInput).toHaveValue(passphrase));
+
+		await waitFor(() => expect(sendButton()).toBeEnabled());
+
+		const signMock = vi
+			.spyOn(wallet.transaction(), "signUsernameResignation")
+			.mockReturnValue(Promise.resolve(UsernameResignationFixture.data.hash));
+		const broadcastMock = vi.spyOn(wallet.transaction(), "broadcast").mockResolvedValue({
+			accepted: [UsernameResignationFixture.data.hash],
+			errors: {},
+			rejected: [],
+		});
+		const transactionMock = createUsernameResignationMock(wallet);
+
+		await userEvent.click(sendButton());
+
+		await waitFor(() => {
+			expect(signMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					gasLimit: expect.any(BigNumber),
+					gasPrice: expect.any(BigNumber),
+					nonce: expect.any(String),
+					signatory: expect.any(Object),
+				}),
+			);
+		});
+
+		await waitFor(() => expect(broadcastMock).toHaveBeenCalledWith(UsernameResignationFixture.data.hash));
+		await waitFor(() => expect(transactionMock).toHaveBeenCalledWith(UsernameResignationFixture.data.hash));
+
+		signMock.mockRestore();
+		broadcastMock.mockRestore();
+		transactionMock.mockRestore();
+		isLegacyColdSpy.mockRestore();
+		legacyNonceSpy.mockRestore();
+
+		await act(() => vi.runOnlyPendingTimers());
+
+		// Step 4 - summary screen
+		await waitFor(
+			() => {
+				expect(screen.getByTestId("TransactionSuccessful")).toBeVisible();
+			},
+			{ timeout: 4000 },
+		);
+
+		// Close the side panel
+		await userEvent.click(screen.getByTestId("SendUsernameResignation__close-button"));
 	});
 
 	it("should handle on change with undefined wallet selection", async () => {

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
@@ -136,9 +136,7 @@ export const SendUsernameResignationSidePanel = ({
 			const signedTransactionId = await activeWallet.transaction().signUsernameResignation({
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold()
-					? activeWallet.legacyNonce()
-					: undefined,
+				nonce: activeWallet.isLegacyCold() ? activeWallet.legacyNonce() : undefined,
 				signatory,
 			});
 

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
@@ -136,7 +136,9 @@ export const SendUsernameResignationSidePanel = ({
 			const signedTransactionId = await activeWallet.transaction().signUsernameResignation({
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold() ? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce") : undefined,
+				nonce: activeWallet.isLegacyCold()
+					? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce")
+					: undefined,
 				signatory,
 			});
 

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
@@ -136,7 +136,7 @@ export const SendUsernameResignationSidePanel = ({
 			const signedTransactionId = await activeWallet.transaction().signUsernameResignation({
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold() ? activeWallet.legacyNonce() : undefined,
+				nonce: activeWallet.isLegacyCold() ? activeWallet.legacyNonce().toFixed(0) : undefined,
 				signatory,
 			});
 

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
@@ -136,7 +136,7 @@ export const SendUsernameResignationSidePanel = ({
 			const signedTransactionId = await activeWallet.transaction().signUsernameResignation({
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce"),
+				nonce: activeWallet.isLegacyCold() ? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce") : undefined,
 				signatory,
 			});
 

--- a/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
+++ b/src/domains/transaction/components/SendUsernameResignationSidePanel/SendUsernameResignationSidePanel.tsx
@@ -137,7 +137,7 @@ export const SendUsernameResignationSidePanel = ({
 				gasLimit,
 				gasPrice,
 				nonce: activeWallet.isLegacyCold()
-					? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce")
+					? activeWallet.legacyNonce()
 					: undefined,
 				signatory,
 			});

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.test.tsx
@@ -350,6 +350,81 @@ describe("SendVote", () => {
 		votingMock.mockRestore();
 	});
 
+	it("should pass `legacyNonce` when wallet is a legacy cold wallet", async () => {
+		const isLegacyColdSpy = vi.spyOn(wallet, "isLegacyCold").mockReturnValue(true);
+		const legacyNonceSpy = vi.spyOn(wallet, "legacyNonce").mockReturnValue(BigNumber.make(1));
+
+		await wallet.synchroniser().votes();
+
+		const voteURL = `/profiles/${fixtureProfileId}/wallets/${wallet.id()}/send-vote`;
+
+		const votes: VoteValidatorProperties[] = [
+			{
+				amount: 10,
+				validatorAddress: validatorData[0].address,
+			},
+		];
+
+		const { router } = render(
+			<Component activeProfile={profile} activeNetwork={wallet.network()} activeWallet={wallet} votes={votes} />,
+			{
+				route: `${voteURL}`,
+			},
+		);
+
+		expect(screen.getByTestId(reviewStepID)).toBeInTheDocument();
+
+		await waitFor(() => expect(screen.getByTestId(reviewStepID)).toHaveTextContent(validatorData[0].address));
+
+		expect(screen.getAllByRole("radio")[1]).toBeChecked();
+
+		await waitFor(() => expect(continueButton()).not.toBeDisabled());
+		await userEvent.click(continueButton());
+
+		// AuthenticationStep
+		expect(screen.getByTestId(authenticationStepID)).toBeInTheDocument();
+
+		const signVoteMock = vi
+			.spyOn(wallet.transaction(), "signVote")
+			.mockReturnValue(Promise.resolve(transactionFixture.data.id));
+		const broadcastVoteMock = vi
+			.spyOn(wallet.transaction(), "broadcast")
+			.mockResolvedValue({ accepted: [transactionFixture.data.id], errors: {}, rejected: [] });
+		const transactionVoteMock = createVoteTransactionMock(wallet);
+
+		const passwordInput = screen.getByTestId("AuthenticationStep__mnemonic");
+		await userEvent.clear(passwordInput);
+		await userEvent.type(passwordInput, passphrase);
+
+		expect(passwordInput).toHaveValue(passphrase);
+
+		await waitFor(() => expect(sendButton()).not.toBeDisabled());
+
+		await act(async () => {
+			await userEvent.click(sendButton());
+		});
+
+		expect(legacyNonceSpy).toHaveBeenCalled();
+		expect(isLegacyColdSpy).toHaveBeenCalled();
+
+		await waitFor(() => {
+			expect(signVoteMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					gasLimit: expect.any(BigNumber),
+					gasPrice: expect.any(BigNumber),
+					nonce: expect.any(String),
+					signatory: expect.any(Object),
+				}),
+			);
+		});
+
+		signVoteMock.mockRestore();
+		broadcastVoteMock.mockRestore();
+		transactionVoteMock.mockRestore();
+		isLegacyColdSpy.mockRestore();
+		legacyNonceSpy.mockRestore();
+	});
+
 	it("should send a unvote & vote transaction and use split voting method", async () => {
 		const votesMock = vi.spyOn(wallet.voting(), "current").mockImplementation(votingMockImplementation);
 

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.test.tsx
@@ -365,7 +365,8 @@ describe("SendVote", () => {
 			},
 		];
 
-		const { router } = render(
+		
+		render(
 			<Component activeProfile={profile} activeNetwork={wallet.network()} activeWallet={wallet} votes={votes} />,
 			{
 				route: `${voteURL}`,

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.test.tsx
@@ -365,7 +365,6 @@ describe("SendVote", () => {
 			},
 		];
 
-		
 		render(
 			<Component activeProfile={profile} activeNetwork={wallet.network()} activeWallet={wallet} votes={votes} />,
 			{

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
@@ -305,7 +305,9 @@ export const SendVoteSidePanel = ({ open, onOpenChange }: { open: boolean; onOpe
 			const voteTransactionInput: Services.TransactionInput = {
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold() ? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce") : undefined,
+				nonce: activeWallet.isLegacyCold()
+					? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce")
+					: undefined,
 				signatory,
 			};
 

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
@@ -305,7 +305,7 @@ export const SendVoteSidePanel = ({ open, onOpenChange }: { open: boolean; onOpe
 			const voteTransactionInput: Services.TransactionInput = {
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce"),
+				nonce: activeWallet.isLegacyCold() ? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce") : undefined,
 				signatory,
 			};
 

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
@@ -306,7 +306,7 @@ export const SendVoteSidePanel = ({ open, onOpenChange }: { open: boolean; onOpe
 				gasLimit,
 				gasPrice,
 				nonce: activeWallet.isLegacyCold()
-					? activeWallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce")
+					? activewallet.legacyNonce()
 					: undefined,
 				signatory,
 			};

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
@@ -305,7 +305,7 @@ export const SendVoteSidePanel = ({ open, onOpenChange }: { open: boolean; onOpe
 			const voteTransactionInput: Services.TransactionInput = {
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold() ? activewallet.legacyNonce() : undefined,
+				nonce: activeWallet.isLegacyCold() ? activewallet.legacyNonce().toFixed(0) : undefined,
 				signatory,
 			};
 

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
@@ -305,7 +305,7 @@ export const SendVoteSidePanel = ({ open, onOpenChange }: { open: boolean; onOpe
 			const voteTransactionInput: Services.TransactionInput = {
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold() ? activewallet.legacyNonce().toFixed(0) : undefined,
+				nonce: activeWallet.isLegacyCold() ? activeWallet.legacyNonce().toFixed(0) : undefined,
 				signatory,
 			};
 

--- a/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
+++ b/src/domains/transaction/components/SendVoteSidePanel/SendVoteSidePanel.tsx
@@ -305,9 +305,7 @@ export const SendVoteSidePanel = ({ open, onOpenChange }: { open: boolean; onOpe
 			const voteTransactionInput: Services.TransactionInput = {
 				gasLimit,
 				gasPrice,
-				nonce: activeWallet.isLegacyCold()
-					? activewallet.legacyNonce()
-					: undefined,
+				nonce: activeWallet.isLegacyCold() ? activewallet.legacyNonce() : undefined,
 				signatory,
 			};
 

--- a/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.test.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.test.tsx
@@ -1,4 +1,5 @@
 import { Contracts } from "@/app/lib/profiles";
+import { BigNumber } from "@/app/lib/helpers";
 import userEvent from "@testing-library/user-event";
 import React, { useEffect } from "react";
 import { FormProvider, useForm, UseFormMethods } from "react-hook-form";
@@ -259,6 +260,47 @@ describe("UsernameRegistrationForm", () => {
 		transactionMock.mockRestore();
 		walletUsesWIFMock.mockRestore();
 		walletWifMock.mockRestore();
+	});
+
+	it("should pass `legacyNonce` when wallet is a legacy cold wallet", async () => {
+		const isLegacyColdSpy = vi.spyOn(wallet, "isLegacyCold").mockReturnValue(true);
+		const legacyNonceSpy = vi.spyOn(wallet, "legacyNonce").mockReturnValue(BigNumber.make(1));
+
+		const form = {
+			clearErrors: vi.fn(),
+			getValues: () => ({
+				gasLimit: "1",
+				gasPrice: "1",
+				mnemonic: MNEMONICS[0],
+				network: wallet.network(),
+				senderAddress: wallet.address(),
+				username: "testuser",
+			}),
+			setError: vi.fn(),
+			setValue: vi.fn(),
+		};
+
+		const signMock = vi
+			.spyOn(wallet.transaction(), "signUsernameRegistration")
+			.mockReturnValue(Promise.resolve(usernameResignationFixture.data.hash));
+		const broadcastMock = vi.spyOn(wallet.transaction(), "broadcast").mockResolvedValue({
+			accepted: [usernameResignationFixture.data.hash],
+			errors: {},
+			rejected: [],
+		});
+		const transactionMock = createTransactionMock(wallet);
+
+		await signUsernameRegistration({ env, form, profile });
+
+		expect(isLegacyColdSpy).toHaveBeenCalled();
+		expect(legacyNonceSpy).toHaveBeenCalled();
+		expect(signMock).toHaveBeenCalledWith(expect.objectContaining({ nonce: "1" }));
+
+		signMock.mockRestore();
+		broadcastMock.mockRestore();
+		transactionMock.mockRestore();
+		isLegacyColdSpy.mockRestore();
+		legacyNonceSpy.mockRestore();
 	});
 
 	it("should set sender address and sync wallet when not fully restored", async () => {

--- a/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
@@ -75,7 +75,7 @@ export const signUsernameRegistration = async ({ env, form, profile, signatory }
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce"),
+		nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
@@ -75,9 +75,7 @@ export const signUsernameRegistration = async ({ env, form, profile, signatory }
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.isLegacyCold()
-			? senderWallet.legacyNonce()
-			: undefined,
+		nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
@@ -76,7 +76,7 @@ export const signUsernameRegistration = async ({ env, form, profile, signatory }
 		gasLimit,
 		gasPrice,
 		nonce: senderWallet.isLegacyCold()
-			? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+			? senderWallet.legacyNonce()
 			: undefined,
 		signatory,
 	});

--- a/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
@@ -75,7 +75,7 @@ export const signUsernameRegistration = async ({ env, form, profile, signatory }
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
+		nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce().toFixed(0) : undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
+++ b/src/domains/transaction/components/UsernameRegistrationForm/UsernameRegistrationForm.tsx
@@ -75,7 +75,9 @@ export const signUsernameRegistration = async ({ env, form, profile, signatory }
 		},
 		gasLimit,
 		gasPrice,
-		nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
+		nonce: senderWallet.isLegacyCold()
+			? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+			: undefined,
 		signatory,
 	});
 

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.test.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.test.tsx
@@ -1,5 +1,6 @@
 import { Contracts } from "@/app/lib/mainsail";
 import { Contracts as ProfilesContracts } from "@/app/lib/profiles";
+import { BigNumber } from "@/app/lib/helpers";
 import userEvent from "@testing-library/user-event";
 import React, { useEffect } from "react";
 import { FormProvider, useForm, UseFormMethods } from "react-hook-form";
@@ -385,6 +386,99 @@ describe("ValidatorRegistrationForm", () => {
 		walletUsesWIFMock.mockRestore();
 		walletWifMock.mockRestore();
 		isValidatorMock.mockRestore();
+	});
+
+	it("should pass `legacyNonce` when wallet is a legacy cold wallet - validator registration", async () => {
+		const isValidatorSpy = vi.spyOn(wallet, "isValidator").mockReturnValue(false);
+		const isLegacyColdSpy = vi.spyOn(wallet, "isLegacyCold").mockReturnValue(true);
+		const legacyNonceSpy = vi.spyOn(wallet, "legacyNonce").mockReturnValue(BigNumber.make(1));
+
+		const getMilestoneMock = vi.spyOn(wallet.network(), "milestone").mockReturnValue({
+			validatorRegistrationFee: 250_000_000_000_000_000_000,
+		});
+
+		const form = {
+			clearErrors: vi.fn(),
+			getValues: () => ({
+				gasLimit: "1",
+				gasPrice: "1",
+				mnemonic: MNEMONICS[0],
+				network: wallet.network(),
+				senderAddress: wallet.address(),
+				validatorPublicKey,
+			}),
+			setError: vi.fn(),
+			setValue: vi.fn(),
+		};
+
+		const signMock = vi
+			.spyOn(wallet.transaction(), "signValidatorRegistration")
+			.mockReturnValue(Promise.resolve(validatorRegistrationFixture.data.hash));
+
+		const broadcastMock = vi.spyOn(wallet.transaction(), "broadcast").mockResolvedValue({
+			accepted: [validatorRegistrationFixture.data.hash],
+			errors: {},
+			rejected: [],
+		});
+
+		const transactionMock = createTransactionMock(wallet);
+
+		await signValidatorRegistration({ env, form, profile });
+
+		expect(isLegacyColdSpy).toHaveBeenCalled();
+		expect(legacyNonceSpy).toHaveBeenCalled();
+		expect(signMock).toHaveBeenCalledWith(expect.objectContaining({ nonce: "1" }));
+
+		signMock.mockRestore();
+		broadcastMock.mockRestore();
+		transactionMock.mockRestore();
+		isLegacyColdSpy.mockRestore();
+		legacyNonceSpy.mockRestore();
+		getMilestoneMock.mockRestore();
+		isValidatorSpy.mockRestore();
+	});
+
+	it("should pass `legacyNonce` when wallet is a legacy cold wallet - update validator", async () => {
+		const isValidatorSpy = vi.spyOn(wallet, "isValidator").mockReturnValue(true);
+		const isLegacyColdSpy = vi.spyOn(wallet, "isLegacyCold").mockReturnValue(true);
+		const legacyNonceSpy = vi.spyOn(wallet, "legacyNonce").mockReturnValue(BigNumber.make(1));
+
+		const form = {
+			clearErrors: vi.fn(),
+			getValues: () => ({
+				gasLimit: "1",
+				gasPrice: "1",
+				mnemonic: MNEMONICS[0],
+				network: wallet.network(),
+				senderAddress: wallet.address(),
+				validatorPublicKey,
+			}),
+			setError: vi.fn(),
+			setValue: vi.fn(),
+		};
+
+		const signUpdateValidatorMock = vi
+			.spyOn(wallet.transaction(), "signUpdateValidator")
+			.mockReturnValue(Promise.resolve(validatorRegistrationFixture.data.hash));
+		const broadcastMock = vi.spyOn(wallet.transaction(), "broadcast").mockResolvedValue({
+			accepted: [validatorRegistrationFixture.data.hash],
+			errors: {},
+			rejected: [],
+		});
+		const transactionMock = createTransactionMock(wallet);
+
+		await signValidatorRegistration({ env, form, profile });
+
+		expect(isLegacyColdSpy).toHaveBeenCalled();
+		expect(legacyNonceSpy).toHaveBeenCalled();
+		expect(signUpdateValidatorMock).toHaveBeenCalledWith(expect.objectContaining({ nonce: "1" }));
+
+		signUpdateValidatorMock.mockRestore();
+		broadcastMock.mockRestore();
+		transactionMock.mockRestore();
+		isValidatorSpy.mockRestore();
+		isLegacyColdSpy.mockRestore();
+		legacyNonceSpy.mockRestore();
 	});
 
 	it("should set sender address and sync wallet if it is not yet fully synced", async () => {

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
@@ -81,7 +81,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			gasLimit,
 			gasPrice,
 			nonce: senderWallet.isLegacyCold()
-				? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+				? senderWallet.legacyNonce()
 				: undefined,
 			signatory,
 		});
@@ -94,7 +94,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			gasLimit,
 			gasPrice,
 			nonce: senderWallet.isLegacyCold()
-				? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+				? senderWallet.legacyNonce()
 				: undefined,
 			signatory,
 		});

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
@@ -80,7 +80,9 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
+			nonce: senderWallet.isLegacyCold()
+				? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+				: undefined,
 			signatory,
 		});
 	} else {
@@ -91,7 +93,9 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
+			nonce: senderWallet.isLegacyCold()
+				? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce")
+				: undefined,
 			signatory,
 		});
 	}

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
@@ -80,7 +80,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce"),
+			nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
 			signatory,
 		});
 	} else {
@@ -91,7 +91,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce"),
+			nonce: senderWallet.isLegacyCold() ? senderWallet.getAttributes().get("wallet.data.attributes.legacyNonce") : undefined,
 			signatory,
 		});
 	}

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
@@ -80,9 +80,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.isLegacyCold()
-				? senderWallet.legacyNonce()
-				: undefined,
+			nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
 			signatory,
 		});
 	} else {
@@ -93,9 +91,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.isLegacyCold()
-				? senderWallet.legacyNonce()
-				: undefined,
+			nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
 			signatory,
 		});
 	}

--- a/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/ValidatorRegistrationForm.tsx
@@ -80,7 +80,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
+			nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce().toFixed(0) : undefined,
 			signatory,
 		});
 	} else {
@@ -91,7 +91,7 @@ export const signValidatorRegistration = async ({ env, form, profile, signatory 
 			},
 			gasLimit,
 			gasPrice,
-			nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce() : undefined,
+			nonce: senderWallet.isLegacyCold() ? senderWallet.legacyNonce().toFixed(0) : undefined,
 			signatory,
 		});
 	}

--- a/src/domains/transaction/hooks/use-send-transfer-form.ts
+++ b/src/domains/transaction/hooks/use-send-transfer-form.ts
@@ -121,7 +121,7 @@ export const useSendTransferForm = ({
 				data,
 				gasLimit,
 				gasPrice,
-				nonce: wallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce"),
+				nonce: wallet.isLegacyCold() ? wallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce") : undefined,
 				signatory,
 				token,
 			};

--- a/src/domains/transaction/hooks/use-send-transfer-form.ts
+++ b/src/domains/transaction/hooks/use-send-transfer-form.ts
@@ -121,9 +121,7 @@ export const useSendTransferForm = ({
 				data,
 				gasLimit,
 				gasPrice,
-				nonce: wallet.isLegacyCold()
-					? wallet.legacyNonce()
-					: undefined,
+				nonce: wallet.isLegacyCold() ? wallet.legacyNonce() : undefined,
 				signatory,
 				token,
 			};

--- a/src/domains/transaction/hooks/use-send-transfer-form.ts
+++ b/src/domains/transaction/hooks/use-send-transfer-form.ts
@@ -122,7 +122,7 @@ export const useSendTransferForm = ({
 				gasLimit,
 				gasPrice,
 				nonce: wallet.isLegacyCold()
-					? wallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce")
+					? wallet.legacyNonce()
 					: undefined,
 				signatory,
 				token,

--- a/src/domains/transaction/hooks/use-send-transfer-form.ts
+++ b/src/domains/transaction/hooks/use-send-transfer-form.ts
@@ -121,7 +121,7 @@ export const useSendTransferForm = ({
 				data,
 				gasLimit,
 				gasPrice,
-				nonce: wallet.isLegacyCold() ? wallet.legacyNonce() : undefined,
+				nonce: wallet.isLegacyCold() ? wallet.legacyNonce().toFixed(0) : undefined,
 				signatory,
 				token,
 			};

--- a/src/domains/transaction/hooks/use-send-transfer-form.ts
+++ b/src/domains/transaction/hooks/use-send-transfer-form.ts
@@ -121,7 +121,9 @@ export const useSendTransferForm = ({
 				data,
 				gasLimit,
 				gasPrice,
-				nonce: wallet.isLegacyCold() ? wallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce") : undefined,
+				nonce: wallet.isLegacyCold()
+					? wallet.getAttributes().get<string>("wallet.data.attributes.legacyNonce")
+					: undefined,
 				signatory,
 				token,
 			};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86e1de083

This PR adds `isLegacyColdWallet` flag for cold legacy wallets and uses `legacyNonce` when the flag is `true`. It also reverts logic from #1848 and adds respective unit tests.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
