### PR TITLE
fix: register validator flow

### DIFF
--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.test.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.test.tsx
@@ -631,6 +631,6 @@ describe("SendRegistrationSidePanel", () => {
 
 const inputValidatorPassphrase = async (key: string = MNEMONICS[2]) => {
 	await userEvent.clear(screen.getByTestId("Input__validator_passphrase"));
-	await userEvent.type(screen.getByTestId("Input__validator_passphrase"), key);
+	await userEvent.paste(key);
 	await waitFor(() => expect(screen.getByTestId("Input__validator_passphrase")).toHaveValue(key));
 };

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -46,10 +46,12 @@ export const SendRegistrationSidePanel = ({
 	open,
 	onOpenChange,
 	registrationType,
+	onMountChange: _onMountChange,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	registrationType: "validatorRegistration" | "usernameRegistration" | "contractDeployment";
+	onMountChange?: (mounted: boolean) => void;
 }) => {
 	const { t } = useTranslation();
 
@@ -235,6 +237,7 @@ export const SendRegistrationSidePanel = ({
 
 	const onMountChange = useCallback((mounted: boolean) => {
 		setMounted(mounted);
+		_onMountChange?.(mounted);
 
 		if (!mounted) {
 			setActiveTab(FORM_STEP);

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -46,10 +46,12 @@ export const SendRegistrationSidePanel = ({
 	open,
 	onOpenChange,
 	registrationType,
+	onMountChange,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	registrationType: "validatorRegistration" | "usernameRegistration" | "contractDeployment";
+	onMountChange: (mounted: boolean) => void;
 }) => {
 	const { t } = useTranslation();
 
@@ -87,9 +89,8 @@ export const SendRegistrationSidePanel = ({
 	const summaryStep = stepCount;
 	const isAuthenticationStep = activeTab === authenticationStep;
 
-	const [mounted, setMounted] = useState(false);
 	const { activeWallet } = useSelectsTransactionSender({
-		active: mounted,
+		active: open,
 		onWalletChange: (wallet) => {
 			setValue("senderAddress", wallet?.address(), { shouldDirty: true, shouldValidate: true });
 
@@ -120,10 +121,10 @@ export const SendRegistrationSidePanel = ({
 	}, [register, activeWallet, common, fees, validatorRegistrationFee, validatorRegistration, registrationType]);
 
 	useEffect(() => {
-		if (mounted) {
+		if (open) {
 			trigger("lockedFee");
 		}
-	}, [senderAddress, mounted]);
+	}, [senderAddress, open]);
 
 	useToggleFeeFields({
 		activeTab,
@@ -231,23 +232,6 @@ export const SendRegistrationSidePanel = ({
 		},
 		[onOpenChange],
 	);
-
-	const onMountChange = useCallback((mounted: boolean) => {
-		setMounted(mounted);
-
-		if (!mounted) {
-			setActiveTab(FORM_STEP);
-			setErrorMessage(undefined);
-
-			const fieldKeyMap = {
-				contractDeployment: "bytecode",
-				usernameRegistration: "username",
-				validatorRegistration: "validatorPublicKey",
-			};
-
-			unregister(fieldKeyMap[registrationType as string]);
-		}
-	}, []);
 
 	const hasSynced = activeWallet && activeWallet.hasSyncedWithNetwork();
 

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -47,12 +47,10 @@ export const SendRegistrationSidePanel = ({
 	open,
 	onOpenChange,
 	registrationType,
-	onMountChange,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	registrationType: "validatorRegistration" | "usernameRegistration" | "contractDeployment";
-	onMountChange?: (mounted: boolean) => void;
 }) => {
 	const { t } = useTranslation();
 
@@ -80,7 +78,7 @@ export const SendRegistrationSidePanel = ({
 
 	const form = useForm({ mode: "onChange" });
 
-	const { formState, register, setValue, watch, getValues, trigger } = form;
+	const { formState, register, setValue, watch, getValues, trigger, unregister } = form;
 	const { isDirty, isSubmitting, isValidating, isValid, dirtyFields } = formState;
 
 	const { fees, isLoading, senderAddress } = watch();
@@ -90,10 +88,10 @@ export const SendRegistrationSidePanel = ({
 	const summaryStep = stepCount;
 	const isAuthenticationStep = activeTab === authenticationStep;
 
-	const isMounted = useIsMounted()();
+	const [mounted, setMounted] = useState(false);
 
 	const { activeWallet } = useSelectsTransactionSender({
-		active: isMounted,
+		active: mounted,
 		onWalletChange: (wallet) => {
 			setValue("senderAddress", wallet?.address(), { shouldDirty: true, shouldValidate: true });
 
@@ -124,10 +122,10 @@ export const SendRegistrationSidePanel = ({
 	}, [register, activeWallet, common, fees, validatorRegistrationFee, validatorRegistration, registrationType]);
 
 	useEffect(() => {
-		if (isMounted) {
+		if (mounted) {
 			trigger("lockedFee");
 		}
-	}, [senderAddress, isMounted]);
+	}, [senderAddress, mounted]);
 
 	useToggleFeeFields({
 		activeTab,
@@ -235,6 +233,23 @@ export const SendRegistrationSidePanel = ({
 		},
 		[onOpenChange],
 	);
+
+	const onMountChange = useCallback((mounted: boolean) => {
+		setMounted(mounted);
+
+		if (!mounted) {
+			setActiveTab(FORM_STEP);
+			setErrorMessage(undefined);
+
+			const fieldKeyMap = {
+				contractDeployment: "bytecode",
+				usernameRegistration: "username",
+				validatorRegistration: "validatorPublicKey",
+			};
+
+			unregister(fieldKeyMap[registrationType as string]);
+		}
+	}, []);
 
 	const hasSynced = activeWallet && activeWallet.hasSyncedWithNetwork();
 

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -37,6 +37,7 @@ import {
 	ContractDeploymentForm,
 	signContractDeployment,
 } from "@/domains/transaction/components/ContractDeploymentForm";
+import { useIsMounted } from "usehooks-ts";
 
 export const FORM_STEP = 1;
 export const REVIEW_STEP = 2;
@@ -89,8 +90,10 @@ export const SendRegistrationSidePanel = ({
 	const summaryStep = stepCount;
 	const isAuthenticationStep = activeTab === authenticationStep;
 
+	const isMounted = useIsMounted()();
+
 	const { activeWallet } = useSelectsTransactionSender({
-		active: open,
+		active: isMounted,
 		onWalletChange: (wallet) => {
 			setValue("senderAddress", wallet?.address(), { shouldDirty: true, shouldValidate: true });
 
@@ -121,10 +124,10 @@ export const SendRegistrationSidePanel = ({
 	}, [register, activeWallet, common, fees, validatorRegistrationFee, validatorRegistration, registrationType]);
 
 	useEffect(() => {
-		if (open) {
+		if (isMounted) {
 			trigger("lockedFee");
 		}
-	}, [senderAddress, open]);
+	}, [senderAddress, isMounted]);
 
 	useToggleFeeFields({
 		activeTab,

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -79,8 +79,8 @@ export const SendRegistrationSidePanel = ({
 
 	const form = useForm({ mode: "onChange" });
 
-	const { formState, register, setValue, watch, getValues, trigger, unregister } = form;
-	const { isDirty, isSubmitting, isValid, dirtyFields } = formState;
+	const { formState, register, setValue, watch, getValues, trigger } = form;
+	const { isDirty, isSubmitting, isValidating, isValid, dirtyFields } = formState;
 
 	const { fees, isLoading, senderAddress } = watch();
 
@@ -395,7 +395,7 @@ export const SendRegistrationSidePanel = ({
 						<Button
 							data-testid="SendRegistration__continue-button"
 							onClick={handleNext}
-							disabled={isNextDisabled || isSubmitting}
+							disabled={isNextDisabled || isSubmitting || isValidating}
 						>
 							{t("COMMON.CONTINUE")}
 						</Button>

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -46,12 +46,10 @@ export const SendRegistrationSidePanel = ({
 	open,
 	onOpenChange,
 	registrationType,
-	onMountChange: _onMountChange,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	registrationType: "validatorRegistration" | "usernameRegistration" | "contractDeployment";
-	onMountChange?: (mounted: boolean) => void;
 }) => {
 	const { t } = useTranslation();
 
@@ -237,7 +235,6 @@ export const SendRegistrationSidePanel = ({
 
 	const onMountChange = useCallback((mounted: boolean) => {
 		setMounted(mounted);
-		_onMountChange?.(mounted);
 
 		if (!mounted) {
 			setActiveTab(FORM_STEP);
@@ -246,7 +243,7 @@ export const SendRegistrationSidePanel = ({
 			const fieldKeyMap = {
 				contractDeployment: "bytecode",
 				usernameRegistration: "username",
-				validatorRegistration: "validatorPublicKey",
+				validatorRegistration: "validatorPassphrase",
 			};
 
 			unregister(fieldKeyMap[registrationType as string]);

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -37,7 +37,6 @@ import {
 	ContractDeploymentForm,
 	signContractDeployment,
 } from "@/domains/transaction/components/ContractDeploymentForm";
-import { useIsMounted } from "usehooks-ts";
 
 export const FORM_STEP = 1;
 export const REVIEW_STEP = 2;

--- a/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
+++ b/src/domains/transaction/components/SendRegistrationSidePanel/SendRegistrationSidePanel.tsx
@@ -51,7 +51,7 @@ export const SendRegistrationSidePanel = ({
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	registrationType: "validatorRegistration" | "usernameRegistration" | "contractDeployment";
-	onMountChange: (mounted: boolean) => void;
+	onMountChange?: (mounted: boolean) => void;
 }) => {
 	const { t } = useTranslation();
 

--- a/src/domains/transaction/components/ValidatorRegistrationForm/FormStep.tsx
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/FormStep.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@/app/components/Icon";
 import React, { ChangeEvent, useEffect } from "react";
 import { Alert } from "@/app/components/Alert";
 import { FormStepProperties } from "@/domains/transaction/components/SendRegistrationSidePanel/SendRegistration.contracts";
-import { InputDefault } from "@/app/components/Input";
+import { InputPassword } from "@/app/components/Input";
 import { Link } from "@/app/components/Link";
 import { WalletCapabilities } from "@/domains/portfolio/lib/wallet.capabilities";
 import { useActiveNetwork } from "@/app/hooks/use-active-network";
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { useValidation } from "@/app/hooks";
 import { SelectAddressDropdown } from "@/domains/profile/components/SelectAddressDropdown";
 import { Contracts } from "@/app/lib/profiles";
+import { MnemonicRules } from "@/domains/transaction/components/MnemonicRules/MnemonicRules";
 
 export const getWalletAddress = (wallet: { address: () => string } | null | undefined): string =>
 	wallet?.address() ?? "";
@@ -108,7 +109,8 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 							</span>
 						</Link>
 					</div>
-					<InputDefault
+
+					<InputPassword
 						data-testid="Input__validator_passphrase"
 						defaultValue={validatorPassphrase}
 						onChange={(event: ChangeEvent<HTMLInputElement>) =>
@@ -118,6 +120,8 @@ export const FormStep: React.FC<FormStepProperties> = ({ wallet, profile }: Form
 							})
 						}
 					/>
+
+					<MnemonicRules mnemonic={validatorPassphrase} wrapperClass="mt-0" />
 				</FormField>
 			</div>
 		</section>

--- a/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ValidatorRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/ValidatorRegistrationForm/__snapshots__/ValidatorRegistrationForm.test.tsx.snap
@@ -263,8 +263,117 @@ exports[`ValidatorRegistrationForm > should render form step 1`] = `
                   class="bg-transparent! p-0! focus:ring-transparent! focus:outline-hidden focus:shadow-none [&.shadow-none]:shadow-none no-ligatures text-sm! sm:text-base! w-full border-none placeholder:text-theme-secondary-400 dim:placeholder:text-theme-dim-500 dark:placeholder:text-theme-secondary-700"
                   data-testid="Input__validator_passphrase"
                   name="validatorPassphrase"
-                  type="text"
+                  type="password"
                 />
+              </div>
+              <div
+                class="flex items-center divide-x divide-theme-secondary-300 dim:divide-theme-dim-700 dark:divide-theme-secondary-800 text-theme-primary-300 dark:text-theme-secondary-600"
+                data-testid="Input__addon-end"
+              >
+                <div
+                  class=""
+                >
+                  <button
+                    class="ring-focus focus:outline-hidden relative flex h-full w-full items-center justify-center text-2xl"
+                    data-ring-focus-margin="-m-1"
+                    data-testid="InputPassword__toggle"
+                    type="button"
+                  >
+                    <div
+                      class="text-theme-secondary-700 dim:text-theme-dim-200 dark:text-theme-dark-200"
+                    >
+                      <div
+                        style="height: 20px; width: 20px;"
+                      >
+                        <svg
+                          id="eye"
+                          style="height: 100%; width: 100%;"
+                          viewBox="0 0 20 20"
+                          x="0"
+                          xml:space="preserve"
+                          xmlns="http://www.w3.org/2000/svg"
+                          y="0"
+                        >
+                          <g
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                          >
+                            <path
+                              d="M10 4.6c-3.2-.1-6.5 2.2-8.6 4.5-.5.5-.5 1.3 0 1.8 2 2.3 5.4 4.6 8.6 4.5 3.3-.1 6.5-2.3 8.6-4.5.5-.5.5-1.3 0-1.8-2.1-2.3-5.4-4.6-8.6-4.5z"
+                            />
+                            <path
+                              d="M13 10c0 1.7-1.3 3-3 3s-3-1.3-3-3 1.3-3 3-3c1.2 0 3 .7 3 3z"
+                            />
+                          </g>
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="rounded-b border border-t-0 border-theme-secondary-300 bg-theme-secondary-100 p-4 dim:border-theme-dim-700 dim:bg-theme-dim-950 dark:border-theme-dark-700 dark:bg-theme-dark-950 mt-0"
+            >
+              <div
+                class="space-y-4"
+                data-testid="Rules"
+              >
+                <div
+                  class="flex items-center space-x-2"
+                  data-testid="MnemonicRule-HAS_VALID_WORD_COUNT-0"
+                >
+                  <span
+                    class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-theme-primary-600 dim:text-theme-dim-navy-400 dark:text-theme-dark-navy-400 border-2 border-theme-secondary-700 dim:border-theme-dim-500 dark:border-theme-dark-500"
+                  />
+                  <span
+                    class="text-sm font-semibold text-theme-secondary-700 dim:text-theme-dim-200 dark:text-theme-dark-200"
+                  >
+                    12 or 24 words
+                  </span>
+                </div>
+                <div
+                  class="flex items-center space-x-2"
+                  data-testid="MnemonicRule-LOWERCASE-0"
+                >
+                  <span
+                    class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-theme-primary-600 dim:text-theme-dim-navy-400 dark:text-theme-dark-navy-400 border-2 border-theme-secondary-700 dim:border-theme-dim-500 dark:border-theme-dark-500"
+                  />
+                  <span
+                    class="text-sm font-semibold text-theme-secondary-700 dim:text-theme-dim-200 dark:text-theme-dark-200"
+                  >
+                    Lowercase characters only
+                  </span>
+                </div>
+                <div
+                  class="flex items-center space-x-2"
+                  data-testid="MnemonicRule-HAS_VALID_SPACING-0"
+                >
+                  <span
+                    class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-theme-primary-600 dim:text-theme-dim-navy-400 dark:text-theme-dark-navy-400 border-2 border-theme-secondary-700 dim:border-theme-dim-500 dark:border-theme-dark-500"
+                  />
+                  <span
+                    class="text-sm font-semibold text-theme-secondary-700 dim:text-theme-dim-200 dark:text-theme-dark-200"
+                  >
+                    Spaces between words
+                  </span>
+                </div>
+                <div
+                  class="flex items-center space-x-2"
+                  data-testid="MnemonicRule-NO_TRAILING_SPACE-0"
+                >
+                  <span
+                    class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-theme-primary-600 dim:text-theme-dim-navy-400 dark:text-theme-dark-navy-400 border-2 border-theme-secondary-700 dim:border-theme-dim-500 dark:border-theme-dark-500"
+                  />
+                  <span
+                    class="text-sm font-semibold text-theme-secondary-700 dim:text-theme-dim-200 dark:text-theme-dark-200"
+                  >
+                    No trailing spaces
+                  </span>
+                </div>
               </div>
             </div>
           </fieldset>

--- a/src/domains/transaction/validations/ValidatorRegistration.ts
+++ b/src/domains/transaction/validations/ValidatorRegistration.ts
@@ -6,6 +6,7 @@ import { Contracts, Helpers } from "@/app/lib/profiles";
 import { BigNumber } from "@/app/lib/helpers";
 import { deriveBlsPublicKey, UnitConverter } from "@arkecosystem/typescript-crypto";
 import { BIP39 } from "@ardenthq/arkvault-crypto";
+import { Utils } from "@/app/components/MiddleTruncation";
 
 export const validatorRegistration = (t: any) => ({
 	lockedFee: (wallet: Contracts.IReadWriteWallet | undefined, getValues: () => object) => ({
@@ -81,18 +82,20 @@ export const validatorRegistration = (t: any) => ({
 				return true;
 			},
 			unique: debounceAsync(async (validatorPassphrase: string) => {
-				let publicKey: string | undefined;
+				let displayPublicKey: string | undefined;
 
 				try {
-					publicKey = deriveBlsPublicKey(validatorPassphrase);
+					const publicKey = deriveBlsPublicKey(validatorPassphrase);
+
+					displayPublicKey = Utils.buildTruncatedText(publicKey, 8, 8);
 
 					const exists = await profile.validators().publicKeyExists(publicKey, network);
 
 					if (exists) {
-						return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", { publicKey });
+						return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", { publicKey: displayPublicKey });
 					}
 				} catch {
-					return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", { publicKey });
+					return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", { publicKey: displayPublicKey });
 				}
 			}, 300) as () => Promise<ValidateResult>,
 		},

--- a/src/domains/transaction/validations/ValidatorRegistration.ts
+++ b/src/domains/transaction/validations/ValidatorRegistration.ts
@@ -92,10 +92,14 @@ export const validatorRegistration = (t: any) => ({
 					const exists = await profile.validators().publicKeyExists(publicKey, network);
 
 					if (exists) {
-						return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", { publicKey: displayPublicKey });
+						return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", {
+							publicKey: displayPublicKey,
+						});
 					}
 				} catch {
-					return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", { publicKey: displayPublicKey });
+					return t("COMMON.INPUT_PUBLIC_KEY.VALIDATION.PUBLIC_KEY_ALREADY_EXISTS", {
+						publicKey: displayPublicKey,
+					});
 				}
 			}, 300) as () => Promise<ValidateResult>,
 		},


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86e1u0q73

This PR fixes the following issues:

- validator passphrase is now using password input field
- validator passphrase field is cleared after unmounting
- `Continue` button is disabled while validating public key

[Screencast from 2026-06-11 15-35-01.webm](https://github.com/user-attachments/assets/a0341aa4-e005-49bc-b4fe-3d657b09e044)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
