### PR TITLE
fix: show close confirmation only for pending migrations

### DIFF
--- a/src/app/lib/mainsail/ledger.migrator.test.ts
+++ b/src/app/lib/mainsail/ledger.migrator.test.ts
@@ -554,6 +554,92 @@ describe("LedgerMigrator", () => {
 		migrator.nextTransaction();
 		expect(migrator.currentTransactionIndex()).toBe(0);
 	});
+
+	it("should return false for isPendingCompletion when there are no transactions", () => {
+		const migrator = new LedgerMigrator({ env, profile });
+		expect(migrator.isPendingCompletion()).toBe(false);
+	});
+
+	it("should return false for isPendingCompletion when all transactions are completed", async () => {
+		mockNanoSTransport();
+		const wallet = profile.wallets().first();
+		const migrator = new LedgerMigrator({ env, profile });
+		const transactionSpy1 = await createTransactionMocks(wallet);
+
+		await migrator.createTransactions([
+			{
+				address: wallet.address(),
+				path: senderPath,
+			},
+		]);
+
+		migrator.nextTransaction();
+		const currentTransaction = migrator.currentTransaction();
+
+		await currentTransaction?.calculateFees();
+		currentTransaction?.selectFee("avg");
+		currentTransaction?.setSenderMaxAmount();
+		currentTransaction?.setIsPending(true);
+		await currentTransaction?.signAndBroadcast();
+		currentTransaction?.setIsCompleted(true);
+
+		expect(migrator.isPendingCompletion()).toBe(false);
+
+		transactionSpy1.restoreAll();
+	});
+
+	it("should return true for isPendingCompletion when some transactions are not completed", async () => {
+		mockNanoSTransport();
+		const wallet = profile.wallets().first();
+		const migrator = new LedgerMigrator({ env, profile });
+
+		await migrator.createTransactions([
+			{
+				address: wallet.address(),
+				path: senderPath,
+			},
+			{
+				address: profile.wallets().last().address(),
+				path: recipientPath,
+			},
+		]);
+
+		expect(migrator.isPendingCompletion()).toBe(true);
+	});
+
+	it("should return true for isPendingCompletion when one of multiple transactions is completed", async () => {
+		mockNanoSTransport();
+		const wallet = profile.wallets().first();
+		const migrator = new LedgerMigrator({ env, profile });
+		const transactionSpy1 = await createTransactionMocks(wallet);
+
+		await migrator.createTransactions([
+			{
+				address: wallet.address(),
+				path: senderPath,
+			},
+			{
+				address: profile.wallets().last().address(),
+				path: recipientPath,
+			},
+		]);
+
+		migrator.nextTransaction();
+		const currentTransaction = migrator.currentTransaction();
+
+		await currentTransaction?.calculateFees();
+		currentTransaction?.selectFee("avg");
+		currentTransaction?.setSenderMaxAmount();
+		currentTransaction?.setIsPending(true);
+		await currentTransaction?.signAndBroadcast();
+		currentTransaction?.setIsCompleted(true);
+
+		expect(migrator.isPendingCompletion()).toBe(true);
+		expect(migrator.completedTransactions().length).toBe(1);
+		expect(migrator.transactions().length).toBe(2);
+
+		transactionSpy1.restoreAll();
+	});
 });
 
 describe("MigrationTransaction", () => {

--- a/src/app/lib/mainsail/ledger.migrator.ts
+++ b/src/app/lib/mainsail/ledger.migrator.ts
@@ -168,6 +168,10 @@ export class LedgerMigrator {
 		return this.transactions().filter((transaction) => transaction.isCompleted());
 	}
 
+	public isPendingCompletion(): boolean {
+		return this.transactions().length > 0 && this.transactions().length > this.completedTransactions().length;
+	}
+
 	public currentTransaction(): MigrationTransaction | undefined {
 		return this.#currentTransaction;
 	}

--- a/src/domains/portfolio/components/LedgerMigration/LedgerMigrationSidepanel.test.tsx
+++ b/src/domains/portfolio/components/LedgerMigration/LedgerMigrationSidepanel.test.tsx
@@ -318,7 +318,12 @@ describe("LedgerMigrationSidepanel", () => {
 			const closeButton = screen.getByTestId("SidePanel__close-button");
 			await userEvent.click(closeButton);
 
-			expect(onOpenChange).toHaveBeenCalledWith(false);
+			await waitFor(
+				() => {
+					expect(onOpenChange).toHaveBeenCalledWith(false);
+				},
+				{ timeout: 4000 },
+			);
 		},
 	);
 
@@ -565,9 +570,6 @@ describe("LedgerMigrationSidepanel", () => {
 			expect(await screen.findByTestId(ledgerReviewStepTestId)).toBeInTheDocument();
 
 			await userEvent.click(screen.getByTestId(acceptResponsibilityTestId));
-			await userEvent.click(screen.getByTestId(overviewContinueButtonTestId));
-
-			expect(await screen.findByTestId(successGotoPortfolioTestId, { timeout: 4000 })).toBeInTheDocument();
 
 			await userEvent.click(screen.getByTestId("SidePanel__close-button"));
 
@@ -608,11 +610,6 @@ describe("LedgerMigrationSidepanel", () => {
 		});
 		await userEvent.click(screen.getByTestId(ledgerContinueButton));
 		expect(await screen.findByTestId(ledgerReviewStepTestId)).toBeInTheDocument();
-
-		await userEvent.click(screen.getByTestId(acceptResponsibilityTestId));
-		await userEvent.click(screen.getByTestId(overviewContinueButtonTestId));
-
-		expect(await screen.findByTestId(successGotoPortfolioTestId, { timeout: 4000 })).toBeInTheDocument();
 
 		await userEvent.click(screen.getByTestId("SidePanel__close-button"));
 		expect(await screen.findByTestId("ConfirmationModal__no-button")).toBeInTheDocument();
@@ -659,9 +656,6 @@ describe("LedgerMigrationSidepanel", () => {
 			expect(await screen.findByTestId(ledgerReviewStepTestId)).toBeInTheDocument();
 
 			await userEvent.click(screen.getByTestId(acceptResponsibilityTestId));
-			await userEvent.click(screen.getByTestId(overviewContinueButtonTestId));
-
-			expect(await screen.findByTestId(successGotoPortfolioTestId, { timeout: 4000 })).toBeInTheDocument();
 
 			await userEvent.click(screen.getByTestId("SidePanel__close-button"));
 			expect(await screen.findByTestId("ConfirmationModal__yes-button")).toBeInTheDocument();

--- a/src/domains/portfolio/components/LedgerMigration/LedgerMigrationSidepanel.test.tsx
+++ b/src/domains/portfolio/components/LedgerMigration/LedgerMigrationSidepanel.test.tsx
@@ -311,10 +311,6 @@ describe("LedgerMigrationSidepanel", () => {
 
 			expect(screen.getByTestId("LedgerMigrationSidepanel")).toBeInTheDocument();
 
-			await waitFor(() => {
-				expect(screen.getByTestId("LedgerConnectionStep")).toBeInTheDocument();
-			});
-
 			const closeButton = screen.getByTestId("SidePanel__close-button");
 			await userEvent.click(closeButton);
 
@@ -539,7 +535,7 @@ describe("LedgerMigrationSidepanel", () => {
 	);
 
 	it.each(["sm", "md", "lg", "xl"])(
-		"should show confirmation modal when closing with completed transactions in %s",
+		"should show confirmation modal when closing with pending transactions in %s",
 		async (containerSize) => {
 			mockNanoSTransport();
 			const wallet = profile.wallets().first();

--- a/src/domains/portfolio/components/LedgerMigration/LedgerMigrationSidepanel.tsx
+++ b/src/domains/portfolio/components/LedgerMigration/LedgerMigrationSidepanel.tsx
@@ -49,7 +49,7 @@ export const LedgerMigrationSidepanel = ({
 	}, [open]);
 
 	const handleOpenChange = (open: boolean) => {
-		if (!open && migrator.completedTransactions().length > 0) {
+		if (!open && migrator.isPendingCompletion()) {
 			setShowConfirmationModal(true);
 			return;
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes https://app.clickup.com/t/2570579/86e25604p
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
