### PR TITLE
fix: update snapshots workflow

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -44,7 +44,7 @@ jobs:
 
             - name: Update Snapshots
               continue-on-error: true # Continue on error to allow the commit action to run
-              run: pnpm test
+              run: LC_ALL=en_US.UTF-8 vitest -u
 
             - uses: stefanzweifel/git-auto-commit-action@v6
               with:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This PR updates `update-snapshots` workflow to use `u` flag to work properly. It also calls vitest without `--standalone` as it is not necessary for this.

> Start Vitest without running tests. Tests will be running only on change. If browser mode is enabled, the UI will be opened automatically. This option is ignored when CLI file filters are passed. (default: false)

<img width="1375" height="755" alt="image" src="https://github.com/user-attachments/assets/621d6ec4-75be-4503-9a88-39b5a0474fe5" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
