### PR TITLE
fix: scan only ark addresses on migration flow

### DIFF
--- a/src/app/contexts/Ledger/hooks/scanner.ts
+++ b/src/app/contexts/Ledger/hooks/scanner.ts
@@ -6,7 +6,11 @@ import { persistLedgerConnection } from "@/app/contexts/Ledger/utils/connection"
 import { scannerReducer } from "./scanner.state";
 import { useLedgerContext } from "@/app/contexts/Ledger/Ledger";
 
-export const useLedgerScanner = (options?: { pageSize?: number; importedLedgerPaths?: string[] }) => {
+export const useLedgerScanner = (options?: {
+	pageSize?: number;
+	importedLedgerPaths?: string[];
+	scanSlip44Eth?: boolean;
+}) => {
 	const { setBusy, setIdle, resetConnectionState, disconnect } = useLedgerContext();
 
 	const [state, dispatch] = useReducer(scannerReducer, {
@@ -49,14 +53,19 @@ export const useLedgerScanner = (options?: { pageSize?: number; importedLedgerPa
 			options: { factor: 1, randomize: false, retries: 50 },
 		});
 
-		const ledgerData = await profile
-			.ledger()
-			.scanner({ scannedWallets: wallets })
-			.scan({
-				importedLedgerPaths: options?.importedLedgerPaths ?? [],
-				isLoadingMore,
-				pageSize: options?.pageSize,
-			});
+		const scanner = profile.ledger().scanner({ scannedWallets: wallets });
+
+		const ledgerData = options?.scanSlip44Eth
+			? await scanner.scan({
+					importedLedgerPaths: options?.importedLedgerPaths ?? [],
+					isLoadingMore,
+					pageSize: options?.pageSize,
+				})
+			: await scanner.scanLegacy({
+					importedLedgerPaths: options?.importedLedgerPaths ?? [],
+					isLoadingMore,
+					pageSize: options?.pageSize,
+				});
 
 		dispatch({ payload: ledgerData, type: "success" });
 

--- a/src/app/lib/mainsail/ledger.scanner.test.ts
+++ b/src/app/lib/mainsail/ledger.scanner.test.ts
@@ -229,4 +229,55 @@ describe("LedgerScannerTest", () => {
 
 		expect(result).toBeDefined();
 	});
+
+	it("should scan legacy and merge wallets when not loading more", async () => {
+		const scanner = profile.ledger().scanner({ scannedWallets: [] });
+		const scanAllWithBalanceSpy = vi
+			.spyOn(scanner, "scanAllWithBalance")
+			.mockResolvedValue([{ address: "0x1", balance: "100", path: "m/44'/111'/0'/0/0" }]);
+
+		const result = await scanner.scanLegacy();
+
+		expect(scanAllWithBalanceSpy).toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+		expect(result[0].address).toBe("0x1");
+	});
+
+	it("should scan legacy and omit wallets when loading more", async () => {
+		const existingWallet = { address: "0xExistingAddress", balance: "50", path: "m/44'/111'/0'/0/0" };
+		const scanner = profile.ledger().scanner({ scannedWallets: [existingWallet] });
+		const scanAllWithBalanceSpy = vi.spyOn(scanner, "scanAllWithBalance").mockResolvedValue([
+			{ address: "0xExistingAddress", balance: "100", path: "m/44'/111'/0'/0/0" },
+			{ address: "0x1", balance: "200", path: "m/44'/111'/0'/0/1" },
+		]);
+
+		const result = await scanner.scanLegacy({ isLoadingMore: true });
+
+		expect(scanAllWithBalanceSpy).toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+		expect(result[0].address).toBe("0x1");
+	});
+
+	it("should scan legacy with importedLedgerPaths", async () => {
+		const scanner = profile.ledger().scanner({ scannedWallets: [] });
+		const scanAllWithBalanceSpy = vi
+			.spyOn(scanner, "scanAllWithBalance")
+			.mockResolvedValue([{ address: "0x1", balance: "100", path: "m/44'/111'/0'/0/0" }]);
+
+		const result = await scanner.scanLegacy({
+			importedLedgerPaths: ["m/44'/111'/0'/0/0"],
+		});
+
+		expect(scanAllWithBalanceSpy).toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+	});
+
+	it("should scan legacy with pageSize option", async () => {
+		const scanner = profile.ledger().scanner({ scannedWallets: [] });
+		const scanAllWithBalanceSpy = vi.spyOn(scanner, "scanAllWithBalance").mockResolvedValue([]);
+
+		await scanner.scanLegacy({ pageSize: 10 });
+
+		expect(scanAllWithBalanceSpy).toHaveBeenCalled();
+	});
 });

--- a/src/app/lib/mainsail/ledger.scanner.test.ts
+++ b/src/app/lib/mainsail/ledger.scanner.test.ts
@@ -5,6 +5,7 @@ import { Contracts } from "@/app/lib/profiles";
 import { WalletData } from "@/app/lib/mainsail/wallet.dto";
 
 let profile: Contracts.IProfile;
+const derivationPath = "m/44'/111'/0'/0/0";
 
 describe("LedgerScannerTest", () => {
 	let transportMock: any;
@@ -158,7 +159,7 @@ describe("LedgerScannerTest", () => {
 			callCount++;
 			if (callCount <= 2) {
 				return {
-					"m/44'/111'/0'/0/0": new WalletData({
+					[derivationPath]: new WalletData({
 						config: profile.wallets().first().network().config(),
 					}).fill({
 						address: profile.wallets().first().address(),
@@ -234,7 +235,7 @@ describe("LedgerScannerTest", () => {
 		const scanner = profile.ledger().scanner({ scannedWallets: [] });
 		const scanAllWithBalanceSpy = vi
 			.spyOn(scanner, "scanAllWithBalance")
-			.mockResolvedValue([{ address: "0x1", balance: "100", path: "m/44'/111'/0'/0/0" }]);
+			.mockResolvedValue([{ address: "0x1", balance: "100", path: derivationPath }]);
 
 		const result = await scanner.scanLegacy();
 
@@ -244,10 +245,10 @@ describe("LedgerScannerTest", () => {
 	});
 
 	it("should scan legacy and omit wallets when loading more", async () => {
-		const existingWallet = { address: "0xExistingAddress", balance: "50", path: "m/44'/111'/0'/0/0" };
+		const existingWallet = { address: "0xExistingAddress", balance: "50", path: derivationPath };
 		const scanner = profile.ledger().scanner({ scannedWallets: [existingWallet] });
 		const scanAllWithBalanceSpy = vi.spyOn(scanner, "scanAllWithBalance").mockResolvedValue([
-			{ address: "0xExistingAddress", balance: "100", path: "m/44'/111'/0'/0/0" },
+			{ address: "0xExistingAddress", balance: "100", path: derivationPath },
 			{ address: "0x1", balance: "200", path: "m/44'/111'/0'/0/1" },
 		]);
 
@@ -262,10 +263,10 @@ describe("LedgerScannerTest", () => {
 		const scanner = profile.ledger().scanner({ scannedWallets: [] });
 		const scanAllWithBalanceSpy = vi
 			.spyOn(scanner, "scanAllWithBalance")
-			.mockResolvedValue([{ address: "0x1", balance: "100", path: "m/44'/111'/0'/0/0" }]);
+			.mockResolvedValue([{ address: "0x1", balance: "100", path: derivationPath }]);
 
 		const result = await scanner.scanLegacy({
-			importedLedgerPaths: ["m/44'/111'/0'/0/0"],
+			importedLedgerPaths: [derivationPath],
 		});
 
 		expect(scanAllWithBalanceSpy).toHaveBeenCalled();

--- a/src/app/lib/mainsail/ledger.scanner.ts
+++ b/src/app/lib/mainsail/ledger.scanner.ts
@@ -65,6 +65,35 @@ export class LedgerScanner {
 		return ledgerData;
 	}
 
+	async scanLegacy(options?: {
+		isLoadingMore?: boolean;
+		pageSize?: number;
+		importedLedgerPaths?: string[];
+	}): Promise<LedgerData[]> {
+		const importedLedgerPaths = [
+			...this.#wallets.map((wallet) => wallet.path),
+			...(options?.importedLedgerPaths ?? []),
+		];
+
+		// Scan legacy ARK addresses by address index.
+		let ledgerData = await this.scanAllWithBalance({
+			byAccountIndex: false,
+			slip44: this.#ledgerService.slip44(),
+			startPath: this.#computeLastPath({
+				importedLedgerPaths,
+				slip44: this.#ledgerService.slip44(),
+			}),
+		});
+
+		if (options?.isLoadingMore) {
+			ledgerData = omitBy(ledgerData, (wallet) => this.#wallets.some((w) => w.address === wallet.address));
+		} else {
+			ledgerData = uniqBy([...this.#wallets, ...ledgerData], (wallet) => wallet.address);
+		}
+
+		return ledgerData;
+	}
+
 	async scanAllWithBalance(config: LedgerImportOptions): Promise<LedgerData[]> {
 		const ledgerData: LedgerData[] = [];
 		let startPath = config.startPath;

--- a/src/domains/portfolio/components/ImportWallet/Ledger/LedgerScanStep.tsx
+++ b/src/domains/portfolio/components/ImportWallet/Ledger/LedgerScanStep.tsx
@@ -309,7 +309,7 @@ export const LedgerScanStep = ({
 		.filter((wallet) => wallet.isLedger())
 		.map((wallet) => wallet.data().get<string>(ProfilesContracts.WalletData.DerivationPath))
 		.filter((path) => typeof path === "string");
-	const ledgerScanner = useLedgerScanner({ importedLedgerPaths });
+	const ledgerScanner = useLedgerScanner({ importedLedgerPaths, scanSlip44Eth: true });
 
 	const { scan, selectedWallets, canRetry, isScanning, abortScanner, error, loadedWallets } = ledgerScanner;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/2570579/86e258cbf 
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
