### PR TITLE
fix: remove duplicate error messages from failed txs

### DIFF
--- a/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmationErrors.test.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmationErrors.test.tsx
@@ -1,0 +1,63 @@
+import { TransactionConfirmationErrors } from "./TransactionConfirmationErrors";
+import { render, screen } from "@/utils/testing-library";
+
+describe("TransactionConfirmationErrors", () => {
+	it("should render error with message", () => {
+		const prettyErrorSpy = vi.fn().mockReturnValue("Execution reverted.");
+
+		render(
+			<TransactionConfirmationErrors
+				transaction={{
+					data: () => ({
+						receipt: () => ({
+							error: () => "Some error",
+							hasUnknownError: () => false,
+							prettyError: prettyErrorSpy,
+						}),
+					}),
+				}}
+			/>,
+		);
+
+		expect(
+			screen.getByText("Error encountered during contract execution: Execution reverted."),
+		).toBeInTheDocument();
+		expect(prettyErrorSpy).toHaveBeenCalled();
+	});
+
+	it("should render generic error when it has unknown error", () => {
+		render(
+			<TransactionConfirmationErrors
+				transaction={{
+					data: () => ({
+						receipt: () => ({
+							error: () => null,
+							hasUnknownError: () => true,
+							prettyError: () => "Ignored",
+						}),
+					}),
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Error encountered during contract execution.")).toBeInTheDocument();
+	});
+
+	it("should render nothing when there is no error", () => {
+		const { container } = render(
+			<TransactionConfirmationErrors
+				transaction={{
+					data: () => ({
+						receipt: () => ({
+							error: () => null,
+							hasUnknownError: () => false,
+							prettyError: () => "",
+						}),
+					}),
+				}}
+			/>,
+		);
+
+		expect(container.querySelector("p")).not.toBeInTheDocument();
+	});
+});

--- a/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmationErrors.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmationErrors.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from "react-i18next";
+
+import { DTO } from "@/app/lib/mainsail";
+
+export const TransactionConfirmationErrors = ({ transaction }: { transaction: DTO.RawTransactionData }) => {
+	const { t } = useTranslation();
+
+	if (transaction.data().receipt().error()) {
+		return (
+			<p className="border-t border-theme-danger-200 px-3 pt-2 font-semibold text-theme-secondary-700 dim:border-theme-danger-400 dim:text-theme-dim-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 sm:px-6 sm:pt-4">
+				{t("TRANSACTION.TRANSACTION_EXECUTION_ERROR_WITH_MESSAGE", {
+					error: transaction.data().receipt().prettyError(),
+				})}
+			</p>
+		);
+	}
+
+	if (transaction.data().receipt().hasUnknownError()) {
+		return (
+			<p className="border-t border-theme-danger-200 px-3 pt-2 font-semibold text-theme-secondary-700 dim:border-theme-danger-400 dim:text-theme-dim-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 sm:px-6 sm:pt-4">
+				{t("TRANSACTION.TRANSACTION_EXECUTION_ERROR")}
+			</p>
+		);
+	}
+
+	return <></>;
+};

--- a/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmations.test.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmations.test.tsx
@@ -139,7 +139,7 @@ describe("TransactionConfirmations", () => {
 		);
 
 		expect(screen.getByTestId("TransactionFailedAlert")).toBeInTheDocument();
-		expect(screen.getByText("Error encountered during contract execution.")).toBeInTheDocument();
+		expect(screen.getByText(/Error encountered during contract execution:/)).toBeInTheDocument();
 	});
 
 	it("should render failed transaction with error and pretty error message", () => {

--- a/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmations.tsx
+++ b/src/domains/transaction/components/TransactionDetail/TransactionConfirmations/TransactionConfirmations.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/app/components/Icon";
 import { Divider } from "@/app/components/Divider";
 import { DTO } from "@/app/lib/mainsail";
 import { useMultiSignatureStatus } from "@/domains/transaction/hooks";
+import { TransactionConfirmationErrors } from "./TransactionConfirmationErrors";
 
 export const TransactionConfirmations = ({
 	isConfirmed,
@@ -43,19 +44,7 @@ export const TransactionConfirmations = ({
 					</p>
 				</div>
 
-				{transaction.data().receipt().hasUnknownError() && (
-					<p className="border-t border-theme-danger-200 px-3 pt-2 font-semibold text-theme-secondary-700 dim:border-theme-danger-400 dim:text-theme-dim-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 sm:px-6 sm:pt-4">
-						{t("TRANSACTION.TRANSACTION_EXECUTION_ERROR")}
-					</p>
-				)}
-
-				{transaction.data().receipt().error() && (
-					<p className="border-t border-theme-danger-200 px-3 pt-2 font-semibold text-theme-secondary-700 dim:border-theme-danger-400 dim:text-theme-dim-200 dark:border-theme-secondary-800 dark:text-theme-secondary-500 sm:px-6 sm:pt-4">
-						{t("TRANSACTION.TRANSACTION_EXECUTION_ERROR_WITH_MESSAGE", {
-							error: transaction.data().receipt().prettyError(),
-						})}
-					</p>
-				)}
+				<TransactionConfirmationErrors transaction={transaction} />
 			</div>
 		);
 	}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/2570579/86e1t6wtm

For known errors, it shows the error message from the server, otherwise it shows the generic error if the error is unknown.

<img width="962" height="564" alt="screenshot-2026-06-24_13-30-14" src="https://github.com/user-attachments/assets/32c81502-e300-4b0a-bf1d-b546c4299de9" />

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
