### PR TITLE
fix: useEffects unloading error

### DIFF
--- a/src/domains/vote/components/ValidatorsTable/ValidatorsTable.tsx
+++ b/src/domains/vote/components/ValidatorsTable/ValidatorsTable.tsx
@@ -49,7 +49,9 @@ export const ValidatorsTable: FC<ValidatorsTableProperties> = ({
 		setIsVoteDisabled(hasVotes && selectedVotes.length === 1);
 	}, [hasVotes, selectedVotes]);
 
-	useEffect(() => window.scrollTo({ behavior: "smooth", top: 0 }), [currentPage]);
+	useEffect(() => {
+		window.scrollTo({ behavior: "smooth", top: 0 })
+	}, [currentPage]);
 
 	useEffect(() => {
 		if (!resignedValidatorVotes?.length) {

--- a/src/domains/vote/components/ValidatorsTable/ValidatorsTable.tsx
+++ b/src/domains/vote/components/ValidatorsTable/ValidatorsTable.tsx
@@ -50,7 +50,7 @@ export const ValidatorsTable: FC<ValidatorsTableProperties> = ({
 	}, [hasVotes, selectedVotes]);
 
 	useEffect(() => {
-		window.scrollTo({ behavior: "smooth", top: 0 })
+		window.scrollTo({ behavior: "smooth", top: 0 });
 	}, [currentPage]);
 
 	useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/2570579/86e2a6ag7

This PR wraps `window.scrollTo` to prevent navigation error when the lifecycle cleanup happens.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
