### PR TITLE
fix: amount overflow issue at 768px

### DIFF
--- a/src/domains/portfolio/components/AddressesSidePanel/AddressRow.tsx
+++ b/src/domains/portfolio/components/AddressesSidePanel/AddressRow.tsx
@@ -194,6 +194,7 @@ export const AddressRow = ({
 					</div>
 					<div className="flex w-1/2 min-w-0 flex-col items-end space-y-2">
 						<Amount
+							showCompactFormat
 							ticker={wallet.network().ticker()}
 							value={wallet.balance()}
 							className={cn("leading-5", {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/2570579/86e2e57np

<img width="861" height="840" alt="image" src="https://github.com/user-attachments/assets/2bcba172-2b5e-4bb9-a7ef-48f3b691f761" />


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] My changes look good in both light AND dark mode
- [ ] The change is not hardcoded to a single network, but has multi-asset in mind
- [ ] I checked my changes for obvious issues, debug statements and commented code
- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
